### PR TITLE
Inject sidecar in properly annotated pods

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -167,6 +167,35 @@ oc get routes
 
 NOTE: make sure to use `https` with the hostname/port you get from the command above, otherwise you'll see a message like: "Application is not available".
 
+== Auto injection of Jaeger Agent sidecars
+
+The operator can also inject Jaeger Agent sidecars in `Deployment` workloads, provided that the deployment has the annotation `inject-jaeger-agent` with a suitable value. The values can be either `"true"` (as string), or the Jaeger instance name, as returned by `kubectl get jaegers`. When `"true"` is used, there should be exactly *one* Jaeger instance for the same namespace as the deployment, otherwise, the operator can't figure out automatically which Jaeger instance to use.
+
+The following snippet shows a simple application that will get a sidecar injected, with the Jaeger Agent pointing to the single Jaeger instance available in the same namespace:
+
+[source,yaml]
+----
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myapp
+  annotations:
+    inject-jaeger-agent: "true" # <1>
+spec:
+  selector:
+    matchLabels:
+      app: myapp
+  template:
+    metadata:
+      labels:
+        app: myapp
+    spec:
+      containers:
+      - name: myapp
+        image: acme/myapp:myversion
+----
+<1> Either `"true"` (as string) or the Jaeger instance name
+
 == Agent as DaemonSet
 
 By default, the Operator expects the agents to be deployed as sidecars to the target applications. This is convenient for several purposes, like in a multi-tenant scenario or to have better load balancing, but there are scenarios where it's desirable to install the agent as a `DaemonSet`. In that case, specify the Agent's strategy to `DaemonSet`, as follows:

