### PR TITLE
Update generated code and reverted change to 'all-in-one' in CRD

### DIFF
--- a/pkg/apis/io/v1alpha1/types.go
+++ b/pkg/apis/io/v1alpha1/types.go
@@ -35,7 +35,7 @@ type Jaeger struct {
 // JaegerSpec defines the structure of the Jaeger JSON object from the CR
 type JaegerSpec struct {
 	Strategy     string              `json:"strategy"`
-	AllInOne     JaegerAllInOneSpec  `json:"all-in-one"`
+	AllInOne     JaegerAllInOneSpec  `json:"allInOne"`
 	Query        JaegerQuerySpec     `json:"query"`
 	Collector    JaegerCollectorSpec `json:"collector"`
 	Agent        JaegerAgentSpec     `json:"agent"`

--- a/pkg/apis/io/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/io/v1alpha1/zz_generated.deepcopy.go
@@ -5,6 +5,7 @@
 package v1alpha1
 
 import (
+	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -40,6 +41,20 @@ func (in *Jaeger) DeepCopyObject() runtime.Object {
 func (in *JaegerAgentSpec) DeepCopyInto(out *JaegerAgentSpec) {
 	*out = *in
 	in.Options.DeepCopyInto(&out.Options)
+	if in.Volumes != nil {
+		in, out := &in.Volumes, &out.Volumes
+		*out = make([]v1.Volume, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.VolumeMounts != nil {
+		in, out := &in.VolumeMounts, &out.VolumeMounts
+		*out = make([]v1.VolumeMount, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.Annotations != nil {
 		in, out := &in.Annotations, &out.Annotations
 		*out = make(map[string]string, len(*in))
@@ -64,6 +79,20 @@ func (in *JaegerAgentSpec) DeepCopy() *JaegerAgentSpec {
 func (in *JaegerAllInOneSpec) DeepCopyInto(out *JaegerAllInOneSpec) {
 	*out = *in
 	in.Options.DeepCopyInto(&out.Options)
+	if in.Volumes != nil {
+		in, out := &in.Volumes, &out.Volumes
+		*out = make([]v1.Volume, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.VolumeMounts != nil {
+		in, out := &in.VolumeMounts, &out.VolumeMounts
+		*out = make([]v1.VolumeMount, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.Annotations != nil {
 		in, out := &in.Annotations, &out.Annotations
 		*out = make(map[string]string, len(*in))
@@ -109,6 +138,20 @@ func (in *JaegerCassandraCreateSchemaSpec) DeepCopy() *JaegerCassandraCreateSche
 func (in *JaegerCollectorSpec) DeepCopyInto(out *JaegerCollectorSpec) {
 	*out = *in
 	in.Options.DeepCopyInto(&out.Options)
+	if in.Volumes != nil {
+		in, out := &in.Volumes, &out.Volumes
+		*out = make([]v1.Volume, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.VolumeMounts != nil {
+		in, out := &in.VolumeMounts, &out.VolumeMounts
+		*out = make([]v1.VolumeMount, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.Annotations != nil {
 		in, out := &in.Annotations, &out.Annotations
 		*out = make(map[string]string, len(*in))
@@ -187,6 +230,20 @@ func (in *JaegerList) DeepCopyObject() runtime.Object {
 func (in *JaegerQuerySpec) DeepCopyInto(out *JaegerQuerySpec) {
 	*out = *in
 	in.Options.DeepCopyInto(&out.Options)
+	if in.Volumes != nil {
+		in, out := &in.Volumes, &out.Volumes
+		*out = make([]v1.Volume, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.VolumeMounts != nil {
+		in, out := &in.VolumeMounts, &out.VolumeMounts
+		*out = make([]v1.VolumeMount, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.Annotations != nil {
 		in, out := &in.Annotations, &out.Annotations
 		*out = make(map[string]string, len(*in))
@@ -216,6 +273,20 @@ func (in *JaegerSpec) DeepCopyInto(out *JaegerSpec) {
 	in.Agent.DeepCopyInto(&out.Agent)
 	in.Storage.DeepCopyInto(&out.Storage)
 	in.Ingress.DeepCopyInto(&out.Ingress)
+	if in.Volumes != nil {
+		in, out := &in.Volumes, &out.Volumes
+		*out = make([]v1.Volume, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.VolumeMounts != nil {
+		in, out := &in.VolumeMounts, &out.VolumeMounts
+		*out = make([]v1.VolumeMount, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/pkg/deployment/query_test.go
+++ b/pkg/deployment/query_test.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/io/v1alpha1"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/api/core/v1"
+
+	"github.com/jaegertracing/jaeger-operator/pkg/apis/io/v1alpha1"
 )
 
 func init() {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -4,7 +4,7 @@ import (
 	"k8s.io/api/core/v1"
 )
 
-// RemoveDuplicatedVolumes defines to remove the last duplicated items in slice if the Name of Volume is the same
+// RemoveDuplicatedVolumes returns a unique list of Volumes based on Volume names. Only the first item is kept.
 func RemoveDuplicatedVolumes(volumes []v1.Volume) []v1.Volume {
 	var results []v1.Volume
 	existing := map[string]bool{}
@@ -20,7 +20,7 @@ func RemoveDuplicatedVolumes(volumes []v1.Volume) []v1.Volume {
 	return results
 }
 
-// RemoveDuplicatedVolumeMounts defines to remove the last duplicated item in slice if the Name of Volume is the same
+// RemoveDuplicatedVolumeMounts returns a unique list based on the item names. Only the first item is kept.
 func RemoveDuplicatedVolumeMounts(volumeMounts []v1.VolumeMount) []v1.VolumeMount {
 	var results []v1.VolumeMount
 	existing := map[string]bool{}


### PR DESCRIPTION
cc @clyang82 

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>