### PR TITLE
Enable annotations to be specified with the deployable components

### DIFF
--- a/pkg/apis/io/v1alpha1/types.go
+++ b/pkg/apis/io/v1alpha1/types.go
@@ -40,10 +40,11 @@ type JaegerStatus struct {
 
 // JaegerQuerySpec defines the options to be used when deploying the query
 type JaegerQuerySpec struct {
-	Ingress JaegerIngressSpec `json:"ingress"`
-	Size    int               `json:"size"`
-	Image   string            `json:"image"`
-	Options Options           `json:"options"`
+	Ingress     JaegerIngressSpec `json:"ingress"`
+	Size        int               `json:"size"`
+	Image       string            `json:"image"`
+	Options     Options           `json:"options"`
+	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
 // JaegerIngressSpec defines the options to be used when deploying the query ingress
@@ -53,23 +54,26 @@ type JaegerIngressSpec struct {
 
 // JaegerAllInOneSpec defines the options to be used when deploying the query
 type JaegerAllInOneSpec struct {
-	Ingress JaegerIngressSpec `json:"ingress"`
-	Image   string            `json:"image"`
-	Options Options           `json:"options"`
+	Ingress     JaegerIngressSpec `json:"ingress"`
+	Image       string            `json:"image"`
+	Options     Options           `json:"options"`
+	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
 // JaegerCollectorSpec defines the options to be used when deploying the collector
 type JaegerCollectorSpec struct {
-	Size    int     `json:"size"`
-	Image   string  `json:"image"`
-	Options Options `json:"options"`
+	Size        int               `json:"size"`
+	Image       string            `json:"image"`
+	Options     Options           `json:"options"`
+	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
 // JaegerAgentSpec defines the options to be used when deploying the agent
 type JaegerAgentSpec struct {
-	Strategy string  `json:"strategy"` // can be either 'DaemonSet' or 'Sidecar' (default)
-	Image    string  `json:"image"`
-	Options  Options `json:"options"`
+	Strategy    string            `json:"strategy"` // can be either 'DaemonSet' or 'Sidecar' (default)
+	Image       string            `json:"image"`
+	Options     Options           `json:"options"`
+	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
 // JaegerStorageSpec defines the common storage options to be used for the query and collector

--- a/pkg/deployment/agent.go
+++ b/pkg/deployment/agent.go
@@ -47,6 +47,9 @@ func (a *Agent) Get() *appsv1.DaemonSet {
 		"prometheus.io/port":      "5778",
 		"sidecar.istio.io/inject": "false",
 	}
+	for k, v := range a.jaeger.Spec.Agent.Annotations {
+		annotations[k] = v
+	}
 
 	return &appsv1.DaemonSet{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/deployment/agent_test.go
+++ b/pkg/deployment/agent_test.go
@@ -65,12 +65,14 @@ func TestDaemonSetAgentAnnotations(t *testing.T) {
 	jaeger := v1alpha1.NewJaeger("TestDaemonSetAgentAnnotations")
 	jaeger.Spec.Agent.Strategy = "daemonset"
 	jaeger.Spec.Agent.Annotations = map[string]string{
-		"hello": "world",
+		"hello":                "world",
+		"prometheus.io/scrape": "false", // Override implicit value
 	}
 
 	agent := NewAgent(jaeger)
 	dep := agent.Get()
 
-	assert.Equal(t, "false", dep.Spec.Template.ObjectMeta.Annotations["sidecar.istio.io/inject"])
-	assert.Equal(t, "world", dep.Spec.Template.ObjectMeta.Annotations["hello"])
+	assert.Equal(t, "false", dep.Spec.Template.Annotations["sidecar.istio.io/inject"])
+	assert.Equal(t, "world", dep.Spec.Template.Annotations["hello"])
+	assert.Equal(t, "false", dep.Spec.Template.Annotations["prometheus.io/scrape"])
 }

--- a/pkg/deployment/agent_test.go
+++ b/pkg/deployment/agent_test.go
@@ -59,6 +59,18 @@ func TestGetDaemonSetDeployment(t *testing.T) {
 
 	ds := agent.Get()
 	assert.NotNil(t, ds)
+}
 
-	assert.Equal(t, "false", ds.Spec.Template.Annotations["sidecar.istio.io/inject"])
+func TestDaemonSetAgentAnnotations(t *testing.T) {
+	jaeger := v1alpha1.NewJaeger("TestDaemonSetAgentAnnotations")
+	jaeger.Spec.Agent.Strategy = "daemonset"
+	jaeger.Spec.Agent.Annotations = map[string]string{
+		"hello": "world",
+	}
+
+	agent := NewAgent(jaeger)
+	dep := agent.Get()
+
+	assert.Equal(t, "false", dep.Spec.Template.ObjectMeta.Annotations["sidecar.istio.io/inject"])
+	assert.Equal(t, "world", dep.Spec.Template.ObjectMeta.Annotations["hello"])
 }

--- a/pkg/deployment/all-in-one.go
+++ b/pkg/deployment/all-in-one.go
@@ -40,6 +40,9 @@ func (a *AllInOne) Get() *appsv1.Deployment {
 		"prometheus.io/port":      "16686",
 		"sidecar.istio.io/inject": "false",
 	}
+	for k, v := range a.jaeger.Spec.AllInOne.Annotations {
+		annotations[k] = v
+	}
 
 	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/deployment/all-in-one_test.go
+++ b/pkg/deployment/all-in-one_test.go
@@ -41,14 +41,16 @@ func TestDefaultAllInOneImage(t *testing.T) {
 func TestAllInOneAnnotations(t *testing.T) {
 	jaeger := v1alpha1.NewJaeger("TestAllInOneAnnotations")
 	jaeger.Spec.AllInOne.Annotations = map[string]string{
-		"hello": "world",
+		"hello":                "world",
+		"prometheus.io/scrape": "false", // Override implicit value
 	}
 
 	allinone := NewAllInOne(jaeger)
 	dep := allinone.Get()
 
-	assert.Equal(t, "false", dep.Spec.Template.ObjectMeta.Annotations["sidecar.istio.io/inject"])
-	assert.Equal(t, "world", dep.Spec.Template.ObjectMeta.Annotations["hello"])
+	assert.Equal(t, "false", dep.Spec.Template.Annotations["sidecar.istio.io/inject"])
+	assert.Equal(t, "world", dep.Spec.Template.Annotations["hello"])
+	assert.Equal(t, "false", dep.Spec.Template.Annotations["prometheus.io/scrape"])
 }
 
 func TestAllInOneHasOwner(t *testing.T) {

--- a/pkg/deployment/all-in-one_test.go
+++ b/pkg/deployment/all-in-one_test.go
@@ -36,8 +36,19 @@ func TestDefaultAllInOneImage(t *testing.T) {
 		},
 	}
 	assert.Equal(t, envvars, d.Spec.Template.Spec.Containers[0].Env)
+}
 
-	assert.Equal(t, "false", d.Spec.Template.ObjectMeta.Annotations["sidecar.istio.io/inject"])
+func TestAllInOneAnnotations(t *testing.T) {
+	jaeger := v1alpha1.NewJaeger("TestAllInOneAnnotations")
+	jaeger.Spec.AllInOne.Annotations = map[string]string{
+		"hello": "world",
+	}
+
+	allinone := NewAllInOne(jaeger)
+	dep := allinone.Get()
+
+	assert.Equal(t, "false", dep.Spec.Template.ObjectMeta.Annotations["sidecar.istio.io/inject"])
+	assert.Equal(t, "world", dep.Spec.Template.ObjectMeta.Annotations["hello"])
 }
 
 func TestAllInOneHasOwner(t *testing.T) {

--- a/pkg/deployment/collector.go
+++ b/pkg/deployment/collector.go
@@ -44,6 +44,9 @@ func (c *Collector) Get() *appsv1.Deployment {
 		"prometheus.io/port":      "14268",
 		"sidecar.istio.io/inject": "false",
 	}
+	for k, v := range c.jaeger.Spec.Collector.Annotations {
+		annotations[k] = v
+	}
 
 	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/deployment/collector_test.go
+++ b/pkg/deployment/collector_test.go
@@ -73,12 +73,14 @@ func TestDefaultCollectorImage(t *testing.T) {
 func TestCollectorAnnotations(t *testing.T) {
 	jaeger := v1alpha1.NewJaeger("TestCollectorAnnotations")
 	jaeger.Spec.Collector.Annotations = map[string]string{
-		"hello": "world",
+		"hello":                "world",
+		"prometheus.io/scrape": "false", // Override implicit value
 	}
 
 	collector := NewCollector(jaeger)
 	dep := collector.Get()
 
-	assert.Equal(t, "false", dep.Spec.Template.ObjectMeta.Annotations["sidecar.istio.io/inject"])
-	assert.Equal(t, "world", dep.Spec.Template.ObjectMeta.Annotations["hello"])
+	assert.Equal(t, "false", dep.Spec.Template.Annotations["sidecar.istio.io/inject"])
+	assert.Equal(t, "world", dep.Spec.Template.Annotations["hello"])
+	assert.Equal(t, "false", dep.Spec.Template.Annotations["prometheus.io/scrape"])
 }

--- a/pkg/deployment/collector_test.go
+++ b/pkg/deployment/collector_test.go
@@ -68,6 +68,17 @@ func TestDefaultCollectorImage(t *testing.T) {
 		},
 	}
 	assert.Equal(t, envvars, containers[0].Env)
+}
+
+func TestCollectorAnnotations(t *testing.T) {
+	jaeger := v1alpha1.NewJaeger("TestCollectorAnnotations")
+	jaeger.Spec.Collector.Annotations = map[string]string{
+		"hello": "world",
+	}
+
+	collector := NewCollector(jaeger)
+	dep := collector.Get()
 
 	assert.Equal(t, "false", dep.Spec.Template.ObjectMeta.Annotations["sidecar.istio.io/inject"])
+	assert.Equal(t, "world", dep.Spec.Template.ObjectMeta.Annotations["hello"])
 }

--- a/pkg/deployment/query.go
+++ b/pkg/deployment/query.go
@@ -52,6 +52,9 @@ func (q *Query) Get() *appsv1.Deployment {
 		// it at will. So, we leave this configured just like any other application would
 		"inject-jaeger-agent": q.jaeger.Name,
 	}
+	for k, v := range q.jaeger.Spec.Query.Annotations {
+		annotations[k] = v
+	}
 
 	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/deployment/query_test.go
+++ b/pkg/deployment/query_test.go
@@ -44,8 +44,19 @@ func TestDefaultQueryImage(t *testing.T) {
 
 	assert.Len(t, containers, 1)
 	assert.Equal(t, "org/custom-query-image:123", containers[0].Image)
+}
+
+func TestQueryAnnotations(t *testing.T) {
+	jaeger := v1alpha1.NewJaeger("TestQueryAnnotations")
+	jaeger.Spec.Query.Annotations = map[string]string{
+		"hello": "world",
+	}
+
+	query := NewQuery(jaeger)
+	dep := query.Get()
 
 	assert.Equal(t, "false", dep.Spec.Template.ObjectMeta.Annotations["sidecar.istio.io/inject"])
+	assert.Equal(t, "world", dep.Spec.Template.ObjectMeta.Annotations["hello"])
 }
 
 func TestQueryPodName(t *testing.T) {

--- a/pkg/deployment/query_test.go
+++ b/pkg/deployment/query_test.go
@@ -49,14 +49,16 @@ func TestDefaultQueryImage(t *testing.T) {
 func TestQueryAnnotations(t *testing.T) {
 	jaeger := v1alpha1.NewJaeger("TestQueryAnnotations")
 	jaeger.Spec.Query.Annotations = map[string]string{
-		"hello": "world",
+		"hello":                "world",
+		"prometheus.io/scrape": "false", // Override implicit value
 	}
 
 	query := NewQuery(jaeger)
 	dep := query.Get()
 
-	assert.Equal(t, "false", dep.Spec.Template.ObjectMeta.Annotations["sidecar.istio.io/inject"])
-	assert.Equal(t, "world", dep.Spec.Template.ObjectMeta.Annotations["hello"])
+	assert.Equal(t, "false", dep.Spec.Template.Annotations["sidecar.istio.io/inject"])
+	assert.Equal(t, "world", dep.Spec.Template.Annotations["hello"])
+	assert.Equal(t, "false", dep.Spec.Template.Annotations["prometheus.io/scrape"])
 }
 
 func TestQueryPodName(t *testing.T) {


### PR DESCRIPTION
Provides a more general way to define annotations, instead of specific approach used in #81.

Signed-off-by: Gary Brown <gary@brownuk.com>