### PR TITLE
Fixed deployment of Elasticsearch via its operator

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -242,14 +242,13 @@ spec:
 
 == Elasticsearch storage
 
-If no `es.server-urls` are provided Jaeger operator creates Elasticsearch CR based on the configuration
-provided in storage section. Make sure link:https://github.com/openshift/elasticsearch-operator[elasticsearch-operator]
-is running in your cluster otherwise Elasticsearch deployment will not be created. The Elasticsearch is meant
-to be dedicated for a single Jaeger instance.
+Under some circumstances, the Jaeger Operator can make use of the Elasticsearch operator to provision a suitable Elasticsearch cluster.
 
-At the moment there can be only one Jaeger with Elasticsearch instance in a namespace.
+IMPORTANT: this feature is experimental and currently works only on OpenShift clusters. Elasticsearch also requires the memory setting to be configured like `minishift ssh -- 'sudo sysctl -w vm.max_map_count=262144'`
 
-Note that Elasticsearch requires virtual memory settings: `minikube ssh -- 'sudo sysctl -w vm.max_map_count=262144'`
+When there are no `es.server-urls` options as part of a Jaeger `production` instance, the Jaeger Operator creates an Elasticsearch cluster via the Elasticsearch Operator by creating a CR based on the configuration provided in storage section. Make sure link:https://github.com/openshift/elasticsearch-operator[elasticsearch-operator] is running in your cluster otherwise the Elasticsearch deployment will not be created. The Elasticsearch cluster is meant to be dedicated for a single Jaeger instance.
+
+IMPORTANT: At the moment there can be only one Jaeger with self-provisioned Elasticsearch instance per namespace.
 
 == Accessing the UI
 

