### PR TITLE
Update allInOneWithIngressTest to work on OpenShift

### DIFF
--- a/test/e2e/daemonset.go
+++ b/test/e2e/daemonset.go
@@ -33,7 +33,7 @@ func DaemonSet(t *testing.T) {
 
 func daemonsetTest(t *testing.T, f *framework.Framework, ctx *framework.TestCtx) error {
 	// TODO restore this after fix of https://github.com/jaegertracing/jaeger-operator/issues/322
-	if isOpenShift(t, f) {
+	if isOpenShift(t) {
 		t.Skipf("Test %s is not currently supported on OpenShift because of issue 322\n", t.Name())
 	}
 	cleanupOptions := &framework.CleanupOptions{TestContext: ctx, Timeout: timeout, RetryInterval: retryInterval}

--- a/test/e2e/suite_smoke_test.go
+++ b/test/e2e/suite_smoke_test.go
@@ -8,6 +8,7 @@ import (
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	osv1 "github.com/openshift/api/route/v1"
 
 	"github.com/jaegertracing/jaeger-operator/pkg/apis"
 	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
@@ -20,6 +21,10 @@ func TestSmoke(t *testing.T) {
 			APIVersion: "jaegertracing.io/v1",
 		},
 	}))
+
+	if isOpenShift(t) {
+		assert.NoError(t, framework.AddToFrameworkScheme(osv1.AddToScheme, &osv1.Route{}))
+	}
 
 	t.Run("smoke", func(t *testing.T) {
 		t.Run("my-jaeger", JaegerAllInOne)

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -66,8 +66,8 @@ func prepare(t *testing.T) *framework.TestCtx {
 	return ctx
 }
 
-func isOpenShift(t *testing.T, f *framework.Framework) bool {
-	apiList, err := availableAPIs(f.KubeConfig)
+func isOpenShift(t *testing.T) bool {
+	apiList, err := availableAPIs(framework.Global.KubeConfig)
 	if err != nil {
 		t.Logf("Error trying to find APIs: %v\n", err)
 	}


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com> 

This resolves #326 by adding the ability to find routes with the kubeclient.  

It also contains a minor change to the isOpenShift function, as I realized I did not need to pass it a framework object.
