### PR TITLE
Fix table of contents on readme

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,9 +1,11 @@
+:toc: macro
+
 image:https://travis-ci.org/jaegertracing/jaeger-operator.svg?branch=master["Build Status", link="https://travis-ci.org/jaegertracing/jaeger-operator"]
 image:https://goreportcard.com/badge/github.com/jaegertracing/jaeger-operator["Go Report Card", link="https://goreportcard.com/report/github.com/jaegertracing/jaeger-operator"]
 image:https://codecov.io/gh/jaegertracing/jaeger-operator/branch/master/graph/badge.svg["Code Coverage", link="https://codecov.io/gh/jaegertracing/jaeger-operator"]
 
 = Jaeger Operator for Kubernetes
-:toc:
+toc::[]
 
 == Installing the operator on Kubernetes
 


### PR DESCRIPTION
As we have the badges, the table of contents macro wasn't getting called. One way of fixing this is like this PR. Another way is to get the header + toc as the first things in the doc, with the badges next.

Before:
![image](https://user-images.githubusercontent.com/13387/47145418-0261f100-d2ca-11e8-9b2b-79de131a4eee.png)

After:
![image](https://user-images.githubusercontent.com/13387/47145404-f8d88900-d2c9-11e8-9ecf-5802ad28a630.png)

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>