### PR TITLE
Load back Elasticsearch certs from secrets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,7 @@ e2e-tests-es: prepare-e2e-tests es
 
 .PHONY: run
 run: crd
+	@rm -rf /tmp/_cert*
 	@bash -c 'trap "exit 0" INT; OPERATOR_NAME=${OPERATOR_NAME} KUBERNETES_CONFIG=${KUBERNETES_CONFIG} WATCH_NAMESPACE=${WATCH_NAMESPACE} go run -ldflags ${LD_FLAGS} main.go start'
 
 .PHONY: es

--- a/Makefile
+++ b/Makefile
@@ -96,8 +96,8 @@ e2e-tests-es: prepare-e2e-tests es
 
 .PHONY: run
 run: crd
-	@bash -c 'trap "exit 0" INT; OPERATOR_NAME=${OPERATOR_NAME} KUBERNETES_CONFIG=${KUBERNETES_CONFIG} WATCH_NAMESPACE=${WATCH_NAMESPACE} go run -ldflags ${LD_FLAGS} main.go start'
 	@rm -rf /tmp/_cert*
+	@bash -c 'trap "exit 0" INT; OPERATOR_NAME=${OPERATOR_NAME} KUBERNETES_CONFIG=${KUBERNETES_CONFIG} WATCH_NAMESPACE=${WATCH_NAMESPACE} go run -ldflags ${LD_FLAGS} main.go start'
 
 .PHONY: es
 es: storage

--- a/Makefile
+++ b/Makefile
@@ -96,8 +96,8 @@ e2e-tests-es: prepare-e2e-tests es
 
 .PHONY: run
 run: crd
-	@rm -rf /tmp/_cert*
 	@bash -c 'trap "exit 0" INT; OPERATOR_NAME=${OPERATOR_NAME} KUBERNETES_CONFIG=${KUBERNETES_CONFIG} WATCH_NAMESPACE=${WATCH_NAMESPACE} go run -ldflags ${LD_FLAGS} main.go start'
+	@rm -rf /tmp/_cert*
 
 .PHONY: es
 es: storage

--- a/pkg/storage/elasticsearch.go
+++ b/pkg/storage/elasticsearch.go
@@ -44,7 +44,7 @@ func (ed *ElasticsearchDeployment) InjectStorageConfiguration(p *corev1.PodSpec)
 		Name: volumeName,
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
-				SecretName: secretName(ed.Jaeger.Name, jaegerSecret.name),
+				SecretName: jaegerSecret.instanceName(ed.Jaeger),
 			},
 		},
 	})
@@ -98,7 +98,7 @@ func (ed *ElasticsearchDeployment) InjectSecretsConfiguration(p *corev1.PodSpec)
 		Name: volumeName,
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
-				SecretName: secretName(ed.Jaeger.Name, curatorSecret.name),
+				SecretName: curatorSecret.instanceName(ed.Jaeger),
 			},
 		},
 	})

