### PR TITLE
Reinstated sidecar for query, plus small refactoring of sidecar

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -302,7 +302,7 @@ spec:
 
 == Auto injection of Jaeger Agent sidecars
 
-The operator can also inject Jaeger Agent sidecars in `Deployment` workloads, provided that the deployment has the annotation `inject-jaeger-agent` with a suitable value. The values can be either `"true"` (as string), or the Jaeger instance name, as returned by `kubectl get jaegers`. When `"true"` is used, there should be exactly *one* Jaeger instance for the same namespace as the deployment, otherwise, the operator can't figure out automatically which Jaeger instance to use.
+The operator can also inject Jaeger Agent sidecars in `Deployment` workloads, provided that the deployment has the annotation `sidecar.jaegertracing.io/inject` with a suitable value. The values can be either `"true"` (as string), or the Jaeger instance name, as returned by `kubectl get jaegers`. When `"true"` is used, there should be exactly *one* Jaeger instance for the same namespace as the deployment, otherwise, the operator can't figure out automatically which Jaeger instance to use.
 
 The following snippet shows a simple application that will get a sidecar injected, with the Jaeger Agent pointing to the single Jaeger instance available in the same namespace:
 
@@ -313,7 +313,7 @@ kind: Deployment
 metadata:
   name: myapp
   annotations:
-    inject-jaeger-agent: "true" # <1>
+    "sidecar.jaegertracing.io/inject": "true" # <1>
 spec:
   selector:
     matchLabels:

--- a/deploy/examples/business-application-injected-sidecar.yaml
+++ b/deploy/examples/business-application-injected-sidecar.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: myapp
   annotations:
-    inject-jaeger-agent: "true"
+    "sidecar.jaegertracing.io/inject": "true"
 spec:
   selector:
     matchLabels:

--- a/pkg/controller/deployment/deployment_controller.go
+++ b/pkg/controller/deployment/deployment_controller.go
@@ -99,7 +99,7 @@ func (r *ReconcileDeployment) Reconcile(request reconcile.Request) (reconcile.Re
 				"jaeger":           jaeger.Name,
 				"jaeger-namespace": jaeger.Namespace,
 			}).Info("Injecting Jaeger Agent sidecar")
