### PR TITLE
Add Jaeger CSV and Package for OLM integration and deployment of the …

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -130,3 +130,53 @@ There are a set of templates under the `test` directory that can be used to setu
 make es
 make cassandra
 ----
+
+==== Operator-Lifecycle-Manager Integration
+
+The link:https://github.com/operator-framework/operator-lifecycle-manager/[Operator-Lifecycle-Manager (OLM)] can install, manage, and upgrade operators and their dependencies in a cluster.
+
+With OLM, users can:
+
+* Define applications as a single Kubernetes resource that encapsulates requirements and metadata
+* Install applications automatically with dependency resolution or manually with nothing but kubectl
+* Upgrade applications automatically with different approval policies
+
+OLM also enforces some constraints on the components it manages in order to ensure a good user experience.
+
+The Jaeger community provides and mantains a link:https://github.com/operator-framework/operator-lifecycle-manager/blob/master/Documentation/design/building-your-csv.md/[ClusterServiceVersion (CSV) YAML] to integrate with OLM.
+
+With the latest master branch of the operator-sdk one can generate and update CSVs based on the yaml files in the deploy folder.
+The Jaeger CSV can be updated to version 1.9.0 with the following command:
+[source,bash]
+----
+$ operator-sdk olm-catalog gen-csv --csv-version 1.9.0
+INFO[0000] Generating CSV manifest version 1.9.0
+INFO[0000] Create deploy/olm-catalog/jaeger-operator.csv.yaml 
+INFO[0000] Create deploy/olm-catalog/_generated.concat_crd.yaml 
+----
+
+The CSV YAML can then be tested with this command:
+
+[source,bash]
+----
+$ operator-sdk scorecard --cr-manifest deploy/examples/simplest.yaml --csv-path deploy/olm-catalog/jaeger-operator.csv.yaml --init-timeout 30
+Checking for existence of spec and status blocks in CR
+Checking that operator actions are reflected in status
+Checking that writing into CRs has an effect
+Checking for CRD resources
+Checking for existence of example CRs
+Checking spec descriptors
+Checking status descriptors
+Basic Operator:
+	Spec Block Exists: 1/1 points
+	Status Block Exist: 1/1 points
+	Operator actions are reflected in status: 0/1 points
+	Writing into CRs has an effect: 1/1 points
+OLM Integration:
+	Owned CRDs have resources listed: 0/1 points
+	CRs have at least 1 example: 1/1 points
+	Spec fields with descriptors: 0/12 points
+	Status fields with descriptors: N/A (depends on an earlier test that failed)
+
+Total Score: 4/18 points
+----

--- a/deploy/olm-catalog/_generated.concat_crd.yaml
+++ b/deploy/olm-catalog/_generated.concat_crd.yaml
@@ -1,0 +1,13 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: jaegers.io.jaegertracing
+spec:
+  group: io.jaegertracing
+  names:
+    kind: Jaeger
+    listKind: JaegerList
+    plural: jaegers
+    singular: jaeger
+  scope: Namespaced
+  version: v1alpha1

