### PR TITLE
Cloned resources to run the operator on its own namespace for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,16 +66,16 @@ e2e-tests: cassandra es crd build docker push
 	@mkdir -p deploy/test
 	@echo Running end-to-end tests...
 
-	@cp deploy/role_binding.yaml deploy/test/namespace-manifests.yaml
+	@cp test/role_binding.yaml deploy/test/namespace-manifests.yaml
 	@echo "---" >> deploy/test/namespace-manifests.yaml
 
-	@cat deploy/role.yaml >> deploy/test/namespace-manifests.yaml
+	@cat test/role.yaml >> deploy/test/namespace-manifests.yaml
 	@echo "---" >> deploy/test/namespace-manifests.yaml
 
-	@cat deploy/service_account.yaml >> deploy/test/namespace-manifests.yaml
+	@cat test/service_account.yaml >> deploy/test/namespace-manifests.yaml
 	@echo "---" >> deploy/test/namespace-manifests.yaml
 
-	@cat deploy/operator.yaml | sed "s~image: jaegertracing\/jaeger-operator\:.*~image: $(BUILD_IMAGE)~gi" >> deploy/test/namespace-manifests.yaml
+	@cat test/operator.yaml | sed "s~image: jaegertracing\/jaeger-operator\:.*~image: $(BUILD_IMAGE)~gi" >> deploy/test/namespace-manifests.yaml
 	@go test ./test/e2e/... -kubeconfig $(KUBERNETES_CONFIG) -namespacedMan ../../deploy/test/namespace-manifests.yaml -globalMan ../../deploy/crds/io_v1alpha1_jaeger_crd.yaml -root .
 
 .PHONY: run

--- a/test/operator.yaml
+++ b/test/operator.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jaeger-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: jaeger-operator
+  template:
+    metadata:
+      labels:
+        name: jaeger-operator
+    spec:
+      serviceAccountName: jaeger-operator
+      containers:
+        - name: jaeger-operator
+          image: jaegertracing/jaeger-operator:1.9.1
+          ports:
+          - containerPort: 60000
+            name: metrics
+          args: ["start"]
+          imagePullPolicy: Always
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_NAME
+              value: "jaeger-operator"

--- a/test/role.yaml
+++ b/test/role.yaml
@@ -1,0 +1,60 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: jaeger-operator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  - serviceaccounts
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - io.jaegertracing
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - "*"
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  - cronjobs
+  verbs:
+  - "*"
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - "*"

--- a/test/role_binding.yaml
+++ b/test/role_binding.yaml
@@ -1,0 +1,11 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: jaeger-operator
+subjects:
+- kind: ServiceAccount
+  name: jaeger-operator
+roleRef:
+  kind: Role
+  name: jaeger-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/test/service_account.yaml
+++ b/test/service_account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jaeger-operator


### PR DESCRIPTION
The e2e tests are currently broken in master, due to #188. While we figure out a better way to handle the feature and the tests, this temporary solution should be applied.

Once this PR is applied, the e2e tests are passing again:

```
$ make e2e-tests 
Formatting code...
Building...
Sending build context to Docker daemon  128.8MB
Step 1/4 : FROM alpine:3.8
 ---> 196d12cf6ab1
Step 2/4 : USER nobody
 ---> Using cache
 ---> 18305c5b670d
Step 3/4 : ADD build/_output/bin/jaeger-operator /usr/local/bin/jaeger-operator
 ---> 74182e60b900
Step 4/4 : ENTRYPOINT ["/usr/local/bin/jaeger-operator"]
 ---> Running in f1ea53662541
Removing intermediate container f1ea53662541
 ---> 72d5ace489b1
Successfully built 72d5ace489b1
Successfully tagged jpkroehling/jaeger-operator:latest
Pushing image jpkroehling/jaeger-operator:latest...
Running end-to-end tests...
ok  	github.com/jaegertracing/jaeger-operator/test/e2e	345.292s
```
Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>