### PR TITLE
Enable single operator to monitor all namespaces

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -19,12 +19,17 @@ To install the operator, run:
 
 [source,bash]
 ----
+kubectl create namespace observability # <1>
 kubectl create -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/master/deploy/crds/io_v1alpha1_jaeger_crd.yaml
 kubectl create -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/master/deploy/service_account.yaml
 kubectl create -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/master/deploy/role.yaml
 kubectl create -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/master/deploy/role_binding.yaml
 kubectl create -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/master/deploy/operator.yaml
 ----
+<1> This creates the namespace used by default in the deployment files.
+
+If you want to install the Jaeger operator in a different namespace, you will need to edit the deployment
+files to change `observability` to the required value.
 
 At this point, there should be a `jaeger-operator` deployment available:
 
@@ -45,12 +50,17 @@ The instructions from the previous section also work on OpenShift given that the
 ----
 oc login -u system:admin
 
+oc new-project observability # <1>
 oc create -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/master/deploy/crds/io_v1alpha1_jaeger_crd.yaml
 oc create -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/master/deploy/service_account.yaml
 oc create -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/master/deploy/role.yaml
 oc create -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/master/deploy/role_binding.yaml
 oc create -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/master/deploy/operator-openshift.yaml
 ----
+<1> This creates the namespace used by default in the deployment files.
+
+If you want to install the Jaeger operator in a different namespace, you will need to edit the deployment
+files to change `observability` to the required value.
 
 Once the operator is installed, grant the role `jaeger-operator` to users who should be able to install individual Jaeger instances. The following example creates a role binding allowing the user `developer` to create Jaeger instances:
 

--- a/deploy/crds/io_v1alpha1_jaeger_crd.yaml
+++ b/deploy/crds/io_v1alpha1_jaeger_crd.yaml
@@ -2,6 +2,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: jaegers.io.jaegertracing
+  namespace: observability
 spec:
   group: io.jaegertracing
   names:

--- a/deploy/crds/io_v1alpha1_jaeger_crd.yaml
+++ b/deploy/crds/io_v1alpha1_jaeger_crd.yaml
@@ -2,7 +2,6 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: jaegers.io.jaegertracing
-  namespace: observability
 spec:
   group: io.jaegertracing
   names:

--- a/deploy/olm-catalog/jaeger-operator.csv.yaml
+++ b/deploy/olm-catalog/jaeger-operator.csv.yaml
@@ -64,23 +64,73 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - kind: Jaeger
+    - description: A configuration file for a Jaeger custom resource.
+      displayName: Jaeger
+      kind: Jaeger
       name: jaegers.io.jaegertracing
       version: v1alpha1
   description: Provides monitoring and troubleshooting microservices-based distributed
     systems
   displayName: jaeger-operator
-  installModes:
-  - type: OwnNamespace
-    supported: false
-  - type: SingleNamespace
-    supported: false
-  - type: MultiNamespace
-    supported: false
-  - type: AllNamespaces
-    supported: true
   install:
     spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          - serviceaccounts
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - io.jaegertracing
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - extensions
+          resources:
+          - ingresses
+          verbs:
+          - '*'
+        - apiGroups:
+          - batch
+          resources:
+          - jobs
+          - cronjobs
+          verbs:
+          - '*'
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - '*'
+        serviceAccountName: jaeger-operator
       deployments:
       - name: jaeger-operator
         spec:
@@ -98,19 +148,15 @@ spec:
               containers:
               - args:
                 - start
-                - --platform=openshift
                 env:
                 - name: WATCH_NAMESPACE
-                  valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.annotations['olm.targetNamespaces']
                 - name: POD_NAME
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: jaeger-operator
-                image: jaegertracing/jaeger-operator:1.9.0
+                image: jaegertracing/jaeger-operator:1.9.1
                 imagePullPolicy: Always
                 name: jaeger-operator
                 ports:
@@ -170,6 +216,15 @@ spec:
           - '*'
         serviceAccountName: jaeger-operator
     strategy: deployment
+  installModes:
+  - supported: false
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
   keywords:
   - tracing
   - monitoring
@@ -188,10 +243,3 @@ spec:
     matchLabels:
       name: jaeger-operator
   version: 1.9.0
-  customresourcedefinitions:
-    owned:
-    - name: jaegers.io.jaegertracing
-      version: v1alpha1
-      kind: Jaeger
-      displayName: Jaeger
-      description: A configuration file for a Jaeger custom resource.

--- a/deploy/operator-openshift.yaml
+++ b/deploy/operator-openshift.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: jaeger-operator
+  namespace: observability
 spec:
   replicas: 1
   selector:

--- a/deploy/operator-openshift.yaml
+++ b/deploy/operator-openshift.yaml
@@ -23,9 +23,7 @@ spec:
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
+              value: ""
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: jaeger-operator
+  namespace: observability
 spec:
   replicas: 1
   selector:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -23,9 +23,7 @@ spec:
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
+              value: ""
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -3,6 +3,7 @@ kind: ClusterRole
 metadata:
   creationTimestamp: null
   name: jaeger-operator
+  namespace: observability
 rules:
 - apiGroups:
   - ""

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -1,5 +1,5 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   creationTimestamp: null
   name: jaeger-operator

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -2,6 +2,7 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: jaeger-operator
+  namespace: observability
 subjects:
 - kind: ServiceAccount
   name: jaeger-operator

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -1,11 +1,12 @@
-kind: RoleBinding
+kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: jaeger-operator
 subjects:
 - kind: ServiceAccount
   name: jaeger-operator
+  namespace: observability
 roleRef:
-  kind: Role
+  kind: ClusterRole
   name: jaeger-operator
   apiGroup: rbac.authorization.k8s.io

--- a/deploy/service_account.yaml
+++ b/deploy/service_account.yaml
@@ -2,3 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: jaeger-operator
+  namespace: observability


### PR DESCRIPTION
Resolves #24 

This PR demonstrates how a single operator can be used to create Jaeger instances in different namespaces.

For example,
```
kubectl create -n observability -f deploy/crds/io_v1alpha1_jaeger_crd.yaml
kubectl create -n observability -f deploy/service_account.yaml
kubectl create -n observability -f deploy/role.yaml
kubectl create -n observability -f deploy/role_binding.yaml
kubectl create -n observability -f deploy/operator.yaml

kubectl apply -n other -f deploy/examples/simplest.yaml
```
The problem with this approach is that the `role_binding.yaml` has to have the `namespace` hardcoded. Not sure if this can reference the namespace as a parameter, as with the env vars?

Options:
- leave the current operator deployment focused on a single namespace and provide documentation about how to change them to watch all namespaces
- if there is no way to provide a reference to the namespace in the `role_binding.yaml`, then maybe we would need a helm chart to install the operator and use `{{ .Release.Namespace }}`
 

Signed-off-by: Gary Brown <gary@brownuk.com>