### PR TITLE
Initialise menu to include Log Out option when using OAuth Proxy

### DIFF
--- a/pkg/strategy/controller.go
+++ b/pkg/strategy/controller.go
@@ -208,7 +208,8 @@ func enableLogOut(uiOpts map[string]interface{}, spec *v1.JaegerSpec) {
 		},
 		{
 		  "label": "Log Out",
-		  "url": "/oauth/sign_in"
+		  "url": "/oauth/sign_in",
+		  "anchorTarget": "_self"
 		}
 	  ]`
 

--- a/pkg/strategy/controller_test.go
+++ b/pkg/strategy/controller_test.go
@@ -376,8 +376,9 @@ func TestMenuWithSignOut(t *testing.T) {
 			},
 		},
 		map[string]interface{}{
-			"label": "Log Out",
-			"url":   "/oauth/sign_in",
+			"label":        "Log Out",
+			"url":          "/oauth/sign_in",
+			"anchorTarget": "_self",
 		},
 	}
 	assert.Equal(t, uiOpts["menu"], expected)
@@ -393,7 +394,7 @@ func TestMenuNoSignOutExistingMenu(t *testing.T) {
 	uiOpts := map[string]interface{}{
 		"menu": []interface{}{},
 	}
-	enableLogOut(uiOpts, &v1.JaegerSpec{Ingress: v1.JaegerIngressSpec{Security: v1.IngressSecurityNoneExplicit}})
+	enableLogOut(uiOpts, &v1.JaegerSpec{Ingress: v1.JaegerIngressSpec{Security: v1.IngressSecurityOAuthProxy}})
 	assert.Contains(t, uiOpts, "menu")
 	assert.Len(t, uiOpts["menu"], 0)
 }

--- a/pkg/strategy/controller_test.go
+++ b/pkg/strategy/controller_test.go
@@ -360,6 +360,44 @@ func TestNormalizeUIDependenciesTab(t *testing.T) {
 	}
 }
 
+func TestMenuWithSignOut(t *testing.T) {
+	uiOpts := map[string]interface{}{}
+	enableLogOut(uiOpts, &v1.JaegerSpec{Ingress: v1.JaegerIngressSpec{Security: v1.IngressSecurityOAuthProxy}})
+	assert.Contains(t, uiOpts, "menu")
+
+	expected := []interface{}{
+		map[string]interface{}{
+			"label": "About",
+			"items": []interface{}{
+				map[string]interface{}{
+					"label": "Documentation",
+					"url":   "https://www.jaegertracing.io/docs/latest",
+				},
+			},
+		},
+		map[string]interface{}{
+			"label": "Log Out",
+			"url":   "/oauth/sign_in",
+		},
+	}
+	assert.Equal(t, uiOpts["menu"], expected)
+}
+
+func TestMenuNoSignOutIngressSecurityNone(t *testing.T) {
+	uiOpts := map[string]interface{}{}
+	enableLogOut(uiOpts, &v1.JaegerSpec{Ingress: v1.JaegerIngressSpec{Security: v1.IngressSecurityNoneExplicit}})
+	assert.NotContains(t, uiOpts, "menu")
+}
+
+func TestMenuNoSignOutExistingMenu(t *testing.T) {
+	uiOpts := map[string]interface{}{
+		"menu": []interface{}{},
+	}
+	enableLogOut(uiOpts, &v1.JaegerSpec{Ingress: v1.JaegerIngressSpec{Security: v1.IngressSecurityNoneExplicit}})
+	assert.Contains(t, uiOpts, "menu")
+	assert.Len(t, uiOpts["menu"], 0)
+}
+
 func assertHasAllObjects(t *testing.T, name string, s S, deployments map[string]bool, daemonsets map[string]bool, services map[string]bool, ingresses map[string]bool, routes map[string]bool, serviceAccounts map[string]bool, configMaps map[string]bool) {
 	for _, o := range s.Deployments() {
 		deployments[o.Name] = true


### PR DESCRIPTION
Adds menu (About sub-menu and Log Out) when OAuth Proxy configured.

Currently when selecting the Log Out button it opens another tab - this may require a change in jaeger-ui.

Signed-off-by: Gary Brown <gary@brownuk.com>