--- a/pkg/storage/elasticsearch_secrets.go
+++ b/pkg/storage/elasticsearch_secrets.go
@@ -104,7 +104,7 @@ func extractSecretsToFile(jaeger *v1.Jaeger, secrets []corev1.Secret, s ...secre
 	}
 	for _, sec := range s {
 		if secret, ok := secretMap[sec.instanceName(jaeger)]; ok {
-			if err := extractSecretToFile(jaeger, secret.Data, sec); err != nil {
+			if err := extractSecretToFile(getWorkingDir(jaeger), secret.Data, sec); err != nil {
 				return errors.Wrap(err, fmt.Sprintf("failed to extract secret %s", secret.Name))
 			}
 		}
@@ -112,9 +112,9 @@ func extractSecretsToFile(jaeger *v1.Jaeger, secrets []corev1.Secret, s ...secre
 	return nil
 }
 
-func extractSecretToFile(jaeger *v1.Jaeger, data map[string][]byte, secret secret) error {
+func extractSecretToFile(workingDir string, data map[string][]byte, secret secret) error {
 	for k, v := range secret.keyFileNameMap {
-		if err := writeToFile(getWorkingDir(jaeger), v, data[k]); err != nil {
+		if err := writeToFile(workingDir, v, data[k]); err != nil {
 			return err
 
 		}
@@ -207,7 +207,7 @@ func writeToFile(dir, file string, value []byte) error {
 	defer f.Close()
 	_, err = f.Write(value)
 	if err != nil {
-		// remove the file on failure - so it can be correctly created on the next iteration
+		// remove the file on failure - it can be correctly created in the next iteration
 		os.RemoveAll(path)
 		return err
 	}

--- a/pkg/storage/elasticsearch_secrets.go
+++ b/pkg/storage/elasticsearch_secrets.go
@@ -200,7 +200,6 @@ func writeToWorkingDirFile(dir, toFile string, value []byte) error {
 	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
 		return err
 	}
-	//#nosec G302 Expect file permissions to be 0600 or less (Confidence: HIGH, Severity: MEDIUM)
 	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0600)
 	if err != nil {
 		return err

--- a/pkg/storage/elasticsearch_secrets.go
+++ b/pkg/storage/elasticsearch_secrets.go
@@ -200,6 +200,7 @@ func writeToWorkingDirFile(dir, toFile string, value []byte) error {
 	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
 		return err
 	}
+	//#nosec G302 Expect file permissions to be 0600 or less (Confidence: HIGH, Severity: MEDIUM)
 	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0666)
 	if err != nil {
 		return err

--- a/pkg/storage/elasticsearch_secrets.go
+++ b/pkg/storage/elasticsearch_secrets.go
@@ -88,7 +88,7 @@ func ESSecrets(jaeger *v1.Jaeger) []corev1.Secret {
 
 // CreateESCerts runs bash scripts which generates certificates
 // The secrets are pulled back to FS in case of operator restart
-// The scrip checks if secrets are expired or need to be regenerated
+// The script checks if secrets are expired or need to be regenerated
 func CreateESCerts(jaeger *v1.Jaeger, existingSecrets []corev1.Secret) error {
 	err := extractSecretsToFile(jaeger, existingSecrets, masterSecret, esSecret, jaegerSecret, curatorSecret)
 	if err != nil {
@@ -201,7 +201,7 @@ func writeToWorkingDirFile(dir, toFile string, value []byte) error {
 		return err
 	}
 	//#nosec G302 Expect file permissions to be 0600 or less (Confidence: HIGH, Severity: MEDIUM)
-	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0666)
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0600)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/elasticsearch_secrets_test.go
+++ b/pkg/storage/elasticsearch_secrets_test.go
@@ -94,6 +94,11 @@ func TestExtractSecretsToFile(t *testing.T) {
 	assert.Equal(t, []byte(content), ca)
 }
 
+func TestExtractSecretsToFile_Err(t *testing.T) {
+	err := extractSecretToFile("/root", map[string][]byte{"foo": {}}, secret{keyFileNameMap: map[string]string{"foo": "foo"}})
+	assert.EqualError(t, err, "open /root/foo: permission denied")
+}
+
 func TestExtractSecretsToFile_FileExists(t *testing.T) {
 	defer os.RemoveAll(tmpWorkingDir)
 	content := "115dasrez"

--- a/pkg/storage/elasticsearch_secrets_test.go
+++ b/pkg/storage/elasticsearch_secrets_test.go
@@ -38,7 +38,7 @@ func TestCreateESSecrets(t *testing.T) {
 	}
 }
 
-func TestCreteSecret(t *testing.T) {
+func TestCreateSecret(t *testing.T) {
 	j := v1.NewJaeger("foo")
 	j.Namespace = "myproject"
 	s := createSecret(j, "bar", map[string][]byte{"foo": {}})
@@ -70,7 +70,7 @@ func TestGetWorkingFileDirContent_FileDoesNotExists(t *testing.T) {
 	assert.Nil(t, b)
 }
 
-func TestGetFileContet_EmptyPath(t *testing.T) {
+func TestGetFileContent_EmptyPath(t *testing.T) {
 	b := getFileContents("")
 	assert.Nil(t, b)
 }

--- a/pkg/strategy/controller.go
+++ b/pkg/strategy/controller.go
@@ -6,6 +6,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/cronjob"
@@ -13,7 +14,7 @@ import (
 )
 
 // For returns the appropriate Strategy for the given Jaeger instance
-func For(ctx context.Context, jaeger *v1.Jaeger) S {
+func For(ctx context.Context, jaeger *v1.Jaeger, secrets []corev1.Secret) S {
 	if strings.EqualFold(jaeger.Spec.Strategy, "all-in-one") {
 		jaeger.Logger().Warn("Strategy 'all-in-one' is no longer supported, please use 'allInOne'")
 		jaeger.Spec.Strategy = "allInOne"
@@ -30,7 +31,7 @@ func For(ctx context.Context, jaeger *v1.Jaeger) S {
 		return newStreamingStrategy(jaeger)
 	}
 
-	return newProductionStrategy(jaeger)
+	return newProductionStrategy(jaeger, secrets)
 }
 
 // normalize changes the incoming Jaeger object so that the defaults are applied when

--- a/pkg/strategy/controller_test.go
+++ b/pkg/strategy/controller_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 )
@@ -13,7 +14,7 @@ import (
 func TestNewControllerForAllInOneAsDefault(t *testing.T) {
 	jaeger := v1.NewJaeger("TestNewControllerForAllInOneAsDefault")
 
-	ctrl := For(context.TODO(), jaeger)
+	ctrl := For(context.TODO(), jaeger, []corev1.Secret{})
 	assert.Equal(t, ctrl.Type(), AllInOne)
 }
 
@@ -21,7 +22,7 @@ func TestNewControllerForAllInOneAsExplicitValue(t *testing.T) {
 	jaeger := v1.NewJaeger("TestNewControllerForAllInOneAsExplicitValue")
 	jaeger.Spec.Strategy = "ALL-IN-ONE" // same as 'all-in-one'
 
-	ctrl := For(context.TODO(), jaeger)
+	ctrl := For(context.TODO(), jaeger, []corev1.Secret{})
 	assert.Equal(t, ctrl.Type(), AllInOne)
 }
 
@@ -30,7 +31,7 @@ func TestNewControllerForProduction(t *testing.T) {
 	jaeger.Spec.Strategy = "production"
 	jaeger.Spec.Storage.Type = "elasticsearch"
 
-	ctrl := For(context.TODO(), jaeger)
+	ctrl := For(context.TODO(), jaeger, []corev1.Secret{})
 	assert.Equal(t, ctrl.Type(), Production)
 }
 
@@ -49,7 +50,7 @@ func TestElasticsearchAsStorageOptions(t *testing.T) {
 		"es.server-urls": "http://elasticsearch-example-es-cluster:9200",
 	})
 
-	ctrl := For(context.TODO(), jaeger)
+	ctrl := For(context.TODO(), jaeger, []corev1.Secret{})
 	deps := ctrl.Deployments()
 	assert.Len(t, deps, 2) // query and collector, for a production setup
 	counter := 0
@@ -102,7 +103,7 @@ func TestDeprecatedAllInOneStrategy(t *testing.T) {
 			Strategy: "all-in-one",
 		},
 	}
-	For(context.TODO(), jaeger)
+	For(context.TODO(), jaeger, []corev1.Secret{})
 	assert.Equal(t, "allInOne", jaeger.Spec.Strategy)
 }
 
@@ -115,7 +116,7 @@ func TestStorageMemoryOnlyUsedWithAllInOneStrategy(t *testing.T) {
 			},
 		},
 	}
-	For(context.TODO(), jaeger)
+	For(context.TODO(), jaeger, []corev1.Secret{})
 	assert.Equal(t, "allInOne", jaeger.Spec.Strategy)
 }
 

--- a/pkg/strategy/production.go
+++ b/pkg/strategy/production.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/viper"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/jaegertracing/jaeger-operator/pkg/account"
 	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
@@ -19,7 +20,7 @@ import (
 	"github.com/jaegertracing/jaeger-operator/pkg/storage"
 )
 
-func newProductionStrategy(jaeger *v1.Jaeger) S {
+func newProductionStrategy(jaeger *v1.Jaeger, existingSecrets []corev1.Secret) S {
 	c := S{typ: Production}
 	collector := deployment.NewCollector(jaeger)
 	query := deployment.NewQuery(jaeger)
@@ -99,7 +100,7 @@ func newProductionStrategy(jaeger *v1.Jaeger) S {
 			Jaeger: jaeger,
 		}
 
-		err := storage.CreateESCerts()
+		err := storage.CreateESCerts(jaeger, existingSecrets)
 		if err != nil {
 			jaeger.Logger().WithError(err).Error("failed to create Elasticsearch certificates, Elasticsearch won't be deployed")
 		} else {

--- a/pkg/strategy/production_test.go
+++ b/pkg/strategy/production_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
@@ -21,7 +22,7 @@ func init() {
 
 func TestCreateProductionDeployment(t *testing.T) {
 	name := "TestCreateProductionDeployment"
-	c := newProductionStrategy(v1.NewJaeger(name))
+	c := newProductionStrategy(v1.NewJaeger(name), []corev1.Secret{})
 	assertDeploymentsAndServicesForProduction(t, name, c, false, false, false)
 }
 
@@ -33,7 +34,7 @@ func TestCreateProductionDeploymentOnOpenShift(t *testing.T) {
 	jaeger := v1.NewJaeger(name)
 	normalize(jaeger)
 
-	c := newProductionStrategy(jaeger)
+	c := newProductionStrategy(jaeger, []corev1.Secret{})
 	assertDeploymentsAndServicesForProduction(t, name, c, false, true, false)
 }
 
@@ -43,7 +44,7 @@ func TestCreateProductionDeploymentWithDaemonSetAgent(t *testing.T) {
 	j := v1.NewJaeger(name)
 	j.Spec.Agent.Strategy = "DaemonSet"
 
-	c := newProductionStrategy(j)
+	c := newProductionStrategy(j, []corev1.Secret{})
 	assertDeploymentsAndServicesForProduction(t, name, c, true, false, false)
 }
 
@@ -57,7 +58,7 @@ func TestCreateProductionDeploymentWithUIConfigMap(t *testing.T) {
 		},
 	})
 
-	c := newProductionStrategy(j)
+	c := newProductionStrategy(j, []corev1.Secret{})
 	assertDeploymentsAndServicesForProduction(t, name, c, false, false, true)
 }
 
@@ -84,7 +85,7 @@ func TestOptionsArePassed(t *testing.T) {
 		},
 	}
 
-	ctrl := For(context.TODO(), jaeger)
+	ctrl := For(context.TODO(), jaeger, []corev1.Secret{})
 	deployments := ctrl.Deployments()
 	for _, dep := range deployments {
 		args := dep.Spec.Template.Spec.Containers[0].Args
@@ -108,7 +109,7 @@ func TestDelegateProductionDependencies(t *testing.T) {
 	// for now, we just have storage dependencies
 	j := v1.NewJaeger("TestDelegateProductionDependencies")
 	j.Spec.Storage.Type = "cassandra"
-	c := newProductionStrategy(j)
+	c := newProductionStrategy(j, []corev1.Secret{})
 	assert.Equal(t, c.Dependencies(), storage.Dependencies(j))
 }
 
@@ -163,19 +164,19 @@ func assertDeploymentsAndServicesForProduction(t *testing.T, name string, s S, h
 
 func TestSparkDependenciesProduction(t *testing.T) {
 	testSparkDependencies(t, func(jaeger *v1.Jaeger) S {
-		return newProductionStrategy(jaeger)
+		return newProductionStrategy(jaeger, []corev1.Secret{})
 	})
 }
 
 func TestEsIndexCleanerProduction(t *testing.T) {
 	testEsIndexCleaner(t, func(jaeger *v1.Jaeger) S {
-		return newProductionStrategy(jaeger)
+		return newProductionStrategy(jaeger, []corev1.Secret{})
 	})
 }
 
 func TestAgentSidecarIsInjectedIntoQueryForStreamingForProduction(t *testing.T) {
 	j := v1.NewJaeger("TestAgentSidecarIsInjectedIntoQueryForStreamingForProduction")
-	c := newProductionStrategy(j)
+	c := newProductionStrategy(j, []corev1.Secret{})
 	for _, dep := range c.Deployments() {
 		if strings.HasSuffix(dep.Name, "-query") {
 			assert.Equal(t, 2, len(dep.Spec.Template.Spec.Containers))

--- a/pkg/strategy/streaming_test.go
+++ b/pkg/strategy/streaming_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
@@ -89,7 +90,7 @@ func TestStreamingOptionsArePassed(t *testing.T) {
 		},
 	}
 
-	ctrl := For(context.TODO(), jaeger)
+	ctrl := For(context.TODO(), jaeger, []corev1.Secret{})
 	deployments := ctrl.Deployments()
 	for _, dep := range deployments {
 		args := dep.Spec.Template.Spec.Containers[0].Args


### PR DESCRIPTION
Resolves #320 

* avoids generating different certs if the operator restarts
* restores edited secrets by user
* stores certs in `/tmp/_cert/namespace/instance_name/uuid`

Signed-off-by: Pavol Loffay <ploffay@redhat.com>