### PR TITLE
Fixed the bump of release in deploy artifacts

### DIFF
--- a/.travis/release.sh
+++ b/.travis/release.sh
@@ -12,14 +12,32 @@ OPERATOR_VERSION=$(echo ${OPERATOR_VERSION} | grep -Po "([\d\.]+)")
 TAG=${TAG:-"v${OPERATOR_VERSION}"}
 BUILD_IMAGE=${BUILD_IMAGE:-"${BASE_BUILD_IMAGE}:${OPERATOR_VERSION}"}
 
-sed "s~image: jaegertracing\/jaeger-operator\:.*~image: ${BUILD_IMAGE}~gi" -i deploy/operator.yaml
-sed "s~image: jaegertracing\/jaeger-operator\:.*~image: ${BUILD_IMAGE}~gi" -i deploy/operator-openshift.yaml
+# changes to deploy/operator.yaml
+sed "s~image: jaegertracing/jaeger-operator.*~image: ${BUILD_IMAGE}~gi" -i deploy/operator.yaml
+
+# changes to deploy/olm-catalog/jaeger.package.yaml
+sed "s/currentCSV: jaeger-operator.*/currentCSV: jaeger-operator.v${OPERATOR_VERSION}/gi" -i deploy/olm-catalog/jaeger.package.yaml
+
+# changes to deploy/olm-catalog/jaeger-operator.csv.yaml
+sed "s~containerImage: docker.io/jaegertracing/jaeger-operator.*~containerImage: docker.io/${BUILD_IMAGE}~gi" -i deploy/olm-catalog/jaeger-operator.csv.yaml
+sed "s/name: jaeger-operator\.v.*/name: jaeger-operator.v${OPERATOR_VERSION}/gi" -i deploy/olm-catalog/jaeger-operator.csv.yaml
+sed "s~image: jaegertracing/jaeger-operator.*~image: ${BUILD_IMAGE}~gi" -i deploy/olm-catalog/jaeger-operator.csv.yaml
+## there's a "version: v1alpha1" there somewhere...
+sed -E "s/version: ([0-9\.]+).*/version: ${OPERATOR_VERSION}/gi" deploy/olm-catalog/jaeger-operator.csv.yaml
+
+# changes to test/operator.yaml
+sed "s~image: jaegertracing/jaeger-operator.*~image: ${BUILD_IMAGE}~gi" -i test/operator.yaml
 
 git diff -s --exit-code
 if [[ $? == 0 ]]; then
     echo "No changes detected. Skipping."
 else
-    git add deploy/operator.yaml deploy/operator-openshift.yaml
+    git add \
+      deploy/operator.yaml \
+      deploy/olm-catalog/jaeger.package.yaml \
+      deploy/olm-catalog/jaeger-operator.csv.yaml \
+      test/operator.yaml
+
     git commit -qm "Release ${TAG}" --author="Jaeger Release <jaeger-release@jaegertracing.io>"
     git tag ${TAG}
     git push --repo=https://${GH_WRITE_TOKEN}@github.com/jaegertracing/jaeger-operator.git --tags

--- a/deploy/olm-catalog/jaeger-operator.csv.yaml
+++ b/deploy/olm-catalog/jaeger-operator.csv.yaml
@@ -54,11 +54,11 @@ metadata:
       ]
     categories: tracing, monitoring, troubleshooting
     certified: "false"
-    containerImage: docker.io/jaegertracing/jaeger-operator:1.9.0
+    containerImage: docker.io/jaegertracing/jaeger-operator:1.10.0
     createdAt: "2019-01-09T12:00:00Z"
     support: Jaeger
   creationTimestamp: null
-  name: jaeger-operator.v1.9.0
+  name: jaeger-operator.v1.10.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -156,7 +156,7 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: jaeger-operator
-                image: jaegertracing/jaeger-operator:1.9.1
+                image: jaegertracing/jaeger-operator:1.10.0
                 imagePullPolicy: Always
                 name: jaeger-operator
                 ports:
@@ -242,4 +242,4 @@ spec:
   selector:
     matchLabels:
       name: jaeger-operator
-  version: 1.9.0
+  version: 1.10.0

--- a/deploy/olm-catalog/jaeger-operator.csv.yaml
+++ b/deploy/olm-catalog/jaeger-operator.csv.yaml
@@ -13,7 +13,7 @@ metadata:
           "spec": {
             "strategy": "allInOne",
             "allInOne": {
-              "image": "jaegertracing/all-in-one:1.9",
+              "image": "jaegertracing/all-in-one:1.10",
               "options": {
                 "log-level": "debug",
                 "query": {

--- a/deploy/olm-catalog/jaeger.package.yaml
+++ b/deploy/olm-catalog/jaeger.package.yaml
@@ -1,4 +1,4 @@
 packageName: jaeger
 channels:
 - name: alpha
-  currentCSV: jaeger-operator.v1.9.0
+  currentCSV: jaeger-operator.v1.10.0

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: jaeger-operator
       containers:
         - name: jaeger-operator
-          image: jaegertracing/jaeger-operator:1.9.2
+          image: jaegertracing/jaeger-operator:1.10.0
           ports:
           - containerPort: 60000
             name: metrics

--- a/test/operator.yaml
+++ b/test/operator.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: jaeger-operator
       containers:
         - name: jaeger-operator
-          image: jaegertracing/jaeger-operator:1.9.1
+          image: jaegertracing/jaeger-operator:1.10.0
           ports:
           - containerPort: 60000
             name: metrics


### PR DESCRIPTION
Since #173, we have a few more files to bump the version during the releases.
Since #217, we don't have the `operator-openshift.yaml` file anymore, causing the `release.sh` [to fail](https://travis-ci.org/jaegertracing/jaeger-operator/jobs/499756950#L484).

This PR fixes both scenarios and bumps the necessary versions to the latest ones.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>