### PR TITLE
Change Operator provider to CNCF

### DIFF
--- a/.travis/release.sh
+++ b/.travis/release.sh
@@ -22,6 +22,10 @@ sed "s/currentCSV: jaeger-operator.*/currentCSV: jaeger-operator.v${OPERATOR_VER
 sed "s~containerImage: docker.io/jaegertracing/jaeger-operator.*~containerImage: docker.io/${BUILD_IMAGE}~gi" -i deploy/olm-catalog/jaeger-operator.csv.yaml
 sed "s/name: jaeger-operator\.v.*/name: jaeger-operator.v${OPERATOR_VERSION}/gi" -i deploy/olm-catalog/jaeger-operator.csv.yaml
 sed "s~image: jaegertracing/jaeger-operator.*~image: ${BUILD_IMAGE}~gi" -i deploy/olm-catalog/jaeger-operator.csv.yaml
+
+export PREVIOUS_OPERATOR_VERSION=`grep "version: [0-9]" deploy/olm-catalog/jaeger-operator.csv.yaml | cut -f4 -d' '`
+sed "s/replaces: jaeger-operator\.v.*/replaces: jaeger-operator.v${PREVIOUS_OPERATOR_VERSION}/gi" -i deploy/olm-catalog/jaeger-operator.csv.yaml
+
 ## there's a "version: v1" there somewhere that we want to avoid
 sed -E "s/version: ([0-9\.]+).*/version: ${OPERATOR_VERSION}/gi" -i deploy/olm-catalog/jaeger-operator.csv.yaml
 

--- a/deploy/olm-catalog/jaeger-operator.csv.yaml
+++ b/deploy/olm-catalog/jaeger-operator.csv.yaml
@@ -59,6 +59,7 @@ metadata:
     support: Jaeger
   creationTimestamp: null
   name: jaeger-operator.v1.10.0
+  replaces: jaeger-operator.v1.9.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}

--- a/deploy/olm-catalog/jaeger-operator.csv.yaml
+++ b/deploy/olm-catalog/jaeger-operator.csv.yaml
@@ -253,7 +253,7 @@ spec:
   - email: jaeger-tracing@googlegroups.com
     name: Jaeger Google Group
   provider:
-    name: Jaeger
+    name: CNCF
   selector:
     matchLabels:
       name: jaeger-operator


### PR DESCRIPTION
Change provider from `Jaeger` to `CNCF` to enable it to be listed with other CNCF project operators.

@awgreene Would you be able to review and confirm this an appropriate change to update the provider used on operatorhub.io? If so, how does the update get applied to the hub?

Signed-off-by: Gary Brown <gary@brownuk.com>