### PR TITLE
Fix reverting ingress security to oauth-proxy on openshift if set to none

### DIFF
--- a/pkg/strategy/controller.go
+++ b/pkg/strategy/controller.go
@@ -133,13 +133,6 @@ func normalizeRollover(spec *v1.JaegerEsRolloverSpec) {
 	}
 }
 
-//func normalizeUI(spec *v1.JaegerSpec) {
-//	if strings.EqualFold(spec.Storage.Options.Map()["es-archive.enabled"], "true") ||
-//		strings.EqualFold(spec.Storage.Options.Map()["cassandra-archive.enabled"], "true") {
-//		spec.UI.Options
-//	}
-//}
-
 func unknownStorage(typ string) bool {
 	for _, k := range storage.ValidTypes() {
 		if strings.EqualFold(typ, k) {

--- a/pkg/strategy/controller.go
+++ b/pkg/strategy/controller.go
@@ -75,7 +75,7 @@ func normalize(jaeger *v1.Jaeger) {
 		// cases:
 		// - omitted on Kubernetes
 		// - 'none' on any platform
-		jaeger.Spec.Ingress.Security = v1.IngressSecurityNone
+		jaeger.Spec.Ingress.Security = v1.IngressSecurityNoneExplicit
 	}
 
 	normalizeSparkDependencies(&jaeger.Spec.Storage.SparkDependencies, jaeger.Spec.Storage.Type)
@@ -132,6 +132,13 @@ func normalizeRollover(spec *v1.JaegerEsRolloverSpec) {
 		spec.Schedule = "*/30 * * * *"
 	}
 }
+
+//func normalizeUI(spec *v1.JaegerSpec) {
+//	if strings.EqualFold(spec.Storage.Options.Map()["es-archive.enabled"], "true") ||
+//		strings.EqualFold(spec.Storage.Options.Map()["cassandra-archive.enabled"], "true") {
+//		spec.UI.Options
+//	}
+//}
 
 func unknownStorage(typ string) bool {
 	for _, k := range storage.ValidTypes() {

--- a/pkg/strategy/controller_test.go
+++ b/pkg/strategy/controller_test.go
@@ -122,14 +122,14 @@ func TestStorageMemoryOnlyUsedWithAllInOneStrategy(t *testing.T) {
 func TestSetSecurityToNoneByDefault(t *testing.T) {
 	jaeger := v1.NewJaeger("TestSetSecurityToNoneByDefault")
 	normalize(jaeger)
-	assert.Equal(t, v1.IngressSecurityNone, jaeger.Spec.Ingress.Security)
+	assert.Equal(t, v1.IngressSecurityNoneExplicit, jaeger.Spec.Ingress.Security)
 }
 
 func TestSetSecurityToNoneWhenExplicitSettingToNone(t *testing.T) {
 	jaeger := v1.NewJaeger("TestSetSecurityToNoneWhenExplicitSettingToNone")
 	jaeger.Spec.Ingress.Security = v1.IngressSecurityNoneExplicit
 	normalize(jaeger)
-	assert.Equal(t, v1.IngressSecurityNone, jaeger.Spec.Ingress.Security)
+	assert.Equal(t, v1.IngressSecurityNoneExplicit, jaeger.Spec.Ingress.Security)
 }
 
 func TestSetSecurityToOAuthProxyByDefaultOnOpenShift(t *testing.T) {
@@ -148,7 +148,7 @@ func TestSetSecurityToNoneOnNonOpenShift(t *testing.T) {
 
 	normalize(jaeger)
 
-	assert.Equal(t, v1.IngressSecurityNone, jaeger.Spec.Ingress.Security)
+	assert.Equal(t, v1.IngressSecurityNoneExplicit, jaeger.Spec.Ingress.Security)
 }
 
 func TestAcceptExplicitValueFromSecurityWhenOnOpenShift(t *testing.T) {
@@ -160,7 +160,7 @@ func TestAcceptExplicitValueFromSecurityWhenOnOpenShift(t *testing.T) {
 
 	normalize(jaeger)
 
-	assert.Equal(t, v1.IngressSecurityNone, jaeger.Spec.Ingress.Security)
+	assert.Equal(t, v1.IngressSecurityNoneExplicit, jaeger.Spec.Ingress.Security)
 }
 
 func TestNormalizeIndexCleaner(t *testing.T) {


### PR DESCRIPTION
Resolves #298 

The ingress security on OCP was always reverted to "oauth-proxy" if it was configured as "none".



Signed-off-by: Pavol Loffay <ploffay@redhat.com>