--- a/pkg/controller/production.go
+++ b/pkg/controller/production.go
@@ -29,7 +29,7 @@ func (c *productionController) Create() []sdk.Object {
 
 	components := []sdk.Object{
 		collector.Get(),
-		agent.InjectSidecar(*query.Get()),
+		query.Get(),
 	}
 
 	ds := agent.Get()

--- a/pkg/controller/production_test.go
+++ b/pkg/controller/production_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/sdk"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
-	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/jaegertracing/jaeger-operator/pkg/apis/io/v1alpha1"
@@ -41,24 +40,6 @@ func TestUpdateProductionDeployment(t *testing.T) {
 	name := "TestUpdateProductionDeployment"
 	c := newProductionController(context.TODO(), v1alpha1.NewJaeger(name))
 	assert.Len(t, c.Update(), 0)
-}
-
-func TestAgentIsInjectedIntoQuery(t *testing.T) {
-	name := "TestAgentIsInjectedIntoQuery"
-	c := newProductionController(context.TODO(), v1alpha1.NewJaeger(name))
-	objs := c.Create()
-	var dep *appsv1.Deployment
-
-	for _, obj := range objs {
-		switch obj.(type) {
-		case *appsv1.Deployment:
-			dep = obj.(*appsv1.Deployment)
-			break
-		}
-	}
-
-	assert.Len(t, dep.Spec.Template.Spec.Containers, 2)
-	assert.Contains(t, dep.Spec.Template.Spec.Containers[1].Image, "jaeger-agent")
 }
 
 func TestOptionsArePassed(t *testing.T) {

--- a/pkg/deployment/agent.go
+++ b/pkg/deployment/agent.go
@@ -32,7 +32,7 @@ func NewAgent(jaeger *v1alpha1.Jaeger) *Agent {
 // Get returns a Agent pod
 func (a *Agent) Get() *appsv1.DaemonSet {
 	if strings.ToLower(a.jaeger.Spec.Agent.Strategy) != "daemonset" {
-		logrus.Infof(
+		logrus.Debugf(
 			"The Jaeger instance '%v' is using a Sidecar strategy for the Jaeger Agent. Skipping its DaemonSet deployment.",
 			a.jaeger.Name,
 		)
@@ -118,39 +118,6 @@ func (a *Agent) Get() *appsv1.DaemonSet {
 			},
 		},
 	}
-}
-
-// InjectSidecar adds a new container to the deployment, containing Jaeger's agent
-func (a *Agent) InjectSidecar(dep appsv1.Deployment) *appsv1.Deployment {
-	sidecar := v1.Container{
-		Image: a.jaeger.Spec.Agent.Image,
-		Name:  "jaeger-agent",
-		Args:  []string{fmt.Sprintf("--collector.host-port=%s:14267", service.GetNameForCollectorService(a.jaeger))},
-		Ports: []v1.ContainerPort{
-			{
-				ContainerPort: 5775,
-				Name:          "zk-compact-trft",
-				Protocol:      v1.ProtocolUDP,
-			},
-			{
-				ContainerPort: 5778,
-				Name:          "config-rest",
-			},
-			{
-				ContainerPort: 6831,
-				Name:          "jg-compact-trft",
-				Protocol:      v1.ProtocolUDP,
-			},
-			{
-				ContainerPort: 6832,
-				Name:          "jg-binary-trft",
-				Protocol:      v1.ProtocolUDP,
-			},
-		},
-	}
-
-	dep.Spec.Template.Spec.Containers = append(dep.Spec.Template.Spec.Containers, sidecar)
-	return &dep
 }
 
 func (a *Agent) selector() map[string]string {

--- a/pkg/deployment/agent_test.go
+++ b/pkg/deployment/agent_test.go
@@ -45,7 +45,7 @@ func TestGetDefaultAgentDeployment(t *testing.T) {
 	assert.Nil(t, agent.Get()) // it's not implemented yet
 }
 
-func TestGetSicedarDeployment(t *testing.T) {
+func TestGetSidecarDeployment(t *testing.T) {
 	jaeger := v1alpha1.NewJaeger("TestNewAgent")
 	jaeger.Spec.Agent.Strategy = "sidecar"
 	agent := NewAgent(jaeger)
@@ -57,15 +57,4 @@ func TestGetDaemonSetDeployment(t *testing.T) {
 	jaeger.Spec.Agent.Strategy = "daemonset"
 	agent := NewAgent(jaeger)
 	assert.NotNil(t, agent.Get())
-}
-
-func TestInjectSidecar(t *testing.T) {
-	jaeger := v1alpha1.NewJaeger("TestNewAgent")
-	dep := NewQuery(jaeger).Get()
-	agent := NewAgent(jaeger)
-
-	dep = agent.InjectSidecar(*dep)
-
-	assert.Len(t, dep.Spec.Template.Spec.Containers, 2)
-	assert.Contains(t, dep.Spec.Template.Spec.Containers[1].Image, "jaeger-agent")
 }

--- a/pkg/deployment/query.go
+++ b/pkg/deployment/query.go
@@ -43,6 +43,13 @@ func (q *Query) Get() *appsv1.Deployment {
 	annotations := map[string]string{
 		"prometheus.io/scrape": "true",
 		"prometheus.io/port":   "16686",
+
+		// note that we are explicitly using a string here, not the value from `inject.Annotation`
+		// this has two reasons:
+		// 1) as it is, it would cause a circular dependency, so, we'd have to extract that constant to somewhere else
+		// 2) this specific string is part of the "public API" of the operator: we should not change
+		// it at will. So, we leave this configured just like any other application would
+		"inject-jaeger-agent": q.jaeger.Name,
 	}
 
 	return &appsv1.Deployment{

--- a/pkg/inject/sidecar.go
+++ b/pkg/inject/sidecar.go
@@ -1,0 +1,99 @@
+package inject
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/api/core/v1"
+
+	"github.com/jaegertracing/jaeger-operator/pkg/apis/io/v1alpha1"
+	"github.com/jaegertracing/jaeger-operator/pkg/deployment"
+	"github.com/jaegertracing/jaeger-operator/pkg/service"
+)
+
+var (
+	// Annotation is the annotation name to look for when deciding whether or not to inject
+	Annotation = "inject-jaeger-agent"
+)
+
+// Sidecar adds a new container to the deployment, connecting to the given jaeger instance
+func Sidecar(dep *appsv1.Deployment, jaeger *v1alpha1.Jaeger) {
+	deployment.NewAgent(jaeger) // we need some initialization from that, but we don't actually need the agent's instance here
+
+	if jaeger == nil || dep.Annotations[Annotation] != jaeger.Name {
+		logrus.Debugf("Skipping sidecar injection for deployment %v", dep.Name)
+	} else {
+		logrus.Debugf("Injecting sidecar for pod %v", dep.Name)
+		dep.Spec.Template.Spec.Containers = append(dep.Spec.Template.Spec.Containers, container(jaeger))
+	}
+}
+
+// Needed determines whether a pod needs to get a sidecar injected or not
+func Needed(dep *appsv1.Deployment) bool {
+	if dep.Annotations[Annotation] == "" {
+		logrus.Debugf("Not needed, annotation not present for %v", dep.Name)
+		return false
+	}
+
+	// this pod is annotated, it should have a sidecar
+	// but does it already have one?
+	hasSidecar := false
+	for _, container := range dep.Spec.Template.Spec.Containers {
+		if container.Name == "jaeger-agent" { // we don't labels/annotations on containers, so, we rely on its name
+			hasSidecar = true
+		}
+	}
+
+	return !hasSidecar
+}
+
+// Select a suitable Jaeger from the JaegerList for the given Pod, or nil of none is suitable
+func Select(target *appsv1.Deployment, availableJaegerPods *v1alpha1.JaegerList) *v1alpha1.Jaeger {
+	jaegerName := target.Annotations[Annotation]
+	if strings.ToLower(jaegerName) == "true" && len(availableJaegerPods.Items) == 1 {
+		// if there's only *one* jaeger within this namespace, then that's what
+		// we'll use -- otherwise, we should just not inject, as it's not clear which
+		// jaeger instance to use!
+		// first, we make sure we normalize the name:
+		jaeger := &availableJaegerPods.Items[0]
+		target.Annotations[Annotation] = jaeger.Name
+		return jaeger
+	}
+
+	for _, p := range availableJaegerPods.Items {
+		if p.Name == jaegerName {
+			// matched the name!
+			return &p
+		}
+	}
+	return nil
+}
+
+func container(jaeger *v1alpha1.Jaeger) v1.Container {
+	args := append(jaeger.Spec.Agent.Options.ToArgs(), fmt.Sprintf("--collector.host-port=%s:14267", service.GetNameForCollectorService(jaeger)))
+	return v1.Container{
+		Image: jaeger.Spec.Agent.Image,
+		Name:  "jaeger-agent",
+		Args:  args,
+		Ports: []v1.ContainerPort{
+			{
+				ContainerPort: 5775,
+				Name:          "zk-compact-trft",
+			},
+			{
+				ContainerPort: 5778,
+				Name:          "config-rest",
+			},
+			{
+				ContainerPort: 6831,
+				Name:          "jg-compact-trft",
+			},
+			{
+				ContainerPort: 6832,
+				Name:          "jg-binary-trft",
+			},
+		},
+	}
+}

--- a/pkg/inject/sidecar.go
+++ b/pkg/inject/sidecar.go
@@ -39,14 +39,13 @@ func Needed(dep *appsv1.Deployment) bool {
 
 	// this pod is annotated, it should have a sidecar
 	// but does it already have one?
-	hasSidecar := false
 	for _, container := range dep.Spec.Template.Spec.Containers {
 		if container.Name == "jaeger-agent" { // we don't labels/annotations on containers, so, we rely on its name
-			hasSidecar = true
+			return false
 		}
 	}
 
-	return !hasSidecar
+	return true
 }
 
 // Select a suitable Jaeger from the JaegerList for the given Pod, or nil of none is suitable

--- a/pkg/inject/sidecar_test.go
+++ b/pkg/inject/sidecar_test.go
@@ -1,0 +1,156 @@
+package inject
+
+import (
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/jaegertracing/jaeger-operator/pkg/apis/io/v1alpha1"
+)
+
+func setDefaults() {
+	viper.SetDefault("jaeger-version", "1.7")
+	viper.SetDefault("jaeger-agent-image", "jaegertracing/jaeger-agent")
+}
+
+func init() {
+	setDefaults()
+}
+
+func reset() {
+	viper.Reset()
+	setDefaults()
+}
+
+func TestInjectSidecar(t *testing.T) {
+	jaeger := v1alpha1.NewJaeger("TestInjectSidecar")
+	dep := dep(map[string]string{Annotation: jaeger.Name})
+	Sidecar(dep, jaeger)
+	assert.Len(t, dep.Spec.Template.Spec.Containers, 2)
+	assert.Contains(t, dep.Spec.Template.Spec.Containers[1].Image, "jaeger-agent")
+}
+
+func TestSkipInjectSidecar(t *testing.T) {
+	jaeger := v1alpha1.NewJaeger("TestSkipInjectSidecar")
+	dep := dep(map[string]string{Annotation: "non-existing-operator"})
+	Sidecar(dep, jaeger)
+	assert.Len(t, dep.Spec.Template.Spec.Containers, 1)
+	assert.NotContains(t, dep.Spec.Template.Spec.Containers[0].Image, "jaeger-agent")
+}
+
+func TestSidecarNotNeeded(t *testing.T) {
+	dep := &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						v1.Container{},
+					},
+				},
+			},
+		},
+	}
+
+	assert.False(t, Needed(dep))
+}
+
+func TestSidecarNeeded(t *testing.T) {
+	dep := dep(map[string]string{Annotation: "some-jaeger-instance"})
+	assert.True(t, Needed(dep))
+}
+
+func TestHasSidecarAlready(t *testing.T) {
+	dep := dep(map[string]string{Annotation: "TestHasSidecarAlready"})
+	assert.True(t, Needed(dep))
+	jaeger := v1alpha1.NewJaeger("TestHasSidecarAlready")
+	Sidecar(dep, jaeger)
+	assert.False(t, Needed(dep))
+}
+
+func TestSelectSingleJaegerPod(t *testing.T) {
+	dep := dep(map[string]string{Annotation: "true"})
+	jaegerPods := &v1alpha1.JaegerList{
+		Items: []v1alpha1.Jaeger{
+			v1alpha1.Jaeger{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "the-only-jaeger-instance-available",
+				},
+			},
+		},
+	}
+
+	jaeger := Select(dep, jaegerPods)
+	assert.NotNil(t, jaeger)
+	assert.Equal(t, "the-only-jaeger-instance-available", jaeger.Name)
+}
+
+func TestCannotSelectFromMultipleJaegerPods(t *testing.T) {
+	dep := dep(map[string]string{Annotation: "true"})
+	jaegerPods := &v1alpha1.JaegerList{
+		Items: []v1alpha1.Jaeger{
+			v1alpha1.Jaeger{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "the-first-jaeger-instance-available",
+				},
+			},
+			v1alpha1.Jaeger{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "the-second-jaeger-instance-available",
+				},
+			},
+		},
+	}
+
+	jaeger := Select(dep, jaegerPods)
+	assert.Nil(t, jaeger)
+}
+
+func TestNoAvailableJaegerPods(t *testing.T) {
+	dep := dep(map[string]string{Annotation: "true"})
+	jaeger := Select(dep, &v1alpha1.JaegerList{})
+	assert.Nil(t, jaeger)
+}
+
+func TestSelectBasedOnName(t *testing.T) {
+	dep := dep(map[string]string{Annotation: "the-second-jaeger-instance-available"})
+
+	jaegerPods := &v1alpha1.JaegerList{
+		Items: []v1alpha1.Jaeger{
+			v1alpha1.Jaeger{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "the-first-jaeger-instance-available",
+				},
+			},
+			v1alpha1.Jaeger{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "the-second-jaeger-instance-available",
+				},
+			},
+		},
+	}
+
+	jaeger := Select(dep, jaegerPods)
+	assert.NotNil(t, jaeger)
+	assert.Equal(t, "the-second-jaeger-instance-available", jaeger.Name)
+}
+
+func dep(annotations map[string]string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: annotations,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						v1.Container{},
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/stub/handler.go
+++ b/pkg/stub/handler.go
@@ -2,13 +2,17 @@ package stub
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/operator-framework/operator-sdk/pkg/sdk"
 	"github.com/sirupsen/logrus"
+	appsv1 "k8s.io/api/apps/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/jaegertracing/jaeger-operator/pkg/apis/io/v1alpha1"
 	"github.com/jaegertracing/jaeger-operator/pkg/controller"
+	"github.com/jaegertracing/jaeger-operator/pkg/inject"
 )
 
 // NewHandler constructs a new Jaeger operator handler
