### PR TITLE
Add sidecar.istio.io/inject=false annotation to all-in-one, agent (da…

### DIFF
--- a/pkg/deployment/agent.go
+++ b/pkg/deployment/agent.go
@@ -43,8 +43,9 @@ func (a *Agent) Get() *appsv1.DaemonSet {
 	trueVar := true
 	selector := a.selector()
 	annotations := map[string]string{
-		"prometheus.io/scrape": "true",
-		"prometheus.io/port":   "5778",
+		"prometheus.io/scrape":    "true",
+		"prometheus.io/port":      "5778",
+		"sidecar.istio.io/inject": "false",
 	}
 
 	return &appsv1.DaemonSet{

--- a/pkg/deployment/agent_test.go
+++ b/pkg/deployment/agent_test.go
@@ -56,5 +56,9 @@ func TestGetDaemonSetDeployment(t *testing.T) {
 	jaeger := v1alpha1.NewJaeger("TestNewAgent")
 	jaeger.Spec.Agent.Strategy = "daemonset"
 	agent := NewAgent(jaeger)
-	assert.NotNil(t, agent.Get())
+
+	ds := agent.Get()
+	assert.NotNil(t, ds)
+
+	assert.Equal(t, "false", ds.Spec.Template.Annotations["sidecar.istio.io/inject"])
 }

--- a/pkg/deployment/all-in-one.go
+++ b/pkg/deployment/all-in-one.go
@@ -36,8 +36,9 @@ func (a *AllInOne) Get() *appsv1.Deployment {
 	selector := a.selector()
 	trueVar := true
 	annotations := map[string]string{
-		"prometheus.io/scrape": "true",
-		"prometheus.io/port":   "16686",
+		"prometheus.io/scrape":    "true",
+		"prometheus.io/port":      "16686",
+		"sidecar.istio.io/inject": "false",
 	}
 
 	return &appsv1.Deployment{

--- a/pkg/deployment/all-in-one_test.go
+++ b/pkg/deployment/all-in-one_test.go
@@ -36,6 +36,8 @@ func TestDefaultAllInOneImage(t *testing.T) {
 		},
 	}
 	assert.Equal(t, envvars, d.Spec.Template.Spec.Containers[0].Env)
+
+	assert.Equal(t, "false", d.Spec.Template.ObjectMeta.Annotations["sidecar.istio.io/inject"])
 }
 
 func TestAllInOneHasOwner(t *testing.T) {

--- a/pkg/deployment/collector.go
+++ b/pkg/deployment/collector.go
@@ -40,8 +40,9 @@ func (c *Collector) Get() *appsv1.Deployment {
 	trueVar := true
 	replicas := int32(c.jaeger.Spec.Collector.Size)
 	annotations := map[string]string{
-		"prometheus.io/scrape": "true",
-		"prometheus.io/port":   "14268",
+		"prometheus.io/scrape":    "true",
+		"prometheus.io/port":      "14268",
+		"sidecar.istio.io/inject": "false",
 	}
 
 	return &appsv1.Deployment{

--- a/pkg/deployment/collector_test.go
+++ b/pkg/deployment/collector_test.go
@@ -68,4 +68,6 @@ func TestDefaultCollectorImage(t *testing.T) {
 		},
 	}
 	assert.Equal(t, envvars, containers[0].Env)
+
+	assert.Equal(t, "false", dep.Spec.Template.ObjectMeta.Annotations["sidecar.istio.io/inject"])
 }

--- a/pkg/deployment/query.go
+++ b/pkg/deployment/query.go
@@ -41,8 +41,9 @@ func (q *Query) Get() *appsv1.Deployment {
 	trueVar := true
 	replicas := int32(q.jaeger.Spec.Query.Size)
 	annotations := map[string]string{
-		"prometheus.io/scrape": "true",
-		"prometheus.io/port":   "16686",
+		"prometheus.io/scrape":    "true",
+		"prometheus.io/port":      "16686",
+		"sidecar.istio.io/inject": "false",
 
 		// note that we are explicitly using a string here, not the value from `inject.Annotation`
 		// this has two reasons:

--- a/pkg/deployment/query_test.go
+++ b/pkg/deployment/query_test.go
@@ -44,6 +44,8 @@ func TestDefaultQueryImage(t *testing.T) {
 
 	assert.Len(t, containers, 1)
 	assert.Equal(t, "org/custom-query-image:123", containers[0].Image)
+
+	assert.Equal(t, "false", dep.Spec.Template.ObjectMeta.Annotations["sidecar.istio.io/inject"])
 }
 
 func TestQueryPodName(t *testing.T) {


### PR DESCRIPTION
…emonset), query and collector

As annotations are ignored if not relevant, just added to the list. However in future, if necessary we could detect whether jaeger is being deployed into an Istio enabled cluster, and possibly only add the annotation then.

Signed-off-by: Gary Brown <gary@brownuk.com>