### PR TITLE
Add prometheus scrape annotations to Jaeger collector, query and all-…

### DIFF
--- a/pkg/deployment/all-in-one.go
+++ b/pkg/deployment/all-in-one.go
@@ -35,6 +35,10 @@ func (a *AllInOne) Get() *appsv1.Deployment {
 	logrus.Debug("Assembling an all-in-one deployment")
 	selector := a.selector()
 	trueVar := true
+	annotations := map[string]string{
+		"prometheus.io/scrape": "true",
+		"prometheus.io/port":   "16686",
+	}
 
 	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
@@ -60,7 +64,8 @@ func (a *AllInOne) Get() *appsv1.Deployment {
 			},
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: selector,
+					Labels:      selector,
+					Annotations: annotations,
 				},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{{

--- a/pkg/deployment/collector.go
+++ b/pkg/deployment/collector.go
@@ -39,6 +39,10 @@ func (c *Collector) Get() *appsv1.Deployment {
 	selector := c.selector()
 	trueVar := true
 	replicas := int32(c.jaeger.Spec.Collector.Size)
+	annotations := map[string]string{
+		"prometheus.io/scrape": "true",
+		"prometheus.io/port":   "14268",
+	}
 
 	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
@@ -65,7 +69,8 @@ func (c *Collector) Get() *appsv1.Deployment {
 			},
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: selector,
+					Labels:      selector,
+					Annotations: annotations,
 				},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{{

--- a/pkg/deployment/query.go
+++ b/pkg/deployment/query.go
@@ -40,6 +40,10 @@ func (q *Query) Get() *appsv1.Deployment {
 	selector := q.selector()
 	trueVar := true
 	replicas := int32(q.jaeger.Spec.Query.Size)
+	annotations := map[string]string{
+		"prometheus.io/scrape": "true",
+		"prometheus.io/port":   "16686",
+	}
 
 	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
@@ -66,7 +70,8 @@ func (q *Query) Get() *appsv1.Deployment {
 			},
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: selector,
+					Labels:      selector,
+					Annotations: annotations,
 				},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{{


### PR DESCRIPTION
…in-one

This PR allows an existing prometheus deployment to scrape the metrics from the Jaeger backend.

Currently the agent is not annotated, as only appears to be support for injecting sidecar. Will create a separate issue to explore how to annotate agent sidecar, and daemonset when supported.
