### PR TITLE
Avoid timeouts and race conditions esp. on slow machines

### DIFF
--- a/test/e2e/daemonset.go
+++ b/test/e2e/daemonset.go
@@ -135,7 +135,7 @@ func daemonsetTest(t *testing.T, f *framework.Framework, ctx *framework.TestCtx)
 		return err
 	}
 
-	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "vertx-create-span", 1, retryInterval, 2 * timeout)
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "vertx-create-span", 1, retryInterval, timeout)
 	if err != nil {
 		return err
 	}

--- a/test/e2e/daemonset.go
+++ b/test/e2e/daemonset.go
@@ -135,7 +135,7 @@ func daemonsetTest(t *testing.T, f *framework.Framework, ctx *framework.TestCtx)
 		return err
 	}
 
-	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "vertx-create-span", 1, retryInterval, timeout)
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "vertx-create-span", 1, retryInterval, 2 * timeout)
 	if err != nil {
 		return err
 	}

--- a/test/e2e/suite_cassandra_test.go
+++ b/test/e2e/suite_cassandra_test.go
@@ -21,6 +21,12 @@ func TestCassandra(t *testing.T) {
 		},
 	}))
 
+	// Don't start tests until cassandra is ready
+	err := WaitForStatefulset(t, framework.Global.KubeClient, storageNamespace, "cassandra", retryInterval, timeout)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	t.Run("cassandra", func(t *testing.T) {
 		t.Run("cassandra", Cassandra)
 		t.Run("spark-dependencies-cass", SparkDependenciesCassandra)

--- a/test/e2e/suite_elasticsearch_test.go
+++ b/test/e2e/suite_elasticsearch_test.go
@@ -21,6 +21,12 @@ func TestElasticsearch(t *testing.T) {
 		},
 	}))
 
+	// Don't start tests until elasticsearch is ready
+	err := WaitForStatefulset(t, framework.Global.KubeClient, storageNamespace, "elasticsearch", retryInterval, timeout)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	t.Run("elasticsearch", func(t *testing.T) {
 		t.Run("spark-dependencies-es", SparkDependenciesElasticsearch)
 		t.Run("simple-prod", SimpleProd)

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -56,7 +56,7 @@ func prepare(t *testing.T) *framework.TestCtx {
 	// get global framework variables
 	f := framework.Global
 	// wait for the operator to be ready
-	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "jaeger-operator", 1, retryInterval, timeout)
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "jaeger-operator", 1, retryInterval, 2 * timeout)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -16,7 +16,7 @@ import (
 
 var (
 	retryInterval        = time.Second * 5
-	timeout              = time.Minute * 1
+	timeout              = time.Minute * 2
 	storageNamespace     = os.Getenv("STORAGE_NAMESPACE")
 	esServerUrls         = "http://elasticsearch." + storageNamespace + ".svc:9200"
 	cassandraServiceName = "cassandra." + storageNamespace + ".svc"
@@ -56,7 +56,7 @@ func prepare(t *testing.T) *framework.TestCtx {
 	// get global framework variables
 	f := framework.Global
 	// wait for the operator to be ready
-	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "jaeger-operator", 1, retryInterval, 2 * timeout)
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "jaeger-operator", 1, retryInterval, timeout)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Resolves #180  Increase the timeout in two places that I've seen cause failures in thethe daemonset test.  Also add waits so that elasticsearch and cassandra tests don't start until es or cassandra are ready.
