### PR TITLE
Add prometheus scrape 'false' annotation to headless collector service

### DIFF
--- a/pkg/service/collector.go
+++ b/pkg/service/collector.go
@@ -20,6 +20,9 @@ func NewCollectorServices(jaeger *v1.Jaeger, selector map[string]string) []*core
 func headlessCollectorService(jaeger *v1.Jaeger, selector map[string]string) *corev1.Service {
 	svc := collectorService(jaeger, selector)
 	svc.Name = GetNameForHeadlessCollectorService(jaeger)
+	svc.Annotations = map[string]string{
+		"prometheus.io/scrape": "false",
+	}
 	svc.Spec.ClusterIP = "None"
 	return svc
 }


### PR DESCRIPTION
Resolves #347 

@jkandasa Haven't been able to reproduce your issue, although it may depend upon the prometheus config being used. I've added an annotation to the headless service which should prevent it being scraped - but if you could verify by testing against the https://hub.docker.com/r/objectiser/jaeger-operator to see if it fixes the problem?

Signed-off-by: Gary Brown <gary@brownuk.com>