### PR TITLE
Derive agent container/host ports from options if specified

### DIFF
--- a/pkg/inject/sidecar.go
+++ b/pkg/inject/sidecar.go
@@ -99,6 +99,11 @@ func container(jaeger *v1.Jaeger) corev1.Container {
 		}
 	}
 
+	zkCompactTrft := util.GetPort("--processor.zipkin-compact.server-host-port=", args, 5775)
+	configRest := util.GetPort("--http-server.host-port=", args, 5778)
+	jgCompactTrft := util.GetPort("--processor.jaeger-compact.server-host-port=", args, 6831)
+	jgBinaryTrft := util.GetPort("--processor.jaeger-binary.server-host-port=", args, 6832)
+
 	// ensure we have a consistent order of the arguments
 	// see https://github.com/jaegertracing/jaeger-operator/issues/334
 	sort.Strings(args)
@@ -109,19 +114,19 @@ func container(jaeger *v1.Jaeger) corev1.Container {
 		Args:  args,
 		Ports: []corev1.ContainerPort{
 			{
-				ContainerPort: 5775,
+				ContainerPort: zkCompactTrft,
 				Name:          "zk-compact-trft",
 			},
 			{
-				ContainerPort: 5778,
+				ContainerPort: configRest,
 				Name:          "config-rest",
 			},
 			{
-				ContainerPort: 6831,
+				ContainerPort: jgCompactTrft,
 				Name:          "jg-compact-trft",
 			},
 			{
-				ContainerPort: 6832,
+				ContainerPort: jgBinaryTrft,
 				Name:          "jg-binary-trft",
 			},
 		},

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"strconv"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -135,4 +136,20 @@ func FindItem(prefix string, args []string) string {
 	}
 
 	return ""
+}
+
+// GetPort returns a port, either from supplied default port, or extracted from supplied arg value
+func GetPort(arg string, args []string, port int32) int32 {
+	portArg := FindItem(arg, args)
+	if len(portArg) > 0 {
+		i := strings.Index(portArg, ":")
+		if i > -1 {
+			newPort, err := strconv.ParseInt(portArg[i+1:], 10, 32)
+			if err == nil {
+				port = int32(newPort)
+			}
+		}
+	}
+
+	return port
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -214,3 +214,21 @@ func TestFindItem(t *testing.T) {
 	assert.Equal(t, "--reporter.type=thrift", FindItem("--reporter.type=", args))
 	assert.Len(t, FindItem("--c-option", args), 0)
 }
+
+func TestGetPortDefault(t *testing.T) {
+	opts := v1.NewOptions(map[string]interface{}{})
+
+	args := opts.ToArgs()
+
+	assert.Equal(t, int32(1234), GetPort("--processor.jaeger-compact.server-host-port=", args, 1234))
+}
+
+func TestGetPortSpecified(t *testing.T) {
+	opts := v1.NewOptions(map[string]interface{}{
+		"processor.jaeger-compact.server-host-port": ":6831",
+	})
+
+	args := opts.ToArgs()
+
+	assert.Equal(t, int32(6831), GetPort("--processor.jaeger-compact.server-host-port=", args, 1234))
+}


### PR DESCRIPTION
Was using hardcoded ports, so traffic wasn't getting through to the agent when the ports were changed using the options.

Signed-off-by: Gary Brown <gary@brownuk.com>