@@ -63,6 +67,34 @@ func (h *Handler) Handle(ctx context.Context, event sdk.Event) error {
 			logrus.Errorf("failed to update %v", o)
 			return err
 		}
+	case *appsv1.Deployment:
+		if inject.Needed(o) {
+			pods := &v1alpha1.JaegerList{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Jaeger",
+					APIVersion: fmt.Sprintf("%s/%s", v1alpha1.SchemeGroupVersion.Group, v1alpha1.SchemeGroupVersion.Version),
+				},
+			}
+			err := sdk.List(o.GetNamespace(), pods)
+			if err != nil {
+				logrus.WithError(err).Error("failed to get the available Jaeger pods")
+				return err
+			}
+
+			jaeger := inject.Select(o, pods)
+			if jaeger != nil {
+				// a suitable jaeger instance was found! let's inject a sidecar pointing to it then
+				logrus.WithFields(logrus.Fields{"deployment": o.Name, "jaeger": jaeger.Name}).Info("Injecting Jaeger Agent sidecar")
+				inject.Sidecar(o, jaeger)
+				if err := sdk.Update(o); err != nil {
+					logrus.WithField("deployment", o).Error("failed to update")
+					return err
+				}
+			} else {
+				logrus.WithField("deployment", o.Name).Info("No suitable Jaeger instances found to inject a sidecar")
+			}
+		}
+
 	}
 	return nil
 }

