### PR TITLE
Use proper jaeger-operator version for e2e tests and remove readiness check from DaemonSet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,18 @@ unit-tests:
 .PHONY: e2e-tests
 e2e-tests: cassandra es crd build docker push
 	@echo Running end-to-end tests...
-	@operator-sdk test local ./test/e2e --go-test-flags="${GO_TEST_FLAGS}"
+
+	@cp deploy/role_binding.yaml deploy/test/namespace-manifests.yaml
+	@echo "---" >> deploy/test/namespace-manifests.yaml
+
+	@cat deploy/role.yaml >> deploy/test/namespace-manifests.yaml
+	@echo "---" >> deploy/test/namespace-manifests.yaml
+
+	@cat deploy/service_account.yaml >> deploy/test/namespace-manifests.yaml
+	@echo "---" >> deploy/test/namespace-manifests.yaml
+
+	@cat deploy/operator.yaml | sed "s~image: jaegertracing\/jaeger-operator\:.*~image: $(BUILD_IMAGE)~gi" >> deploy/test/namespace-manifests.yaml
+	@go test ./test/e2e/... -kubeconfig $(KUBERNETES_CONFIG) -namespacedMan ../../deploy/test/namespace-manifests.yaml -globalMan ../../deploy/crds/io_v1alpha1_jaeger_crd.yaml -root .
 
 .PHONY: run
 run: crd

--- a/pkg/deployment/agent.go
+++ b/pkg/deployment/agent.go
@@ -9,7 +9,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/jaegertracing/jaeger-operator/pkg/apis/io/v1alpha1"
 	"github.com/jaegertracing/jaeger-operator/pkg/service"
@@ -111,15 +110,16 @@ func (a *Agent) Get() *appsv1.DaemonSet {
 								Protocol:      v1.ProtocolUDP,
 							},
 						},
-						ReadinessProbe: &v1.Probe{
-							Handler: v1.Handler{
-								HTTPGet: &v1.HTTPGetAction{
-									Path: "/metrics",
-									Port: intstr.FromInt(5778),
-								},
-							},
-							InitialDelaySeconds: 1,
-						},
+						// TODO(jpkroehling): enable it back once a version with jaegertracing/jaeger#1178 is released
+						// ReadinessProbe: &v1.Probe{
+						// 	Handler: v1.Handler{
+						// 		HTTPGet: &v1.HTTPGetAction{
+						// 			Path: "/metrics",
+						// 			Port: intstr.FromInt(5778),
+						// 		},
+						// 	},
+						// 	InitialDelaySeconds: 1,
+						// },
 						Resources: commonSpec.Resources,
 					}},
 				},


### PR DESCRIPTION
Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>