### PR TITLE
Use "latest" as the image version when none is set

### DIFF
--- a/pkg/deployment/all-in-one.go
+++ b/pkg/deployment/all-in-one.go
@@ -24,7 +24,12 @@ type AllInOne struct {
 // NewAllInOne builds a new AllInOne struct based on the given spec
 func NewAllInOne(jaeger *v1alpha1.Jaeger) *AllInOne {
 	if jaeger.Spec.AllInOne.Image == "" {
-		jaeger.Spec.AllInOne.Image = fmt.Sprintf("%s:%s", viper.GetString("jaeger-all-in-one-image"), viper.GetString("jaeger-version"))
+		imageVersion := viper.GetString("jaeger-version")
+		if len(imageVersion) == 0 {
+			// default to latest when no version has been set
+			imageVersion = "latest"
+		}
+		jaeger.Spec.AllInOne.Image = fmt.Sprintf("%s:%s", viper.GetString("jaeger-all-in-one-image"), imageVersion)
 	}
 
 	return &AllInOne{jaeger: jaeger}

--- a/pkg/deployment/all-in-one_test.go
+++ b/pkg/deployment/all-in-one_test.go
@@ -9,9 +9,23 @@ import (
 	"github.com/jaegertracing/jaeger-operator/pkg/apis/io/v1alpha1"
 )
 
-func init() {
-	viper.SetDefault("jaeger-version", "1.6")
-	viper.SetDefault("jaeger-all-in-one-image", "jaegertracing/all-in-one")
+func TestVersionSetForAllInOneImage(t *testing.T) {
+	viper.Set("jaeger-version", "1.6")
+	viper.Set("jaeger-all-in-one-image", "jaegertracing/all-in-one")
+	defer viper.Reset()
+
+	d := NewAllInOne(v1alpha1.NewJaeger("TestNoVersionSetForAllInOneImage")).Get()
+
+	assert.Equal(t, "jaegertracing/all-in-one:1.6", d.Spec.Template.Spec.Containers[0].Image)
+}
+
+func TestNoVersionSetForAllInOneImage(t *testing.T) {
+	viper.Set("jaeger-all-in-one-image", "jaegertracing/all-in-one")
+	defer viper.Reset()
+
+	d := NewAllInOne(v1alpha1.NewJaeger("TestNoVersionSetForAllInOneImage")).Get()
+
+	assert.Equal(t, "jaegertracing/all-in-one:latest", d.Spec.Template.Spec.Containers[0].Image)
 }
 
 func TestDefaultAllInOneImage(t *testing.T) {


### PR DESCRIPTION
The version can be empty when developing with "go run main.go" so to
avoid having Kubernetes fail to deploy Jaeger because the image is
incorrect, we use "latest" as the default

Signed-off-by: Georgios Andrianakis <geoand@gmail.com>