### PR TITLE
Add support for affinity and tolerations

### DIFF
--- a/pkg/apis/jaegertracing/v1/jaeger_types.go
+++ b/pkg/apis/jaegertracing/v1/jaeger_types.go
@@ -90,6 +90,8 @@ type JaegerCommonSpec struct {
 	VolumeMounts []v1.VolumeMount        `json:"volumeMounts"`
 	Annotations  map[string]string       `json:"annotations,omitempty"`
 	Resources    v1.ResourceRequirements `json:"resources,omitempty"`
+	Affinity     *v1.Affinity            `json:"affinity,omitempty"`
+	Tolerations  []v1.Toleration         `json:"tolerations,omitempty"`
 }
 
 // JaegerQuerySpec defines the options to be used when deploying the query

--- a/pkg/apis/jaegertracing/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/jaegertracing/v1/zz_generated.deepcopy.go
@@ -204,6 +204,18 @@ func (in *JaegerCommonSpec) DeepCopyInto(out *JaegerCommonSpec) {
 		}
 	}
 	in.Resources.DeepCopyInto(&out.Resources)
+	if in.Affinity != nil {
+		in, out := &in.Affinity, &out.Affinity
+		*out = new(corev1.Affinity)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.Tolerations != nil {
+		in, out := &in.Tolerations, &out.Tolerations
+		*out = make([]corev1.Toleration, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/pkg/deployment/agent.go
+++ b/pkg/deployment/agent.go
@@ -140,6 +140,8 @@ func (a *Agent) Get() *appsv1.DaemonSet {
 						},
 						Resources: commonSpec.Resources,
 					}},
+					Affinity:    commonSpec.Affinity,
+					Tolerations: commonSpec.Tolerations,
 				},
 			},
 		},

--- a/pkg/deployment/all-in-one.go
+++ b/pkg/deployment/all-in-one.go
@@ -166,6 +166,8 @@ func (a *AllInOne) Get() *appsv1.Deployment {
 					}},
 					Volumes:            commonSpec.Volumes,
 					ServiceAccountName: account.JaegerServiceAccountFor(a.jaeger),
+					Affinity:           commonSpec.Affinity,
+					Tolerations:        commonSpec.Tolerations,
 				},
 			},
 		},

--- a/pkg/deployment/collector.go
+++ b/pkg/deployment/collector.go
@@ -161,6 +161,8 @@ func (c *Collector) Get() *appsv1.Deployment {
 					}},
 					Volumes:            commonSpec.Volumes,
 					ServiceAccountName: account.JaegerServiceAccountFor(c.jaeger),
+					Affinity:           commonSpec.Affinity,
+					Tolerations:        commonSpec.Tolerations,
 				},
 			},
 		},

--- a/pkg/deployment/ingester.go
+++ b/pkg/deployment/ingester.go
@@ -146,6 +146,8 @@ func (i *Ingester) Get() *appsv1.Deployment {
 					}},
 					Volumes:            commonSpec.Volumes,
 					ServiceAccountName: account.JaegerServiceAccountFor(i.jaeger),
+					Affinity:           commonSpec.Affinity,
+					Tolerations:        commonSpec.Tolerations,
 				},
 			},
 		},

--- a/pkg/deployment/query.go
+++ b/pkg/deployment/query.go
@@ -146,6 +146,8 @@ func (q *Query) Get() *appsv1.Deployment {
 					}},
 					Volumes:            commonSpec.Volumes,
 					ServiceAccountName: account.JaegerServiceAccountFor(q.jaeger),
+					Affinity:           commonSpec.Affinity,
+					Tolerations:        commonSpec.Tolerations,
 				},
 			},
 		},

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -48,6 +48,8 @@ func Merge(commonSpecs []v1.JaegerCommonSpec) *v1.JaegerCommonSpec {
 	var volumeMounts []corev1.VolumeMount
 	var volumes []corev1.Volume
 	resources := &corev1.ResourceRequirements{}
+	var affinity *corev1.Affinity
+	var tolerations []corev1.Toleration
 
 	for _, commonSpec := range commonSpecs {
 		// Merge annotations
@@ -62,6 +64,13 @@ func Merge(commonSpecs []v1.JaegerCommonSpec) *v1.JaegerCommonSpec {
 
 		// Merge resources
 		mergeResources(resources, commonSpec.Resources)
+
+		// Set the affinity based on the most specific definition available
+		if affinity == nil {
+			affinity = commonSpec.Affinity
+		}
+
+		tolerations = append(tolerations, commonSpec.Tolerations...)
 	}
 
 	return &v1.JaegerCommonSpec{
@@ -69,6 +78,8 @@ func Merge(commonSpecs []v1.JaegerCommonSpec) *v1.JaegerCommonSpec {
 		VolumeMounts: removeDuplicatedVolumeMounts(volumeMounts),
 		Volumes:      removeDuplicatedVolumes(volumes),
 		Resources:    *resources,
+		Affinity:     affinity,
+		Tolerations:  tolerations,
 	}
 }
 

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -210,7 +210,8 @@ func TestMergeTolerations(t *testing.T) {
 
 	merged := Merge([]v1.JaegerCommonSpec{specificSpec, generalSpec})
 
-	// Keys are not unique, so should be aggregation of all tolerations
+	// Keys do not need to be unique, so should be aggregation of all tolerations
+	// See https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/ for more details
 	assert.Len(t, merged.Tolerations, 3)
 	assert.Equal(t, "toleration1", merged.Tolerations[0].Key)
 	assert.Equal(t, "toleration2", merged.Tolerations[1].Key)


### PR DESCRIPTION
Combining values from the specific component and general details has been done on the following basis:

* Affinity - there is no information about merging the information from two affinity definitions - so seems most appropriate approach is to just allow the more specific component's affinity definition to override any general one

* Tolerations - an array - the `Key` field is not unique, so not possible to select on that basis (as with annotations) - so just aggregate all of the tolerations from the specific component and general definitions.

Resolves #292 

Signed-off-by: Gary Brown <gary@brownuk.com>