### PR TITLE
Enable top level annotations to be defined

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -130,6 +130,8 @@ spec:
     enabled: false # <8>
   agent:
     strategy: DaemonSet # <9>
+  annotations:
+    scheduler.alpha.kubernetes.io/critical-pod: "" # <10>
 ----
 <1> The default strategy is `allInOne`. The only other possible value is `production`.
 <2> The image to use, in a regular Docker syntax
@@ -140,6 +142,7 @@ spec:
 <7> Some options are namespaced and we can alternatively break them into nested objects. We could have specified `memory.max-traces: 100000`.
 <8> By default, an ingress object is created for the query service. It can be disabled by setting its `enabled` option to `false`. If deploying on OpenShift, this will be represented by a Route object.
 <9> By default, the operator assumes that agents are deployed as sidecars within the target pods. Specifying the strategy as "DaemonSet" changes that and makes the operator deploy the agent as DaemonSet. Note that your tracer client will probably have to override the "JAEGER_AGENT_HOST" env var to use the node's IP.
+<10> Define annotations to be applied to all deployments (not services). These can be overridden by annotations defined on the individual components.
 
 == Accessing the UI
 

--- a/pkg/apis/io/v1alpha1/types.go
+++ b/pkg/apis/io/v1alpha1/types.go
@@ -43,6 +43,7 @@ type JaegerSpec struct {
 	Ingress      JaegerIngressSpec   `json:"ingress"`
 	Volumes      []v1.Volume         `json:"volumes"`
 	VolumeMounts []v1.VolumeMount    `json:"volumeMounts"`
+	Annotations  map[string]string   `json:"annotations,omitempty"`
 }
 
 // JaegerStatus defines what is to be returned from a status query

