### PR TITLE
Removed constraint on namespace when obtaining available Jaeger instances

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -298,6 +298,8 @@ spec:
 ----
 <1> Either `"true"` (as string) or the Jaeger instance name
 
+A complete sample deployment is available at link:./deploy/examples/business-application-injected-sidecar.yaml[`deploy/examples/business-application-injected-sidecar.yaml`]
+
 == Agent as DaemonSet
 
 By default, the Operator expects the agents to be deployed as sidecars to the target applications. This is convenient for several purposes, like in a multi-tenant scenario or to have better load balancing, but there are scenarios where it's desirable to install the agent as a `DaemonSet`. In that case, specify the Agent's strategy to `DaemonSet`, as follows:

--- a/deploy/examples/business-application-injected-sidecar.yaml
+++ b/deploy/examples/business-application-injected-sidecar.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myapp
+  annotations:
+    inject-jaeger-agent: "true"
+spec:
+  selector:
+    matchLabels:
+      app: myapp
+  template:
+    metadata:
+      labels:
+        app: myapp
+    spec:
+      containers:
+      - name: myapp
+        image: jaegertracing/vertx-create-span:operator-e2e-tests
+
+

--- a/pkg/inject/sidecar.go
+++ b/pkg/inject/sidecar.go
@@ -77,7 +77,7 @@ func Select(target *appsv1.Deployment, availableJaegerPods *v1alpha1.JaegerList)
 }
 
 func container(jaeger *v1alpha1.Jaeger) v1.Container {
-	args := append(jaeger.Spec.Agent.Options.ToArgs(), fmt.Sprintf("--collector.host-port=%s:14267", service.GetNameForCollectorService(jaeger)))
+	args := append(jaeger.Spec.Agent.Options.ToArgs(), fmt.Sprintf("--collector.host-port=%s.%s:14267", service.GetNameForCollectorService(jaeger), jaeger.Namespace))
 	return v1.Container{
 		Image: jaeger.Spec.Agent.Image,
 		Name:  "jaeger-agent",


### PR DESCRIPTION
Fixes #60 by removing the namespace constraint when querying for available Jaegers, as Kubernetes will do the right thing and deliver only the ones that the Operator's account can see.

@gregoryfranklin: do you think you'd be able to try this one out?

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>