--- a/pkg/apis/addtoscheme_io_v1alpha1.go
+++ b/pkg/apis/addtoscheme_io_v1alpha1.go
@@ -2,9 +2,10 @@ package apis
 
 import (
 	"github.com/jaegertracing/jaeger-operator/pkg/apis/io/v1alpha1"
+	esv1alpha1 "github.com/jaegertracing/jaeger-operator/pkg/storage/elasticsearch/v1alpha1"
 )
 
 func init() {
 	// Register the types with the Scheme so the components can map objects to GroupVersionKinds and back
-	AddToSchemes = append(AddToSchemes, v1alpha1.SchemeBuilder.AddToScheme)
+	AddToSchemes = append(AddToSchemes, v1alpha1.SchemeBuilder.AddToScheme, esv1alpha1.SchemeBuilder.AddToScheme)
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -2,10 +2,7 @@ package controller
 
 import (
 	routev1 "github.com/openshift/api/route/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-
-	esv1alpha1 "github.com/jaegertracing/jaeger-operator/pkg/storage/elasticsearch/v1alpha1"
 )
 
 // AddToManagerFuncs is a list of functions to add all Controllers to the Manager
@@ -16,9 +13,6 @@ func AddToManager(m manager.Manager) error {
 	if err := routev1.AddToScheme(m.GetScheme()); err != nil {
 		return err
 	}
-	// TODO temporal fix https://github.com/jaegertracing/jaeger-operator/issues/206
-	gv := schema.GroupVersion{Group: "logging.openshift.io", Version: "v1alpha1"}
-	m.GetScheme().AddKnownTypes(gv, &esv1alpha1.Elasticsearch{})
 
 	for _, f := range AddToManagerFuncs {
 		if err := f(m); err != nil {

--- a/pkg/controller/jaeger/elasticsearch.go
+++ b/pkg/controller/jaeger/elasticsearch.go
@@ -1,0 +1,52 @@
+package jaeger
+
+import (
+	"context"
+
+	log "github.com/sirupsen/logrus"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/jaegertracing/jaeger-operator/pkg/apis/io/v1alpha1"
+	"github.com/jaegertracing/jaeger-operator/pkg/inventory"
+	esv1alpha1 "github.com/jaegertracing/jaeger-operator/pkg/storage/elasticsearch/v1alpha1"
+)
+
+func (r *ReconcileJaeger) applyElasticsearches(jaeger v1alpha1.Jaeger, desired []esv1alpha1.Elasticsearch) error {
+	opts := client.MatchingLabels(map[string]string{
+		"app.kubernetes.io/instance":   jaeger.Name,
+		"app.kubernetes.io/managed-by": "jaeger-operator",
+	})
+	list := &esv1alpha1.ElasticsearchList{}
+	if err := r.client.List(context.Background(), opts, list); err != nil {
+		return err
+	}
+
+	logFields := log.WithFields(log.Fields{
+		"namespace": jaeger.Namespace,
+		"instance":  jaeger.Name,
+	})
+
+	inv := inventory.ForElasticsearches(list.Items, desired)
+	for _, d := range inv.Create {
+		logFields.WithField("elasticsearch", d.Name).Debug("creating elasticsearch")
+		if err := r.client.Create(context.Background(), &d); err != nil {
+			return err
+		}
+	}
+
+	for _, d := range inv.Update {
+		logFields.WithField("elasticsearch", d.Name).Debug("updating elasticsearch")
+		if err := r.client.Update(context.Background(), &d); err != nil {
+			return err
+		}
+	}
+
+	for _, d := range inv.Delete {
+		logFields.WithField("elasticsearch", d.Name).Debug("deleting elasticsearch")
+		if err := r.client.Delete(context.Background(), &d); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/controller/jaeger/elasticsearch_test.go
+++ b/pkg/controller/jaeger/elasticsearch_test.go
@@ -1,0 +1,131 @@
+package jaeger
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/jaegertracing/jaeger-operator/pkg/apis/io/v1alpha1"
+	esv1alpha1 "github.com/jaegertracing/jaeger-operator/pkg/storage/elasticsearch/v1alpha1"
+	"github.com/jaegertracing/jaeger-operator/pkg/strategy"
+)
+
+func TestElasticsearchesCreate(t *testing.T) {
+	// prepare
+	nsn := types.NamespacedName{
+		Name: "TestElasticsearchesCreate",
+	}
+
+	objs := []runtime.Object{
+		v1alpha1.NewJaeger(nsn.Name),
+	}
+
+	req := reconcile.Request{
+		NamespacedName: nsn,
+	}
+
+	r, cl := getReconciler(objs)
+	r.strategyChooser = func(jaeger *v1alpha1.Jaeger) strategy.S {
+		s := strategy.New().WithElasticsearches([]esv1alpha1.Elasticsearch{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: nsn.Name,
+			},
+		}})
+		return s
+	}
+
+	// test
+	res, err := r.Reconcile(req)
+
+	// verify
+	assert.NoError(t, err)
+	assert.False(t, res.Requeue, "We don't requeue for now")
+
+	persisted := &esv1alpha1.Elasticsearch{}
+	persistedName := types.NamespacedName{
+		Name:      nsn.Name,
+		Namespace: nsn.Namespace,
+	}
+	err = cl.Get(context.Background(), persistedName, persisted)
+	assert.Equal(t, persistedName.Name, persisted.Name)
+	assert.NoError(t, err)
+}
+
+func TestElasticsearchesUpdate(t *testing.T) {
+	// prepare
+	nsn := types.NamespacedName{
+		Name: "TestElasticsearchesUpdate",
+	}
+
+	orig := esv1alpha1.Elasticsearch{}
+	orig.Name = nsn.Name
+	orig.Annotations = map[string]string{"key": "value"}
+
+	objs := []runtime.Object{
+		v1alpha1.NewJaeger(nsn.Name),
+		&orig,
+	}
+
+	r, cl := getReconciler(objs)
+	r.strategyChooser = func(jaeger *v1alpha1.Jaeger) strategy.S {
+		updated := esv1alpha1.Elasticsearch{}
+		updated.Name = orig.Name
+		updated.Annotations = map[string]string{"key": "new-value"}
+
+		s := strategy.New().WithElasticsearches([]esv1alpha1.Elasticsearch{updated})
+		return s
+	}
+
+	// test
+	_, err := r.Reconcile(reconcile.Request{NamespacedName: nsn})
+	assert.NoError(t, err)
+
+	// verify
+	persisted := &esv1alpha1.Elasticsearch{}
+	persistedName := types.NamespacedName{
+		Name:      orig.Name,
+		Namespace: orig.Namespace,
+	}
+	err = cl.Get(context.Background(), persistedName, persisted)
+	assert.Equal(t, "new-value", persisted.Annotations["key"])
+	assert.NoError(t, err)
+}
+
+func TestElasticsearchesDelete(t *testing.T) {
+	// prepare
+	nsn := types.NamespacedName{
+		Name: "TestElasticsearchesDelete",
+	}
+
+	orig := esv1alpha1.Elasticsearch{}
+	orig.Name = nsn.Name
+
+	objs := []runtime.Object{
+		v1alpha1.NewJaeger(nsn.Name),
+		&orig,
+	}
+
+	r, cl := getReconciler(objs)
+	r.strategyChooser = func(jaeger *v1alpha1.Jaeger) strategy.S {
+		return strategy.S{}
+	}
+
+	// test
+	_, err := r.Reconcile(reconcile.Request{NamespacedName: nsn})
+	assert.NoError(t, err)
+
+	// verify
+	persisted := &esv1alpha1.Elasticsearch{}
+	persistedName := types.NamespacedName{
+		Name:      orig.Name,
+		Namespace: orig.Namespace,
+	}
+	err = cl.Get(context.Background(), persistedName, persisted)
+	assert.Empty(t, persisted.Name)
+	assert.Error(t, err) // not found
+}

--- a/pkg/controller/jaeger/jaeger_controller.go
+++ b/pkg/controller/jaeger/jaeger_controller.go
@@ -132,6 +132,10 @@ func defaultStrategyChooser(instance *v1alpha1.Jaeger) strategy.S {
 }
 
 func (r *ReconcileJaeger) apply(jaeger v1alpha1.Jaeger, str strategy.S) error {
+	if err := r.applyElasticsearches(jaeger, str.Elasticsearches()); err != nil {
+		return err
+	}
+
 	if err := r.applyRoles(jaeger, str.Roles()); err != nil {
 		return err
 	}

--- a/pkg/controller/jaeger/jaeger_controller_test.go
+++ b/pkg/controller/jaeger/jaeger_controller_test.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/jaegertracing/jaeger-operator/pkg/apis/io/v1alpha1"
+	esv1alpha1 "github.com/jaegertracing/jaeger-operator/pkg/storage/elasticsearch/v1alpha1"
 	"github.com/jaegertracing/jaeger-operator/pkg/strategy"
 )
 
@@ -90,8 +91,16 @@ func TestDeletedInstance(t *testing.T) {
 
 func getReconciler(objs []runtime.Object) (*ReconcileJaeger, client.Client) {
 	s := scheme.Scheme
+
+	// OpenShift Route
 	osv1.Install(s)
+
+	// Jaeger
 	s.AddKnownTypes(v1alpha1.SchemeGroupVersion, &v1alpha1.Jaeger{})
+
+	// Jaeger's Elasticsearch
+	s.AddKnownTypes(v1alpha1.SchemeGroupVersion, &esv1alpha1.Elasticsearch{}, &esv1alpha1.ElasticsearchList{})
+
 	cl := fake.NewFakeClient(objs...)
 	return &ReconcileJaeger{client: cl, scheme: s}, cl
 }

--- a/pkg/inventory/elasticsearch.go
+++ b/pkg/inventory/elasticsearch.go
@@ -1,0 +1,62 @@
+package inventory
+
+import (
+	esv1alpha1 "github.com/jaegertracing/jaeger-operator/pkg/storage/elasticsearch/v1alpha1"
+)
+
+// Elasticsearch represents the elastic search inventory based on the current and desired states
+type Elasticsearch struct {
+	Create []esv1alpha1.Elasticsearch
+	Update []esv1alpha1.Elasticsearch
+	Delete []esv1alpha1.Elasticsearch
+}
+
+// ForElasticsearches builds a new elastic search inventory based on the existing and desired states
+func ForElasticsearches(existing []esv1alpha1.Elasticsearch, desired []esv1alpha1.Elasticsearch) Elasticsearch {
+	update := []esv1alpha1.Elasticsearch{}
+	mcreate := esMap(desired)
+	mdelete := esMap(existing)
+
+	for k, v := range mcreate {
+		if t, ok := mdelete[k]; ok {
+			tp := t.DeepCopy()
+
+			tp.Spec = v.Spec
+			tp.ObjectMeta.OwnerReferences = v.ObjectMeta.OwnerReferences
+
+			for k, v := range v.ObjectMeta.Annotations {
+				tp.ObjectMeta.Annotations[k] = v
+			}
+
+			for k, v := range v.ObjectMeta.Labels {
+				tp.ObjectMeta.Labels[k] = v
+			}
+
+			update = append(update, *tp)
+			delete(mcreate, k)
+			delete(mdelete, k)
+		}
+	}
+
+	return Elasticsearch{
+		Create: esList(mcreate),
+		Update: update,
+		Delete: esList(mdelete),
+	}
+}
+
+func esMap(deps []esv1alpha1.Elasticsearch) map[string]esv1alpha1.Elasticsearch {
+	m := map[string]esv1alpha1.Elasticsearch{}
+	for _, d := range deps {
+		m[d.Name] = d
+	}
+	return m
+}
+
+func esList(m map[string]esv1alpha1.Elasticsearch) []esv1alpha1.Elasticsearch {
+	l := []esv1alpha1.Elasticsearch{}
+	for _, v := range m {
+		l = append(l, v)
+	}
+	return l
+}

--- a/pkg/inventory/elasticsearch_test.go
+++ b/pkg/inventory/elasticsearch_test.go
@@ -1,0 +1,53 @@
+package inventory
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	esv1alpha1 "github.com/jaegertracing/jaeger-operator/pkg/storage/elasticsearch/v1alpha1"
+)
+
+func TestElasticsearchInventory(t *testing.T) {
+	toCreate := esv1alpha1.Elasticsearch{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "to-create",
+		},
+	}
+	toUpdate := esv1alpha1.Elasticsearch{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "to-update",
+		},
+		Spec: esv1alpha1.ElasticsearchSpec{
+			ManagementState: esv1alpha1.ManagementStateManaged,
+		},
+	}
+	updated := esv1alpha1.Elasticsearch{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "to-update",
+		},
+		Spec: esv1alpha1.ElasticsearchSpec{
+			ManagementState: esv1alpha1.ManagementStateUnmanaged,
+		},
+	}
+	toDelete := esv1alpha1.Elasticsearch{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "to-delete",
+		},
+	}
+
+	existing := []esv1alpha1.Elasticsearch{toUpdate, toDelete}
+	desired := []esv1alpha1.Elasticsearch{updated, toCreate}
+
+	inv := ForElasticsearches(existing, desired)
+	assert.Len(t, inv.Create, 1)
+	assert.Equal(t, "to-create", inv.Create[0].Name)
+
+	assert.Len(t, inv.Update, 1)
+	assert.Equal(t, "to-update", inv.Update[0].Name)
+	assert.Equal(t, esv1alpha1.ManagementStateUnmanaged, inv.Update[0].Spec.ManagementState)
+
+	assert.Len(t, inv.Delete, 1)
+	assert.Equal(t, "to-delete", inv.Delete[0].Name)
+}

