### PR TITLE
Update test to run on OpenShift

### DIFF
--- a/test/e2e/daemonset.go
+++ b/test/e2e/daemonset.go
@@ -42,11 +42,12 @@ func daemonsetTest(t *testing.T, f *framework.Framework, ctx *framework.TestCtx)
 	}
 
 	if isOpenShift(t) {
-		err = f.Client.Create(goctx.TODO(), hostportSccDaemonset(), cleanupOptions)
+		err = f.Client.Create(goctx.TODO(), hostPortSccDaemonset(), cleanupOptions)
 		if err != nil && !strings.Contains(err.Error(), "already exists") {
 			return err
 		}
 
+		// ideally, we would use the REST API, but for a single-usage within the project, this is the simplest solution that works
 		cmd := exec.Command("oc", "adm", "--namespace", namespace, "policy",  "add-scc-to-user", "daemonset-with-hostport", "-z", "default")
 		output, err := cmd.CombinedOutput()
 		if err != nil {
@@ -211,7 +212,7 @@ func jaegerAgentAsDaemonsetDefinition(namespace string, name string) *v1.Jaeger 
 	return j
 }
 
-func hostportSccDaemonset() (*osv1sec.SecurityContextConstraints) {
+func hostPortSccDaemonset() (*osv1sec.SecurityContextConstraints) {
 	annotations := make(map[string]string)
 	annotations["kubernetes.io/description"] = "Allows DaemonSets to bind to a well-known host port"
 

--- a/test/e2e/suite_smoke_test.go
+++ b/test/e2e/suite_smoke_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	osv1 "github.com/openshift/api/route/v1"
+	osv1sec "github.com/openshift/api/security/v1"
 
 	"github.com/jaegertracing/jaeger-operator/pkg/apis"
 	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
@@ -24,6 +25,7 @@ func TestSmoke(t *testing.T) {
 
 	if isOpenShift(t) {
 		assert.NoError(t, framework.AddToFrameworkScheme(osv1.AddToScheme, &osv1.Route{}))
+		assert.NoError(t, framework.AddToFrameworkScheme(osv1sec.AddToScheme, &osv1sec.SecurityContextConstraints{}))
 	}
 
 	t.Run("smoke", func(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com>

This resolves #327 by taking actions that are needed to permit this test to run on OpenShift.  Part of the solution is a bit hacky as it uses os.Exec to call the "oc adm" command, which means the oc client needs to be on the path wherever this test is being run.

It would be preferable to use either the OpenShift Go client of the Rest API to do this, but we don't use those anywhere else in the tests and adding them would be non-trivial.  I will open an issue to do this in the future.
