### PR TITLE
Normalize options on the stub and update the normalized CR

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -45,9 +45,10 @@ func normalize(jaeger *v1alpha1.Jaeger) {
 
 	if unknownStorage(jaeger.Spec.Storage.Type) {
 		logrus.Infof(
-			"The provided storage type for the Jaeger instance '%v' is unknown ('%v'). Falling back to 'memory'",
+			"The provided storage type for the Jaeger instance '%v' is unknown ('%v'). Falling back to 'memory'. Known options: %v",
 			jaeger.Name,
 			jaeger.Spec.Storage.Type,
+			knownStorages(),
 		)
 		jaeger.Spec.Storage.Type = "memory"
 	}
@@ -70,18 +71,20 @@ func normalize(jaeger *v1alpha1.Jaeger) {
 }
 
 func unknownStorage(typ string) bool {
-	known := []string{
-		"memory",
-		"kafka",
-		"elasticsearch",
-		"cassandra",
-	}
-
-	for _, k := range known {
+	for _, k := range knownStorages() {
 		if strings.ToLower(typ) == k {
 			return false
 		}
 	}
 
 	return true
+}
+
+func knownStorages() []string {
+	return []string{
+		"memory",
+		"kafka",
+		"elasticsearch",
+		"cassandra",
+	}
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -18,25 +18,35 @@ type Controller interface {
 
 // NewController build a new controller object for the given spec
 func NewController(ctx context.Context, jaeger *v1alpha1.Jaeger) Controller {
+	normalize(jaeger)
+
+	logrus.Debugf("Jaeger strategy: %s", jaeger.Spec.Strategy)
+	if jaeger.Spec.Strategy == "all-in-one" {
+		return newAllInOneController(ctx, jaeger)
+	}
+
+	return newProductionController(ctx, jaeger)
+}
+
+// normalize changes the incoming Jaeger object so that the defaults are applied when
+// needed and incompatible options are cleaned
+func normalize(jaeger *v1alpha1.Jaeger) {
 	// we need a name!
-	if jaeger.ObjectMeta.Name == "" {
+	if jaeger.Name == "" {
 		logrus.Infof("This Jaeger instance was created without a name. Setting it to 'my-jaeger'")
-		jaeger.ObjectMeta.Name = "my-jaeger"
+		jaeger.Name = "my-jaeger"
 	}
 
 	// normalize the storage type
 	if jaeger.Spec.Storage.Type == "" {
-		logrus.Infof(
-			"Storage type wasn't provided for the Jaeger instance '%v'. Falling back to 'memory'",
-			jaeger.ObjectMeta.Name,
-		)
+		logrus.Infof("Storage type wasn't provided for the Jaeger instance '%v'. Falling back to 'memory'", jaeger.Name)
 		jaeger.Spec.Storage.Type = "memory"
 	}
 
 	if unknownStorage(jaeger.Spec.Storage.Type) {
 		logrus.Infof(
 			"The provided storage type for the Jaeger instance '%v' is unknown ('%v'). Falling back to 'memory'",
-			jaeger.ObjectMeta.Name,
+			jaeger.Name,
 			jaeger.Spec.Storage.Type,
 		)
 		jaeger.Spec.Storage.Type = "memory"
@@ -47,23 +57,16 @@ func NewController(ctx context.Context, jaeger *v1alpha1.Jaeger) Controller {
 		jaeger.Spec.Strategy = "all-in-one"
 	}
 
-	logrus.Debugf("Jaeger strategy: %s", jaeger.Spec.Strategy)
-	if jaeger.Spec.Strategy == "all-in-one" {
-		return newAllInOneController(ctx, jaeger)
-	}
-
 	// check for incompatible options
-	if strings.ToLower(jaeger.Spec.Storage.Type) == "memory" {
+	// if the storage is `memory`, then the only possible strategy is `all-in-one`
+	if strings.ToLower(jaeger.Spec.Storage.Type) == "memory" && strings.ToLower(jaeger.Spec.Strategy) != "all-in-one" {
 		logrus.Warnf(
-			"No suitable storage was provided for the Jaeger instance '%v'. "+
-				"Falling back to all-in-one. Storage type: '%v'",
-			jaeger.ObjectMeta.Name,
+			"No suitable storage was provided for the Jaeger instance '%v'. Falling back to all-in-one. Storage type: '%v'",
+			jaeger.Name,
 			jaeger.Spec.Storage.Type,
 		)
-		return newAllInOneController(ctx, jaeger)
+		jaeger.Spec.Strategy = "all-in-one"
 	}
-
-	return newProductionController(ctx, jaeger)
 }
 
 func unknownStorage(typ string) bool {


### PR DESCRIPTION
This PR moves some of the normalization logic to the stub from the controller. Once the CR is normalized, it's stored back. The side effect is that the controller will only get valid CRs, so that messages related to the normalization will happen only once.

Before this PR:
```
INFO[0005] Storage type wasn't provided for the Jaeger instance 'simplest'. Falling back to 'memory' 
INFO[0005] Created 'simplest'                           
INFO[0005] Created 'simplest'                           
INFO[0005] Created 'simplest'                           
INFO[0005] Created 'simplest'                           
INFO[0005] Created 'simplest'                           
INFO[0005] Created 'simplest'                           
INFO[0005] Storage type wasn't provided for the Jaeger instance 'simplest'. Falling back to 'memory' 
INFO[0010] Storage type wasn't provided for the Jaeger instance 'simplest'. Falling back to 'memory' 
INFO[0015] Storage type wasn't provided for the Jaeger instance 'simplest'. Falling back to 'memory' 
```

After this PR:
```
INFO[0009] Storage type wasn't provided for the Jaeger instance 'simplest'. Falling back to 'memory' 
INFO[0009] Configured simplest                          
^CINFO[0211] Jaeger Operator finished                     
```

Closes #53
Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>