### PR TITLE
Fixed role rule for Elasticsearch

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -62,13 +62,19 @@ rules:
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
-    - roles
-    - rolebindings
+  - roles
+  - rolebindings
   verbs:
-    - '*'
+  - '*'
 - apiGroups:
   - elasticsearch.jaegertracing.io
   resources:
   - jaeger
   verbs:
   - 'get'
+- apiGroups:
+  - logging.openshift.io
+  resources:
+  - elasticsearches
+  verbs:
+  - '*'

--- a/test/role.yaml
+++ b/test/role.yaml
@@ -61,13 +61,19 @@ rules:
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
-    - roles
-    - rolebindings
+  - roles
+  - rolebindings
   verbs:
-    - '*'
+  - '*'
 - apiGroups:
   - elasticsearch.jaegertracing.io
   resources:
   - jaeger
   verbs:
   - 'get'
+- apiGroups:
+  - logging.openshift.io
+  resources:
+  - elasticsearches
+  verbs:
+  - '*'


### PR DESCRIPTION
Fixes #250 by adding a rule for listing ES clusters. 

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>