### PR TITLE
Silence 'mkdir' from e2e-tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ unit-tests:
 
 .PHONY: e2e-tests
 e2e-tests: cassandra es crd build docker push
-	mkdir -p deploy/test
+	@mkdir -p deploy/test
 	@echo Running end-to-end tests...
 
 	@cp deploy/role_binding.yaml deploy/test/namespace-manifests.yaml


### PR DESCRIPTION
Before:

```
$ make test
Running unit tests...
?   	github.com/jaegertracing/jaeger-operator/cmd	[no test files]
?   	github.com/jaegertracing/jaeger-operator/cmd/manager	[no test files]
ok  	github.com/jaegertracing/jaeger-operator/pkg/account	0.051s	coverage: 100.0% of statements
?   	github.com/jaegertracing/jaeger-operator/pkg/apis	[no test files]
ok  	github.com/jaegertracing/jaeger-operator/pkg/apis/io/v1alpha1	0.033s	coverage: 18.8% of statements
?   	github.com/jaegertracing/jaeger-operator/pkg/cmd/start	[no test files]
?   	github.com/jaegertracing/jaeger-operator/pkg/cmd/version	[no test files]
ok  	github.com/jaegertracing/jaeger-operator/pkg/config/sampling	0.011s	coverage: 94.1% of statements
ok  	github.com/jaegertracing/jaeger-operator/pkg/config/ui	0.012s	coverage: 94.1% of statements
?   	github.com/jaegertracing/jaeger-operator/pkg/controller	[no test files]
?   	github.com/jaegertracing/jaeger-operator/pkg/controller/deployment	[no test files]
ok  	github.com/jaegertracing/jaeger-operator/pkg/controller/jaeger	3.047s	coverage: 64.3% of statements
ok  	github.com/jaegertracing/jaeger-operator/pkg/deployment	0.045s	coverage: 100.0% of statements
ok  	github.com/jaegertracing/jaeger-operator/pkg/ingress	0.067s	coverage: 100.0% of statements
ok  	github.com/jaegertracing/jaeger-operator/pkg/inject	0.087s	coverage: 100.0% of statements
ok  	github.com/jaegertracing/jaeger-operator/pkg/route	0.055s	coverage: 100.0% of statements
ok  	github.com/jaegertracing/jaeger-operator/pkg/service	0.077s	coverage: 100.0% of statements
ok  	github.com/jaegertracing/jaeger-operator/pkg/storage	0.005s	coverage: 100.0% of statements
ok  	github.com/jaegertracing/jaeger-operator/pkg/strategy	0.007s	coverage: 100.0% of statements
ok  	github.com/jaegertracing/jaeger-operator/pkg/util	0.005s	coverage: 100.0% of statements
?   	github.com/jaegertracing/jaeger-operator/pkg/version	[no test files]
Formatting code...
Building...
Sending build context to Docker daemon     79MB
Step 1/4 : FROM alpine:3.8
 ---> 196d12cf6ab1
Step 2/4 : USER nobody
 ---> Using cache
 ---> 18305c5b670d
Step 3/4 : ADD build/_output/bin/jaeger-operator /usr/local/bin/jaeger-operator
 ---> c2b3c95ec3c5
Step 4/4 : ENTRYPOINT ["/usr/local/bin/jaeger-operator"]
 ---> Running in bd96b80c3e70
Removing intermediate container bd96b80c3e70
 ---> e7c06c9ba8d4
Successfully built e7c06c9ba8d4
Successfully tagged jpkroehling/jaeger-operator:latest
Pushing image jpkroehling/jaeger-operator:latest...
mkdir -p deploy/test
Running end-to-end tests...
ok  	github.com/jaegertracing/jaeger-operator/test/e2e	197.423s
```

Notice a `mkdir` on the third line from the bottom.

After this PR:
```
$ make test
Running unit tests...
?   	github.com/jaegertracing/jaeger-operator/cmd	[no test files]
?   	github.com/jaegertracing/jaeger-operator/cmd/manager	[no test files]
ok  	github.com/jaegertracing/jaeger-operator/pkg/account	0.018s	coverage: 100.0% of statements
?   	github.com/jaegertracing/jaeger-operator/pkg/apis	[no test files]
ok  	github.com/jaegertracing/jaeger-operator/pkg/apis/io/v1alpha1	0.016s	coverage: 18.8% of statements
?   	github.com/jaegertracing/jaeger-operator/pkg/cmd/start	[no test files]
?   	github.com/jaegertracing/jaeger-operator/pkg/cmd/version	[no test files]
ok  	github.com/jaegertracing/jaeger-operator/pkg/config/sampling	0.031s	coverage: 94.1% of statements
ok  	github.com/jaegertracing/jaeger-operator/pkg/config/ui	0.010s	coverage: 94.1% of statements
?   	github.com/jaegertracing/jaeger-operator/pkg/controller	[no test files]
?   	github.com/jaegertracing/jaeger-operator/pkg/controller/deployment	[no test files]
ok  	github.com/jaegertracing/jaeger-operator/pkg/controller/jaeger	3.056s	coverage: 64.3% of statements
ok  	github.com/jaegertracing/jaeger-operator/pkg/deployment	0.045s	coverage: 100.0% of statements
ok  	github.com/jaegertracing/jaeger-operator/pkg/ingress	0.039s	coverage: 100.0% of statements
ok  	github.com/jaegertracing/jaeger-operator/pkg/inject	0.046s	coverage: 100.0% of statements
ok  	github.com/jaegertracing/jaeger-operator/pkg/route	0.012s	coverage: 100.0% of statements
ok  	github.com/jaegertracing/jaeger-operator/pkg/service	0.031s	coverage: 100.0% of statements
ok  	github.com/jaegertracing/jaeger-operator/pkg/storage	0.005s	coverage: 100.0% of statements
ok  	github.com/jaegertracing/jaeger-operator/pkg/strategy	0.007s	coverage: 100.0% of statements
ok  	github.com/jaegertracing/jaeger-operator/pkg/util	0.006s	coverage: 100.0% of statements
?   	github.com/jaegertracing/jaeger-operator/pkg/version	[no test files]
Formatting code...
Building...
Sending build context to Docker daemon  79.01MB
Step 1/4 : FROM alpine:3.8
 ---> 196d12cf6ab1
Step 2/4 : USER nobody
 ---> Using cache
 ---> 18305c5b670d
Step 3/4 : ADD build/_output/bin/jaeger-operator /usr/local/bin/jaeger-operator
 ---> 2c09bd1780cd
Step 4/4 : ENTRYPOINT ["/usr/local/bin/jaeger-operator"]
 ---> Running in 541f83f5b7bd
Removing intermediate container 541f83f5b7bd
 ---> d16b2d5cae65
Successfully built d16b2d5cae65
Successfully tagged jpkroehling/jaeger-operator:latest
Pushing image jpkroehling/jaeger-operator:latest...
Running end-to-end tests...
ok  	github.com/jaegertracing/jaeger-operator/test/e2e	157.138s
```

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>