### PR TITLE
Disable spark dependencies for self provisioned es

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -260,7 +260,7 @@ spec:
 
 Under some circumstances, the Jaeger Operator can make use of the link:https://github.com/openshift/elasticsearch-operator[Elasticsearch Operator] to provision a suitable Elasticsearch cluster.
 
-IMPORTANT: this feature is experimental and has been tested only on OpenShift clusters. Elasticsearch also requires the memory setting to be configured like `minishift ssh -- 'sudo sysctl -w vm.max_map_count=262144'`. Spark dependencies are neither supported link:https://github.com/jaegertracing/jaeger-operator/issues/294[#294].
+IMPORTANT: this feature is experimental and has been tested only on OpenShift clusters. Elasticsearch also requires the memory setting to be configured like `minishift ssh -- 'sudo sysctl -w vm.max_map_count=262144'`. Spark dependencies are not supported with this feature link:https://github.com/jaegertracing/jaeger-operator/issues/294[#294].
 
 When there are no `es.server-urls` options as part of a Jaeger `production` instance and `elasticsearch` is set as the storage type, the Jaeger Operator creates an Elasticsearch cluster via the Elasticsearch Operator by creating a Custom Resource based on the configuration provided in storage section. The Elasticsearch cluster is meant to be dedicated for a single Jaeger instance.
 

--- a/README.adoc
+++ b/README.adoc
@@ -260,7 +260,7 @@ spec:
 
 Under some circumstances, the Jaeger Operator can make use of the link:https://github.com/openshift/elasticsearch-operator[Elasticsearch Operator] to provision a suitable Elasticsearch cluster.
 
-IMPORTANT: this feature is experimental and has been tested only on OpenShift clusters. Elasticsearch also requires the memory setting to be configured like `minishift ssh -- 'sudo sysctl -w vm.max_map_count=262144'`
+IMPORTANT: this feature is experimental and has been tested only on OpenShift clusters. Elasticsearch also requires the memory setting to be configured like `minishift ssh -- 'sudo sysctl -w vm.max_map_count=262144'`. Spark dependencies are neither supported link:https://github.com/jaegertracing/jaeger-operator/issues/294[#294].
 
 When there are no `es.server-urls` options as part of a Jaeger `production` instance and `elasticsearch` is set as the storage type, the Jaeger Operator creates an Elasticsearch cluster via the Elasticsearch Operator by creating a Custom Resource based on the configuration provided in storage section. The Elasticsearch cluster is meant to be dedicated for a single Jaeger instance.
 

--- a/pkg/strategy/controller.go
+++ b/pkg/strategy/controller.go
@@ -79,24 +79,26 @@ func normalize(jaeger *v1.Jaeger) {
 	}
 
 	// note that the order normalization matters - UI norm expects all normalized properties
-	normalizeSparkDependencies(&jaeger.Spec.Storage.SparkDependencies, jaeger.Spec.Storage.Type)
+	normalizeSparkDependencies(&jaeger.Spec.Storage)
 	normalizeIndexCleaner(&jaeger.Spec.Storage.EsIndexCleaner, jaeger.Spec.Storage.Type)
 	normalizeElasticsearch(&jaeger.Spec.Storage.Elasticsearch)
 	normalizeRollover(&jaeger.Spec.Storage.Rollover)
 	normalizeUI(&jaeger.Spec)
 }
 
-func normalizeSparkDependencies(spec *v1.JaegerDependenciesSpec, storage string) {
+func normalizeSparkDependencies(spec *v1.JaegerStorageSpec) {
 	// auto enable only for supported storages
-	if cronjob.SupportedStorage(storage) && spec.Enabled == nil {
+	if cronjob.SupportedStorage(spec.Type) &&
+		spec.SparkDependencies.Enabled == nil &&
+		!storage.ShouldDeployElasticsearch(*spec) {
 		trueVar := true
-		spec.Enabled = &trueVar
+		spec.SparkDependencies.Enabled = &trueVar
 	}
-	if spec.Image == "" {
-		spec.Image = viper.GetString("jaeger-spark-dependencies-image")
+	if spec.SparkDependencies.Image == "" {
+		spec.SparkDependencies.Image = viper.GetString("jaeger-spark-dependencies-image")
 	}
-	if spec.Schedule == "" {
-		spec.Schedule = "55 23 * * *"
+	if spec.SparkDependencies.Schedule == "" {
+		spec.SparkDependencies.Schedule = "55 23 * * *"
 	}
 }
 

--- a/pkg/strategy/controller_test.go
+++ b/pkg/strategy/controller_test.go
@@ -207,16 +207,25 @@ func TestNormalizeSparkDependencies(t *testing.T) {
 	trueVar := true
 	falseVar := false
 	tests := []struct {
-		underTest v1.JaegerDependenciesSpec
-		expected  v1.JaegerDependenciesSpec
+		underTest v1.JaegerStorageSpec
+		expected  v1.JaegerStorageSpec
 	}{
-		{underTest: v1.JaegerDependenciesSpec{},
-			expected: v1.JaegerDependenciesSpec{Schedule: "55 23 * * *", Image: "foo", Enabled: &trueVar}},
-		{underTest: v1.JaegerDependenciesSpec{Schedule: "foo", Image: "bla", Enabled: &falseVar},
-			expected: v1.JaegerDependenciesSpec{Schedule: "foo", Image: "bla", Enabled: &falseVar}},
+		{
+			underTest: v1.JaegerStorageSpec{Type: "elasticsearch", Options: v1.NewOptions(map[string]interface{}{"es.server-urls": "foo"})},
+			expected: v1.JaegerStorageSpec{Type: "elasticsearch", Options: v1.NewOptions(map[string]interface{}{"es.server-urls": "foo"}),
+				SparkDependencies: v1.JaegerDependenciesSpec{Schedule: "55 23 * * *", Image: "foo", Enabled: &trueVar}},
+		},
+		{
+			underTest: v1.JaegerStorageSpec{Type: "elasticsearch"},
+			expected:  v1.JaegerStorageSpec{Type: "elasticsearch", SparkDependencies: v1.JaegerDependenciesSpec{Schedule: "55 23 * * *", Image: "foo"}},
+		},
+		{
+			underTest: v1.JaegerStorageSpec{Type: "elasticsearch", SparkDependencies: v1.JaegerDependenciesSpec{Schedule: "foo", Image: "bla", Enabled: &falseVar}},
+			expected:  v1.JaegerStorageSpec{Type: "elasticsearch", SparkDependencies: v1.JaegerDependenciesSpec{Schedule: "foo", Image: "bla", Enabled: &falseVar}},
+		},
 	}
 	for _, test := range tests {
-		normalizeSparkDependencies(&test.underTest, "elasticsearch")
+		normalizeSparkDependencies(&test.underTest)
 		assert.Equal(t, test.expected, test.underTest)
 	}
 }


### PR DESCRIPTION
Resolves #316 

We don't want auto-enabled spark deps for self-provisioned ES

Signed-off-by: Pavol Loffay <ploffay@redhat.com>