--- a/test/e2e/all_in_one_test.go
+++ b/test/e2e/all_in_one_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func JaegerAllInOne(t *testing.T) {
+	t.Parallel()
 	ctx := prepare(t)
 	defer ctx.Cleanup(t)
 

--- a/test/e2e/jaeger_test.go
+++ b/test/e2e/jaeger_test.go
@@ -37,11 +37,11 @@ func TestJaeger(t *testing.T) {
 		t.Run("simple-prod", SimpleProd)
 
 		t.Run("daemonset", DaemonSet)
+		t.Run("sidecar", Sidecar)
 	})
 }
 
 func prepare(t *testing.T) framework.TestCtx {
-	t.Parallel() // so far, our tests can run concurrently
 	ctx := framework.NewTestCtx(t)
 	err := ctx.InitializeClusterResources()
 	if err != nil {

--- a/test/e2e/production_test.go
+++ b/test/e2e/production_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func SimpleProd(t *testing.T) {
+	t.Parallel()
 	ctx := prepare(t)
 	defer ctx.Cleanup(t)
 

--- a/test/e2e/sidecar.go
+++ b/test/e2e/sidecar.go
@@ -1,0 +1,168 @@
+package e2e
+
+import (
+	goctx "context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+	"time"
+
+	framework "github.com/operator-framework/operator-sdk/pkg/test"
+	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/jaegertracing/jaeger-operator/pkg/apis/io/v1alpha1"
+	"github.com/jaegertracing/jaeger-operator/pkg/inject"
+)
+
+// Sidecar runs a test with the agent as sidecar
+func Sidecar(t *testing.T) {
+	ctx := prepare(t)
+	defer ctx.Cleanup(t)
+
+	if err := sidecarTest(t, framework.Global, ctx); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func sidecarTest(t *testing.T, f *framework.Framework, ctx framework.TestCtx) error {
+	namespace, err := ctx.GetNamespace()
+	if err != nil {
+		return fmt.Errorf("could not get namespace: %v", err)
+	}
+
+	j := &v1alpha1.Jaeger{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Jaeger",
+			APIVersion: "io.jaegertracing/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "agent-as-sidecar",
+			Namespace: namespace,
+		},
+		Spec: v1alpha1.JaegerSpec{
+			Strategy: "all-in-one",
+			AllInOne: v1alpha1.JaegerAllInOneSpec{},
+			Agent: v1alpha1.JaegerAgentSpec{
+				Options: v1alpha1.NewOptions(map[string]interface{}{
+					"log-level": "debug",
+				}),
+			},
+		},
+	}
+
+	err = f.DynamicClient.Create(goctx.TODO(), j)
+	if err != nil {
+		return err
+	}
+
+	selector := map[string]string{"app": "vertx-create-span-sidecar"}
+	dep := &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "vertx-create-span-sidecar",
+			Namespace:   namespace,
+			Annotations: map[string]string{inject.Annotation: "true"},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: selector,
+			},
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: selector,
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{{
+						Image: "jaegertracing/vertx-create-span:operator-e2e-tests",
+						Name:  "vertx-create-span-sidecar",
+						Ports: []v1.ContainerPort{
+							{
+								ContainerPort: 8080,
+							},
+						},
+						ReadinessProbe: &v1.Probe{
+							Handler: v1.Handler{
+								HTTPGet: &v1.HTTPGetAction{
+									Path: "/",
+									Port: intstr.FromInt(8080),
+								},
+							},
+							InitialDelaySeconds: 1,
+						},
+						LivenessProbe: &v1.Probe{
+							Handler: v1.Handler{
+								HTTPGet: &v1.HTTPGetAction{
+									Path: "/",
+									Port: intstr.FromInt(8080),
+								},
+							},
+							InitialDelaySeconds: 1,
+						},
+					}},
+				},
+			},
+		},
+	}
+	err = f.DynamicClient.Create(goctx.TODO(), dep)
+	if err != nil {
+		return err
+	}
+
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "vertx-create-span-sidecar", 1, retryInterval, timeout)
+	if err != nil {
+		return err
+	}
+
+	err = WaitForIngress(t, f.KubeClient, namespace, "agent-as-sidecar-query", retryInterval, timeout)
+	if err != nil {
+		return err
+	}
+
+	i, err := f.KubeClient.ExtensionsV1beta1().Ingresses(namespace).Get("agent-as-sidecar-query", metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	if len(i.Status.LoadBalancer.Ingress) != 1 {
+		return fmt.Errorf("Wrong number of ingresses. Expected 1, was %v", len(i.Status.LoadBalancer.Ingress))
+	}
+
+	address := i.Status.LoadBalancer.Ingress[0].IP
+	url := fmt.Sprintf("http://%s/api/traces?service=order", address)
+	c := http.Client{Timeout: time.Second}
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+
+	return wait.Poll(retryInterval, timeout, func() (done bool, err error) {
+		res, err := c.Do(req)
+		if err != nil {
+			return false, err
+		}
+
+		body, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			return false, err
+		}
+
+		resp := &resp{}
+		err = json.Unmarshal(body, &resp)
+		if err != nil {
+			return false, err
+		}
+
+		return len(resp.Data) > 0, nil
+	})
+}

--- a/test/e2e/simplest_test.go
+++ b/test/e2e/simplest_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func SimplestJaeger(t *testing.T) {
+	t.Parallel()
 	ctx := prepare(t)
 	defer ctx.Cleanup(t)
 


### PR DESCRIPTION
This PR adds support for auto-injection of Jaeger agents into target `Deployment` objects. Technically, this can be done for all objects containing `Pod` objects, like `StatefulSet` or `DaemonSet`, but this PR limits the first implementation to `Deployment`, to get it tested first. If there's demand, it's relatively easy to add support for other constructs.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>