### PR TITLE
Ensure 'make generate' has been executed when model changes are made

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -5,3 +5,7 @@ go get github.com/securego/gosec/cmd/gosec/...
 
 echo "Installing golint"
 go get -u golang.org/x/lint/golint
+
+echo "Installing operator-sdk"
+curl https://github.com/operator-framework/operator-sdk/releases/download/v0.0.7/operator-sdk-v0.0.7-x86_64-linux-gnu -sLo $GOPATH/bin/operator-sdk
+chmod +x $GOPATH/bin/operator-sdk

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -30,6 +30,16 @@ make dep
 make install
 ----
 
+Alternatively, a released binary can be used instead:
+
+[source,bash]
+----
+curl https://github.com/operator-framework/operator-sdk/releases/download/v0.0.7/operator-sdk-v0.0.7-x86_64-linux-gnu -sLo $GOPATH/bin/operator-sdk
+chmod +x $GOPATH/bin/operator-sdk
+----
+
+NOTE: Make sure your `$GOPATH/bin` is part of your regular `$PATH`.
+
 === Developing
 
 As usual for operators following the Operator SDK, the dependencies are checked into the source repository under the `vendor` directory. The dependencies are managed using link:https://github.com/golang/dep[`go dep`]. Refer to that project's documentation for instructions on how to add or update dependencies.

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,10 @@ check:
 	@echo Checking...
 	@$(foreach file, $(shell go fmt $(PACKAGES) 2>&1), echo "Some files need formatting. Failing." || exit 1)
 
+.PHONY: ensure-generate-is-noop
+ensure-generate-is-noop: generate
+	@git diff -s --exit-code pkg/apis/io/v1alpha1/zz_generated.deepcopy.go || (echo "Build failed: a model has been changed but the deep copy functions aren't up to date. Run 'make generate' and update your PR." && exit 1)
+
 .PHONY: format
 format:
 	@echo Formatting code...
@@ -97,4 +101,4 @@ test: unit-tests e2e-tests
 all: check format lint build test
 
 .PHONY: ci
-ci: check format lint build unit-tests
+ci: ensure-generate-is-noop check format lint build unit-tests


### PR DESCRIPTION
Closes #99

When a model has been changed but the deep copy functions haven't been changed, this is shown:

```
$ make ci
Run code-generation for custom resources
Generating deepcopy funcs

Build failed: a model has been changed but the deep copy functions aren't up to date. Run 'make generate' and update your PR.
make: *** [Makefile:27: ensure-generate-is-noop] Error 1
```

Otherwise, this is what a successful build looks like now:

```
$ make ci
Run code-generation for custom resources
Generating deepcopy funcs

Checking...
Formatting code...
Linting...
Building...
Running unit tests...
?   	github.com/jaegertracing/jaeger-operator/cmd	[no test files]
ok  	github.com/jaegertracing/jaeger-operator/pkg/apis/io/v1alpha1	0.063s	coverage: 15.5% of statements
?   	github.com/jaegertracing/jaeger-operator/pkg/cmd/start	[no test files]
?   	github.com/jaegertracing/jaeger-operator/pkg/cmd/version	[no test files]
ok  	github.com/jaegertracing/jaeger-operator/pkg/controller	0.010s	coverage: 100.0% of statements
ok  	github.com/jaegertracing/jaeger-operator/pkg/deployment	0.025s	coverage: 100.0% of statements
ok  	github.com/jaegertracing/jaeger-operator/pkg/ingress	0.054s	coverage: 100.0% of statements
ok  	github.com/jaegertracing/jaeger-operator/pkg/inject	0.013s	coverage: 100.0% of statements
ok  	github.com/jaegertracing/jaeger-operator/pkg/route	0.019s	coverage: 100.0% of statements
ok  	github.com/jaegertracing/jaeger-operator/pkg/service	0.008s	coverage: 100.0% of statements
ok  	github.com/jaegertracing/jaeger-operator/pkg/storage	0.025s	coverage: 100.0% of statements
?   	github.com/jaegertracing/jaeger-operator/pkg/stub	[no test files]
ok  	github.com/jaegertracing/jaeger-operator/pkg/util	0.004s	coverage: 100.0% of statements
?   	github.com/jaegertracing/jaeger-operator/pkg/version	[no test files]
```

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>