--- a/pkg/storage/elasticsearch.go
+++ b/pkg/storage/elasticsearch.go
@@ -102,8 +102,16 @@ func (ed *ElasticsearchDeployment) InjectIndexCleanerConfiguration(p *v1.PodSpec
 func (ed *ElasticsearchDeployment) Elasticsearch() *esv1alpha1.Elasticsearch {
 	return &esv1alpha1.Elasticsearch{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace:       ed.Jaeger.Namespace,
-			Name:            esSecret.name,
+			Namespace: ed.Jaeger.Namespace,
+			Name:      esSecret.name,
+			Labels: map[string]string{
+				"app":                          "jaeger",
+				"app.kubernetes.io/name":       esSecret.name,
+				"app.kubernetes.io/instance":   ed.Jaeger.Name,
+				"app.kubernetes.io/component":  "elasticsearch",
+				"app.kubernetes.io/part-of":    "jaeger",
+				"app.kubernetes.io/managed-by": "jaeger-operator",
+			},
 			OwnerReferences: []metav1.OwnerReference{asOwner(ed.Jaeger)},
 		},
 		Spec: esv1alpha1.ElasticsearchSpec{

--- a/pkg/storage/elasticsearch/v1alpha1/register.go
+++ b/pkg/storage/elasticsearch/v1alpha1/register.go
@@ -1,0 +1,14 @@
+package v1alpha1
+
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/scheme"
+)
+
+var (
+	// SchemeGroupVersion is group version used to register these objects
+	SchemeGroupVersion = schema.GroupVersion{Group: "logging.openshift.io", Version: "v1alpha1"}
+
+	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
+	SchemeBuilder = &scheme.Builder{GroupVersion: SchemeGroupVersion}
+)

--- a/pkg/storage/elasticsearch/v1alpha1/types.go
+++ b/pkg/storage/elasticsearch/v1alpha1/types.go
@@ -204,3 +204,7 @@ const (
 	UpdateClusterSettings ClusterEvent = "UpdateClusterSettings"
 	NoEvent               ClusterEvent = "NoEvent"
 )
+
+func init() {
+	SchemeBuilder.Register(&Elasticsearch{}, &ElasticsearchList{})
+}

--- a/pkg/storage/elasticsearch_test.go
+++ b/pkg/storage/elasticsearch_test.go
@@ -84,7 +84,7 @@ func TestCreateElasticsearchCR(t *testing.T) {
 		j.Namespace = "myproject"
 		j.Spec.Storage.Elasticsearch = test.jEsSpec
 		es := &ElasticsearchDeployment{Jaeger: j}
-		cr := es.createCr()
+		cr := es.Elasticsearch()
 		assert.Equal(t, "myproject", cr.Namespace)
 		assert.Equal(t, "elasticsearch", cr.Name)
 		trueVar := true
@@ -108,7 +108,7 @@ func TestInject(t *testing.T) {
 				Containers: []v1.Container{{
 					Args: []string{
 						"foo",
-						"--es.server-urls=" + elasticsearchUrl,
+						"--es.server-urls=" + elasticsearchURL,
 						"--es.token-file=" + k8sTokenFile,
 						"--es.tls.ca=" + caPath,
 						"--es.num-shards=0",
@@ -133,7 +133,7 @@ func TestInject(t *testing.T) {
 				Containers: []v1.Container{{
 					Args: []string{
 						"--es.num-shards=15",
-						"--es.server-urls=" + elasticsearchUrl,
+						"--es.server-urls=" + elasticsearchURL,
 						"--es.token-file=" + k8sTokenFile,
 						"--es.tls.ca=" + caPath,
 						"--es.num-replicas=1",

--- a/pkg/strategy/strategy.go
+++ b/pkg/strategy/strategy.go
@@ -8,23 +8,26 @@ import (
 	"k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
+
+	esv1alpha1 "github.com/jaegertracing/jaeger-operator/pkg/storage/elasticsearch/v1alpha1"
 )
 
 // S knows what type of deployments to build based on a given spec
 type S struct {
-	typ          Type
-	accounts     []v1.ServiceAccount
-	configMaps   []v1.ConfigMap
-	cronJobs     []batchv1beta1.CronJob
-	daemonSets   []appsv1.DaemonSet
-	dependencies []batchv1.Job
-	deployments  []appsv1.Deployment
-	ingresses    []v1beta1.Ingress
-	routes       []osv1.Route
-	roles        []rbacv1.Role
-	roleBindings []rbacv1.RoleBinding
-	services     []v1.Service
-	secrets      []v1.Secret
+	typ             Type
+	accounts        []v1.ServiceAccount
+	configMaps      []v1.ConfigMap
+	cronJobs        []batchv1beta1.CronJob
+	daemonSets      []appsv1.DaemonSet
+	dependencies    []batchv1.Job
+	deployments     []appsv1.Deployment
+	elasticsearches []esv1alpha1.Elasticsearch
+	ingresses       []v1beta1.Ingress
+	routes          []osv1.Route
+	roles           []rbacv1.Role
+	roleBindings    []rbacv1.RoleBinding
+	services        []v1.Service
+	secrets         []v1.Secret
 }
 
 // Type represents a specific deployment strategy, like 'all-in-one'
@@ -88,6 +91,12 @@ func (s S) WithDependencies(deps []batchv1.Job) S {
 	return s
 }
 
+// WithElasticsearches returns the strategy with the given list of elastic search instances
+func (s S) WithElasticsearches(es []esv1alpha1.Elasticsearch) S {
+	s.elasticsearches = es
+	return s
+}
+
 // WithIngresses returns the strategy with the given list of dependencies
 func (s S) WithIngresses(i []v1beta1.Ingress) S {
 	s.ingresses = i
@@ -147,6 +156,11 @@ func (s S) DaemonSets() []appsv1.DaemonSet {
 // Deployments returns the list of deployments for this strategy
 func (s S) Deployments() []appsv1.Deployment {
 	return s.deployments
+}
+
+// Elasticsearches returns the list of elastic search instances for this strategy
+func (s S) Elasticsearches() []esv1alpha1.Elasticsearch {
+	return s.elasticsearches
 }
 
 // Ingresses returns the list of ingress objects for this strategy. This might be platform-dependent

--- a/pkg/strategy/strategy_test.go
+++ b/pkg/strategy/strategy_test.go
@@ -10,6 +10,8 @@ import (
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	"k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
+
+	esv1alpha1 "github.com/jaegertracing/jaeger-operator/pkg/storage/elasticsearch/v1alpha1"
 )
 
 func TestWithAccounts(t *testing.T) {
@@ -40,6 +42,11 @@ func TestWithDependencies(t *testing.T) {
 func TestWithDeployments(t *testing.T) {
 	c := New().WithDeployments([]appsv1.Deployment{{}})
 	assert.Len(t, c.Deployments(), 1)
+}
+
+func TestWithElasticsearches(t *testing.T) {
+	c := New().WithElasticsearches([]esv1alpha1.Elasticsearch{{}})
+	assert.Len(t, c.Elasticsearches(), 1)
 }
 
 func TestWithIngresses(t *testing.T) {


### PR DESCRIPTION
Fixes #233 by adding the ES type to the controller's reconcile loop and inventory.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>