### PR TITLE
Use centos image

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+FROM centos
 
 RUN INSTALL_PKGS=" \
       openssl \


### PR DESCRIPTION
Resolves #219 

```
REPOSITORY                                            TAG                 IMAGE ID            CREATED             SIZE
REPOSITORY                                            TAG                 IMAGE ID            CREATED             SIZE
openshift/origin-elasticsearch-operator               latest              5698765cb3c2        6 minutes ago       260MB
ploffay/jaeger-operator                               latest              f64e6999bef4        13 minutes ago      266MB
registry.svc.ci.openshift.org/openshift/release       golang-1.10         6cb8ecdeb577        18 hours ago        979MB
registry.svc.ci.openshift.org/openshift/origin-v4.0   base                65b5ece9e8e4        35 hours ago        224MB
centos    
```
Signed-off-by: Pavol Loffay <ploffay@redhat.com>