### PR TITLE
Support injection of JAEGER_SERVICE_NAME based on app or k8s recommen…

### DIFF
--- a/pkg/inject/sidecar.go
+++ b/pkg/inject/sidecar.go
@@ -134,7 +134,14 @@ func container(jaeger *v1.Jaeger) corev1.Container {
 }
 
 func decorate(dep *appsv1.Deployment) {
-	if app, found := dep.Spec.Template.Labels["app"]; found {
+	app, found := dep.Spec.Template.Labels["app.kubernetes.io/instance"]
+	if !found {
+		app, found = dep.Spec.Template.Labels["app.kubernetes.io/name"]
+	}
+	if !found {
+		app, found = dep.Spec.Template.Labels["app"]
+	}
+	if found {
 		// Append the namespace to the app name. Using the DNS style "<app>.<namespace>""
 		// which also matches with the style used in Istio.
 		if len(dep.Namespace) > 0 {

--- a/pkg/inject/sidecar_test.go
+++ b/pkg/inject/sidecar_test.go
@@ -59,23 +59,20 @@ func TestInjectSidecarWithEnvVars(t *testing.T) {
 }
 
 func TestInjectSidecarWithEnvVarsK8sAppName(t *testing.T) {
-	jaeger := v1.NewJaeger("TestInjectSidecarWithEnvVars")
+	jaeger := v1.NewJaeger("TestInjectSidecarWithEnvVarsK8sAppName")
 	dep := dep(map[string]string{Annotation: jaeger.Name}, map[string]string{
 		"app":                    "noapp",
 		"app.kubernetes.io/name": "testapp",
 	})
 	dep = Sidecar(jaeger, dep)
 	assert.Len(t, dep.Spec.Template.Spec.Containers, 2)
-	assert.Contains(t, dep.Spec.Template.Spec.Containers[1].Image, "jaeger-agent")
 	assert.Len(t, dep.Spec.Template.Spec.Containers[0].Env, 2)
 	assert.Equal(t, envVarServiceName, dep.Spec.Template.Spec.Containers[0].Env[0].Name)
 	assert.Equal(t, "testapp.default", dep.Spec.Template.Spec.Containers[0].Env[0].Value)
-	assert.Equal(t, envVarPropagation, dep.Spec.Template.Spec.Containers[0].Env[1].Name)
-	assert.Equal(t, "jaeger,b3", dep.Spec.Template.Spec.Containers[0].Env[1].Value)
 }
 
 func TestInjectSidecarWithEnvVarsK8sAppInstance(t *testing.T) {
-	jaeger := v1.NewJaeger("TestInjectSidecarWithEnvVars")
+	jaeger := v1.NewJaeger("TestInjectSidecarWithEnvVarsK8sAppInstance")
 	dep := dep(map[string]string{Annotation: jaeger.Name}, map[string]string{
 		"app":                        "noapp",
 		"app.kubernetes.io/name":     "noname",
@@ -83,12 +80,9 @@ func TestInjectSidecarWithEnvVarsK8sAppInstance(t *testing.T) {
 	})
 	dep = Sidecar(jaeger, dep)
 	assert.Len(t, dep.Spec.Template.Spec.Containers, 2)
-	assert.Contains(t, dep.Spec.Template.Spec.Containers[1].Image, "jaeger-agent")
 	assert.Len(t, dep.Spec.Template.Spec.Containers[0].Env, 2)
 	assert.Equal(t, envVarServiceName, dep.Spec.Template.Spec.Containers[0].Env[0].Name)
 	assert.Equal(t, "testapp.default", dep.Spec.Template.Spec.Containers[0].Env[0].Value)
-	assert.Equal(t, envVarPropagation, dep.Spec.Template.Spec.Containers[0].Env[1].Name)
-	assert.Equal(t, "jaeger,b3", dep.Spec.Template.Spec.Containers[0].Env[1].Value)
 }
 
 func TestInjectSidecarWithEnvVarsWithNamespace(t *testing.T) {

--- a/pkg/inject/sidecar_test.go
+++ b/pkg/inject/sidecar_test.go
@@ -58,6 +58,39 @@ func TestInjectSidecarWithEnvVars(t *testing.T) {
 	assert.Equal(t, "jaeger,b3", dep.Spec.Template.Spec.Containers[0].Env[1].Value)
 }
 
+func TestInjectSidecarWithEnvVarsK8sAppName(t *testing.T) {
+	jaeger := v1.NewJaeger("TestInjectSidecarWithEnvVars")
+	dep := dep(map[string]string{Annotation: jaeger.Name}, map[string]string{
+		"app":                    "noapp",
+		"app.kubernetes.io/name": "testapp",
+	})
+	dep = Sidecar(jaeger, dep)
+	assert.Len(t, dep.Spec.Template.Spec.Containers, 2)
+	assert.Contains(t, dep.Spec.Template.Spec.Containers[1].Image, "jaeger-agent")
+	assert.Len(t, dep.Spec.Template.Spec.Containers[0].Env, 2)
+	assert.Equal(t, envVarServiceName, dep.Spec.Template.Spec.Containers[0].Env[0].Name)
+	assert.Equal(t, "testapp.default", dep.Spec.Template.Spec.Containers[0].Env[0].Value)
+	assert.Equal(t, envVarPropagation, dep.Spec.Template.Spec.Containers[0].Env[1].Name)
+	assert.Equal(t, "jaeger,b3", dep.Spec.Template.Spec.Containers[0].Env[1].Value)
+}
+
+func TestInjectSidecarWithEnvVarsK8sAppInstance(t *testing.T) {
+	jaeger := v1.NewJaeger("TestInjectSidecarWithEnvVars")
+	dep := dep(map[string]string{Annotation: jaeger.Name}, map[string]string{
+		"app":                        "noapp",
+		"app.kubernetes.io/name":     "noname",
+		"app.kubernetes.io/instance": "testapp",
+	})
+	dep = Sidecar(jaeger, dep)
+	assert.Len(t, dep.Spec.Template.Spec.Containers, 2)
+	assert.Contains(t, dep.Spec.Template.Spec.Containers[1].Image, "jaeger-agent")
+	assert.Len(t, dep.Spec.Template.Spec.Containers[0].Env, 2)
+	assert.Equal(t, envVarServiceName, dep.Spec.Template.Spec.Containers[0].Env[0].Name)
+	assert.Equal(t, "testapp.default", dep.Spec.Template.Spec.Containers[0].Env[0].Value)
+	assert.Equal(t, envVarPropagation, dep.Spec.Template.Spec.Containers[0].Env[1].Name)
+	assert.Equal(t, "jaeger,b3", dep.Spec.Template.Spec.Containers[0].Env[1].Value)
+}
+
 func TestInjectSidecarWithEnvVarsWithNamespace(t *testing.T) {
 	jaeger := v1.NewJaeger("TestInjectSidecarWithEnvVarsWithNamespace")
 	dep := dep(map[string]string{Annotation: jaeger.Name}, map[string]string{"app": "testapp"})


### PR DESCRIPTION
…ded labels

Order of precedence is `app.kubernetes.io/instance`, if not found then, `app.kubernetes.io/name` and finally `app` (as now).

Fixes #352 

Signed-off-by: Gary Brown <gary@brownuk.com>