-			inject.Sidecar(instance, jaeger)
+			instance = inject.Sidecar(jaeger, instance)
 			if err := r.client.Update(context.Background(), instance); err != nil {
 				log.WithField("deployment", instance).WithError(err).Error("failed to update")
 				return reconcile.Result{}, err

--- a/pkg/deployment/all-in-one.go
+++ b/pkg/deployment/all-in-one.go
@@ -71,9 +71,10 @@ func (a *AllInOne) Get() *appsv1.Deployment {
 			Kind:       "Deployment",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      a.jaeger.Name,
-			Namespace: a.jaeger.Namespace,
-			Labels:    labels,
+			Name:        a.jaeger.Name,
+			Namespace:   a.jaeger.Namespace,
+			Labels:      labels,
+			Annotations: commonSpec.Annotations,
 			OwnerReferences: []metav1.OwnerReference{
 				metav1.OwnerReference{
 					APIVersion: a.jaeger.APIVersion,

--- a/pkg/deployment/collector.go
+++ b/pkg/deployment/collector.go
@@ -83,9 +83,10 @@ func (c *Collector) Get() *appsv1.Deployment {
 			Kind:       "Deployment",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      c.name(),
-			Namespace: c.jaeger.Namespace,
-			Labels:    labels,
+			Name:        c.name(),
+			Namespace:   c.jaeger.Namespace,
+			Labels:      labels,
+			Annotations: commonSpec.Annotations,
 			OwnerReferences: []metav1.OwnerReference{
 				metav1.OwnerReference{
 					APIVersion: c.jaeger.APIVersion,

--- a/pkg/deployment/query.go
+++ b/pkg/deployment/query.go
@@ -53,7 +53,7 @@ func (q *Query) Get() *appsv1.Deployment {
 			// 1) as it is, it would cause a circular dependency, so, we'd have to extract that constant to somewhere else
 			// 2) this specific string is part of the "public API" of the operator: we should not change
 			// it at will. So, we leave this configured just like any other application would
-			"inject-jaeger-agent": q.jaeger.Name,
+			"sidecar.jaegertracing.io/inject": q.jaeger.Name,
 		},
 	}
 
@@ -80,9 +80,10 @@ func (q *Query) Get() *appsv1.Deployment {
 			Kind:       "Deployment",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-query", q.jaeger.Name),
-			Namespace: q.jaeger.Namespace,
-			Labels:    labels,
+			Name:        fmt.Sprintf("%s-query", q.jaeger.Name),
+			Namespace:   q.jaeger.Namespace,
+			Labels:      labels,
+			Annotations: commonSpec.Annotations,
 			OwnerReferences: []metav1.OwnerReference{
 				metav1.OwnerReference{
 					APIVersion: q.jaeger.APIVersion,

--- a/pkg/strategy/production.go
+++ b/pkg/strategy/production.go
@@ -84,7 +84,7 @@ func newProductionStrategy(jaeger *v1alpha1.Jaeger) S {
 
 	// prepare the deployments, which may get changed by the elasticsearch routine
 	cDep := collector.Get()
-	queryDep := inject.OAuthProxy(jaeger, query.Get())
+	queryDep := inject.Sidecar(jaeger, inject.OAuthProxy(jaeger, query.Get()))
 
 	// assembles the pieces for an elasticsearch self-provisioned deployment via the elasticsearch operator
 	if storage.ShouldDeployElasticsearch(jaeger.Spec.Storage) {

--- a/pkg/strategy/production_test.go
+++ b/pkg/strategy/production_test.go
@@ -166,8 +166,19 @@ func TestSparkDependenciesProduction(t *testing.T) {
 	})
 }
 
-func TestEsIndexClenarProduction(t *testing.T) {
+func TestEsIndexCleanerProduction(t *testing.T) {
 	testEsIndexCleaner(t, func(jaeger *v1alpha1.Jaeger) S {
 		return newProductionStrategy(jaeger)
 	})
+}
+
+func TestAgentSidecarIsInjectedIntoQueryForStreamingForProduction(t *testing.T) {
+	j := v1alpha1.NewJaeger("TestAgentSidecarIsInjectedIntoQueryForStreamingForProduction")
+	c := newProductionStrategy(j)
+	for _, dep := range c.Deployments() {
+		if strings.HasSuffix(dep.Name, "-query") {
+			assert.Equal(t, 2, len(dep.Spec.Template.Spec.Containers))
+			assert.Equal(t, "jaeger-agent", dep.Spec.Template.Spec.Containers[1].Name)
+		}
+	}
 }

--- a/pkg/strategy/streaming.go
+++ b/pkg/strategy/streaming.go
@@ -41,7 +41,7 @@ func newStreamingStrategy(jaeger *v1alpha1.Jaeger) S {
 	}
 
 	// add the deployments
-	c.deployments = []appsv1.Deployment{*collector.Get(), *inject.OAuthProxy(jaeger, query.Get())}
+	c.deployments = []appsv1.Deployment{*collector.Get(), *inject.Sidecar(jaeger, inject.OAuthProxy(jaeger, query.Get()))}
 
 	if d := ingester.Get(); d != nil {
 		c.deployments = append(c.deployments, *d)

--- a/pkg/strategy/streaming_test.go
+++ b/pkg/strategy/streaming_test.go
@@ -184,3 +184,14 @@ func TestEsIndexClenarStreaming(t *testing.T) {
 		return newStreamingStrategy(jaeger)
 	})
 }
+
+func TestAgentSidecarIsInjectedIntoQueryForStreaming(t *testing.T) {
+	j := v1alpha1.NewJaeger("TestAgentSidecarIsInjectedIntoQueryForStreaming")
+	c := newStreamingStrategy(j)
+	for _, dep := range c.Deployments() {
+		if strings.HasSuffix(dep.Name, "-query") {
+			assert.Equal(t, 2, len(dep.Spec.Template.Spec.Containers))
+			assert.Equal(t, "jaeger-agent", dep.Spec.Template.Spec.Containers[1].Name)
+		}
+	}
+}


### PR DESCRIPTION
This PR fixes #244 and applies a small refactoring to the sidecar injection. Special attention to the change to the annotation name, from "inject-jaeger-agent" to "sidecar.jaegertracing.io/inject" (already using a scheme from #201).

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>