### PR TITLE
Add storage secrets to es-index-cleaner cronjob

### DIFF
--- a/pkg/cronjob/es_index_cleaner_test.go
+++ b/pkg/cronjob/es_index_cleaner_test.go
@@ -34,3 +34,12 @@ func TestCreateEsIndexCleaner(t *testing.T) {
 	assert.Equal(t, "INDEX_PREFIX", cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Env[0].Name)
 	assert.Equal(t, "tenant1", cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Env[0].Value)
 }
+
+func TestEsIndexCleanerSecrets(t *testing.T) {
+	jaeger := v1alpha1.NewJaeger("TestEsIndexCleanerSecrets")
+	secret := "mysecret"
+	jaeger.Spec.Storage.SecretName = secret
+
+	cronJob := CreateEsIndexCleaner(jaeger)
+	assert.Equal(t, secret, cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].EnvFrom[0].SecretRef.LocalObjectReference.Name)
+}


### PR DESCRIPTION
Resolves https://github.com/jaegertracing/jaeger-operator/issues/196

Related to https://github.com/jaegertracing/jaeger/pull/1318 which has been merged and released as `jaegertracing/jaeger-es-index-cleaner:latest`.  We're just adding some additional environment variables so its also fine to use with older versions of the jaeger-es-index-cleaner image.