--- a/pkg/apis/io/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/io/v1alpha1/zz_generated.deepcopy.go
@@ -287,6 +287,13 @@ func (in *JaegerSpec) DeepCopyInto(out *JaegerSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.Annotations != nil {
+		in, out := &in.Annotations, &out.Annotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/deployment/agent.go
+++ b/pkg/deployment/agent.go
@@ -47,6 +47,9 @@ func (a *Agent) Get() *appsv1.DaemonSet {
 		"prometheus.io/port":      "5778",
 		"sidecar.istio.io/inject": "false",
 	}
+	for k, v := range a.jaeger.Spec.Annotations {
+		annotations[k] = v
+	}
 	for k, v := range a.jaeger.Spec.Agent.Annotations {
 		annotations[k] = v
 	}

--- a/pkg/deployment/agent_test.go
+++ b/pkg/deployment/agent_test.go
@@ -64,14 +64,19 @@ func TestGetDaemonSetDeployment(t *testing.T) {
 func TestDaemonSetAgentAnnotations(t *testing.T) {
 	jaeger := v1alpha1.NewJaeger("TestDaemonSetAgentAnnotations")
 	jaeger.Spec.Agent.Strategy = "daemonset"
+	jaeger.Spec.Annotations = map[string]string{
+		"name":  "operator",
+		"hello": "jaeger",
+	}
 	jaeger.Spec.Agent.Annotations = map[string]string{
-		"hello":                "world",
+		"hello":                "world", // Override top level annotation
 		"prometheus.io/scrape": "false", // Override implicit value
 	}
 
 	agent := NewAgent(jaeger)
 	dep := agent.Get()
 
+	assert.Equal(t, "operator", dep.Spec.Template.Annotations["name"])
 	assert.Equal(t, "false", dep.Spec.Template.Annotations["sidecar.istio.io/inject"])
 	assert.Equal(t, "world", dep.Spec.Template.Annotations["hello"])
 	assert.Equal(t, "false", dep.Spec.Template.Annotations["prometheus.io/scrape"])

--- a/pkg/deployment/all-in-one.go
+++ b/pkg/deployment/all-in-one.go
@@ -40,6 +40,9 @@ func (a *AllInOne) Get() *appsv1.Deployment {
 		"prometheus.io/port":      "16686",
 		"sidecar.istio.io/inject": "false",
 	}
+	for k, v := range a.jaeger.Spec.Annotations {
+		annotations[k] = v
+	}
 	for k, v := range a.jaeger.Spec.AllInOne.Annotations {
 		annotations[k] = v
 	}

--- a/pkg/deployment/all-in-one_test.go
+++ b/pkg/deployment/all-in-one_test.go
@@ -40,14 +40,19 @@ func TestDefaultAllInOneImage(t *testing.T) {
 
 func TestAllInOneAnnotations(t *testing.T) {
 	jaeger := v1alpha1.NewJaeger("TestAllInOneAnnotations")
+	jaeger.Spec.Annotations = map[string]string{
+		"name":  "operator",
+		"hello": "jaeger",
+	}
 	jaeger.Spec.AllInOne.Annotations = map[string]string{
-		"hello":                "world",
+		"hello":                "world", // Override top level annotation
 		"prometheus.io/scrape": "false", // Override implicit value
 	}
 
 	allinone := NewAllInOne(jaeger)
 	dep := allinone.Get()
 
+	assert.Equal(t, "operator", dep.Spec.Template.Annotations["name"])
 	assert.Equal(t, "false", dep.Spec.Template.Annotations["sidecar.istio.io/inject"])
 	assert.Equal(t, "world", dep.Spec.Template.Annotations["hello"])
 	assert.Equal(t, "false", dep.Spec.Template.Annotations["prometheus.io/scrape"])

--- a/pkg/deployment/collector.go
+++ b/pkg/deployment/collector.go
@@ -46,6 +46,9 @@ func (c *Collector) Get() *appsv1.Deployment {
 		"prometheus.io/port":      "14268",
 		"sidecar.istio.io/inject": "false",
 	}
+	for k, v := range c.jaeger.Spec.Annotations {
+		annotations[k] = v
+	}
 	for k, v := range c.jaeger.Spec.Collector.Annotations {
 		annotations[k] = v
 	}

--- a/pkg/deployment/collector_test.go
+++ b/pkg/deployment/collector_test.go
@@ -72,14 +72,19 @@ func TestDefaultCollectorImage(t *testing.T) {
 
 func TestCollectorAnnotations(t *testing.T) {
 	jaeger := v1alpha1.NewJaeger("TestCollectorAnnotations")
+	jaeger.Spec.Annotations = map[string]string{
+		"name":  "operator",
+		"hello": "jaeger",
+	}
 	jaeger.Spec.Collector.Annotations = map[string]string{
-		"hello":                "world",
+		"hello":                "world", // Override top level annotation
 		"prometheus.io/scrape": "false", // Override implicit value
 	}
 
 	collector := NewCollector(jaeger)
 	dep := collector.Get()
 
+	assert.Equal(t, "operator", dep.Spec.Template.Annotations["name"])
 	assert.Equal(t, "false", dep.Spec.Template.Annotations["sidecar.istio.io/inject"])
 	assert.Equal(t, "world", dep.Spec.Template.Annotations["hello"])
 	assert.Equal(t, "false", dep.Spec.Template.Annotations["prometheus.io/scrape"])

--- a/pkg/deployment/query.go
+++ b/pkg/deployment/query.go
@@ -52,6 +52,9 @@ func (q *Query) Get() *appsv1.Deployment {
 		// it at will. So, we leave this configured just like any other application would
 		"inject-jaeger-agent": q.jaeger.Name,
 	}
+	for k, v := range q.jaeger.Spec.Annotations {
+		annotations[k] = v
+	}
 	for k, v := range q.jaeger.Spec.Query.Annotations {
 		annotations[k] = v
 	}

--- a/pkg/deployment/query_test.go
+++ b/pkg/deployment/query_test.go
@@ -49,14 +49,19 @@ func TestDefaultQueryImage(t *testing.T) {
 
 func TestQueryAnnotations(t *testing.T) {
 	jaeger := v1alpha1.NewJaeger("TestQueryAnnotations")
+	jaeger.Spec.Annotations = map[string]string{
+		"name":  "operator",
+		"hello": "jaeger",
+	}
 	jaeger.Spec.Query.Annotations = map[string]string{
-		"hello":                "world",
+		"hello":                "world", // Override top level annotation
 		"prometheus.io/scrape": "false", // Override implicit value
 	}
 
 	query := NewQuery(jaeger)
 	dep := query.Get()
 
+	assert.Equal(t, "operator", dep.Spec.Template.Annotations["name"])
 	assert.Equal(t, "false", dep.Spec.Template.Annotations["sidecar.istio.io/inject"])
 	assert.Equal(t, "world", dep.Spec.Template.Annotations["hello"])
 	assert.Equal(t, "false", dep.Spec.Template.Annotations["prometheus.io/scrape"])


### PR DESCRIPTION
The top level annotations can be overridden by the component level annotations.

Signed-off-by: Gary Brown <gary@brownuk.com>