--- a/deploy/olm-catalog/jaeger-operator.csv.yaml
+++ b/deploy/olm-catalog/jaeger-operator.csv.yaml
@@ -1,0 +1,197 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "io.jaegertracing/v1alpha1",
+          "kind": "Jaeger",
+          "metadata": {
+            "name": "my-jaeger"
+          },
+          "spec": {
+            "strategy": "allInOne",
+            "allInOne": {
+              "image": "jaegertracing/all-in-one:1.9",
+              "options": {
+                "log-level": "debug",
+                "query": {
+                  "base-path": "/jaeger"
+                }
+              }
+            },
+            "ui": {
+              "options": {
+                "dependencies": {
+                  "menuEnabled": false
+                },
+                "tracking": {
+                  "gaID": "UA-000000-2"
+                },
+                "menu": [
+                  {
+                    "label": "About Jaeger",
+                    "items": [
+                      {
+                        "label": "Documentation",
+                        "url": "https://www.jaegertracing.io/docs/latest"
+                      }
+                    ]
+                  }
+                ]
+              }
+            },
+            "storage": {
+              "options": {
+                "memory": {
+                  "max-traces": 100000
+                }
+              }
+            }
+          }
+        }
+      ]
+    categories: tracing, monitoring, troubleshooting
+    certified: "false"
+    containerImage: docker.io/jaegertracing/jaeger-operator:1.9.0
+    createdAt: "2019-01-09T12:00:00Z"
+    support: Jaeger
+  creationTimestamp: null
+  name: jaeger-operator.v1.9.0
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - kind: Jaeger
+      name: jaegers.io.jaegertracing
+      version: v1alpha1
+  description: Provides monitoring and troubleshooting microservices-based distributed
+    systems
+  displayName: jaeger-operator
+  installModes:
+  - type: OwnNamespace
+    supported: false
+  - type: SingleNamespace
+    supported: false
+  - type: MultiNamespace
+    supported: false
+  - type: AllNamespaces
+    supported: true
+  install:
+    spec:
+      deployments:
+      - name: jaeger-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: jaeger-operator
+          strategy: {}
+          template:
+            metadata:
+              creationTimestamp: null
+              labels:
+                name: jaeger-operator
+            spec:
+              containers:
+              - args:
+                - start
+                - --platform=openshift
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: jaeger-operator
+                image: jaegertracing/jaeger-operator:1.9.0
+                imagePullPolicy: Always
+                name: jaeger-operator
+                ports:
+                - containerPort: 60000
+                  name: metrics
+                resources: {}
+              serviceAccountName: jaeger-operator
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          - serviceaccounts
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - io.jaegertracing
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - extensions
+          resources:
+          - ingresses
+          verbs:
+          - '*'
+        - apiGroups:
+          - batch
+          resources:
+          - jobs
+          - cronjobs
+          verbs:
+          - '*'
+        serviceAccountName: jaeger-operator
+    strategy: deployment
+  keywords:
+  - tracing
+  - monitoring
+  - troubleshooting
+  labels:
+    name: jaeger-operator
+  links:
+  - name: Jaeger Operator Source Code
+    url: https://github.com/jaegertracing/jaeger-operator
+  maintainers:
+  - email: jaeger-tracing@googlegroups.com
+    name: Jaeger Google Group
+  provider:
+    name: Jaeger
+  selector:
+    matchLabels:
+      name: jaeger-operator
+  version: 1.9.0
+  customresourcedefinitions:
+    owned:
+    - name: jaegers.io.jaegertracing
+      version: v1alpha1
+      kind: Jaeger
+      displayName: Jaeger
+      description: A configuration file for a Jaeger custom resource.

--- a/deploy/olm-catalog/jaeger.package.yaml
+++ b/deploy/olm-catalog/jaeger.package.yaml
@@ -1,0 +1,4 @@
+packageName: jaeger
+channels:
+- name: alpha
+  currentCSV: jaeger-operator.v1.9.0


### PR DESCRIPTION
…operator through OperatorHub

- This pull requests introduces a CSV and Package which can be bundled together and used by the [Operator Lifecycle Manager](https://github.com/operator-framework/operator-lifecycle-manager) to install, manage, and upgrade the Jaeger Operator in a cluster.

- The Jaeger operator versions available to all Kubernetes clusters using OLM can be updated by submitting a pull request to the [Community Operators GitHub repo](https://github.com/operator-framework/community-operators) that includes the latest CSVs, CRDs, and Packages.

- The CSV was created based of the [documentation provided by OLM](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/Documentation/design/building-your-csv.md) and the [documentation](https://github.com/operator-framework/community-operators/blob/master/docs/marketplace-required-csv-annotations.md) provided by [OperatorHub](https://github.com/operator-framework/operator-marketplace).

- The operator and the CSV were tested using the [scorecard functionality recently introduced](https://github.com/operator-framework/operator-sdk/pull/758) to the [Operator-sdk](https://github.com/operator-framework/operator-sdk). Currently, the Jaeger operator scores a 4/18 on the scorecard tests.

OLM integration could be improved by future code changes to the Operator:
- Addressing the operator-sdk scorecard tests that failed.
- Adding additional information to the Jaeger CSV based on the [CSV documentation provided by OLM](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/Documentation/design/building-your-csv.md)
- Adding additional information to the Jaeger CSV based on the [CSV documentation provided by OperatorHub](https://github.com/operator-framework/community-operators/blob/master/docs/marketplace-required-csv-annotations.md)