### PR TITLE
Enhance ES index cleaner e2e test to verify indices have been removed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,8 @@ format:
 .PHONY: lint
 lint:
 	@echo Linting...
-	@golint -set_exit_status=1 $(PACKAGES)
-	@gosec -quiet -exclude=G104 $(PACKAGES) 2>/dev/null
+	golint -set_exit_status=1 $(PACKAGES)
+	gosec -quiet -exclude=G104 $(PACKAGES) 2>/dev/null
 
 .PHONY: build
 build: format

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ format:
 lint:
 	@echo Linting...
 	golint -set_exit_status=1 $(PACKAGES)
-	gosec -quiet -exclude=G104 $(PACKAGES) 2>/dev/null
+	#gosec -quiet -exclude=G104 $(PACKAGES) 2>/dev/null
 
 .PHONY: build
 build: format

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,8 @@ lint:
 .PHONY: security
 security:
 	@echo Security...
-	@gosec -exclude=G104 $(PACKAGES)
+	@echo NOTE: Currently disabled due to https://github.com/jaegertracing/jaeger-operator/issues/379
+	@#gosec -exclude=G104 $(PACKAGES)
 
 .PHONY: build
 build: format

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ lint:
 .PHONY: security
 security:
 	@echo Security...
-	@gosec -exclude=G104 ./...
+	@gosec -exclude=G104 $(PACKAGES)
 
 .PHONY: build
 build: format

--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,8 @@ format:
 .PHONY: lint
 lint:
 	@echo Linting...
-	golint -set_exit_status=1 $(PACKAGES)
-	#gosec -quiet -exclude=G104 $(PACKAGES) 2>/dev/null
+	@golint -set_exit_status=1 $(PACKAGES)
+	@gosec -quiet -exclude=G104 $(PACKAGES) 2>/dev/null
 
 .PHONY: build
 build: format

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ lint:
 .PHONY: security
 security:
 	@echo Security...
-	@gosec -exclude=G104 ./... 2>/dev/null
+	@gosec -exclude=G104 ./...
 
 .PHONY: build
 build: format

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,11 @@ format:
 lint:
 	@echo Linting...
 	@golint -set_exit_status=1 $(PACKAGES)
-	@gosec -quiet -exclude=G104 $(PACKAGES) 2>/dev/null
+
+.PHONY: security
+security:
+	@echo Security...
+	@gosec -exclude=G104 ./... 2>/dev/null
 
 .PHONY: build
 build: format
@@ -159,10 +163,10 @@ generate:
 test: unit-tests e2e-tests
 
 .PHONY: all
-all: check format lint build test
+all: check format lint security build test
 
 .PHONY: ci
-ci: ensure-generate-is-noop check format lint build unit-tests
+ci: ensure-generate-is-noop check format lint security build unit-tests
 
 .PHONY: scorecard
 scorecard:

--- a/pkg/apis/jaegertracing/v1/jaeger_types.go
+++ b/pkg/apis/jaegertracing/v1/jaeger_types.go
@@ -223,7 +223,7 @@ type JaegerDependenciesSpec struct {
 // +k8s:openapi-gen=true
 type JaegerEsIndexCleanerSpec struct {
 	Enabled      *bool  `json:"enabled"`
-	NumberOfDays int    `json:"numberOfDays"`
+	NumberOfDays *int   `json:"numberOfDays"`
 	Schedule     string `json:"schedule"`
 	Image        string `json:"image"`
 }

--- a/pkg/apis/jaegertracing/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/jaegertracing/v1/zz_generated.deepcopy.go
@@ -258,6 +258,11 @@ func (in *JaegerEsIndexCleanerSpec) DeepCopyInto(out *JaegerEsIndexCleanerSpec) 
 		*out = new(bool)
 		**out = **in
 	}
+	if in.NumberOfDays != nil {
+		in, out := &in.NumberOfDays, &out.NumberOfDays
+		*out = new(int)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/cronjob/es_index_cleaner.go
+++ b/pkg/cronjob/es_index_cleaner.go
@@ -66,7 +66,7 @@ func CreateEsIndexCleaner(jaeger *v1.Jaeger) *batchv1beta1.CronJob {
 								{
 									Name:    name,
 									Image:   jaeger.Spec.Storage.EsIndexCleaner.Image,
-									Args:    []string{strconv.Itoa(jaeger.Spec.Storage.EsIndexCleaner.NumberOfDays), esUrls},
+									Args:    []string{strconv.Itoa(*jaeger.Spec.Storage.EsIndexCleaner.NumberOfDays), esUrls},
 									Env:     esScriptEnvVars(jaeger.Spec.Storage.Options),
 									EnvFrom: envFromSource,
 								},

--- a/pkg/cronjob/es_index_cleaner_test.go
+++ b/pkg/cronjob/es_index_cleaner_test.go
@@ -11,6 +11,8 @@ import (
 func TestCreateEsIndexCleaner(t *testing.T) {
 	jaeger := &v1.Jaeger{Spec: v1.JaegerSpec{Storage: v1.JaegerStorageSpec{Options: v1.NewOptions(
 		map[string]interface{}{"es.index-prefix": "tenant1", "es.server-urls": "http://nowhere:666,foo"})}}}
+	days := 0
+	jaeger.Spec.Storage.EsIndexCleaner.NumberOfDays = &days
 	cronJob := CreateEsIndexCleaner(jaeger)
 	assert.Equal(t, 2, len(cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Args))
 	// default number of days (7) is applied in normalize in controller
@@ -25,6 +27,8 @@ func TestEsIndexCleanerSecrets(t *testing.T) {
 	secret := "mysecret"
 	jaeger.Spec.Storage.SecretName = secret
 
+	days := 0
+	jaeger.Spec.Storage.EsIndexCleaner.NumberOfDays = &days
 	cronJob := CreateEsIndexCleaner(jaeger)
 	assert.Equal(t, secret, cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].EnvFrom[0].SecretRef.LocalObjectReference.Name)
 }

--- a/pkg/strategy/all-in-one_test.go
+++ b/pkg/strategy/all-in-one_test.go
@@ -166,21 +166,22 @@ func TestEsIndexCleanerAllInOne(t *testing.T) {
 
 func testEsIndexCleaner(t *testing.T, fce func(jaeger *v1.Jaeger) S) {
 	trueVar := true
+	days := 0
 	tests := []struct {
 		jaeger              *v1.Jaeger
 		sparkCronJobEnabled bool
 	}{
 		{jaeger: &v1.Jaeger{Spec: v1.JaegerSpec{
 			Storage: v1.JaegerStorageSpec{Type: "elasticsearch",
-				EsIndexCleaner: v1.JaegerEsIndexCleanerSpec{Enabled: &trueVar}},
+				EsIndexCleaner: v1.JaegerEsIndexCleanerSpec{Enabled: &trueVar, NumberOfDays: &days}},
 		}}, sparkCronJobEnabled: true},
 		{jaeger: &v1.Jaeger{Spec: v1.JaegerSpec{
 			Storage: v1.JaegerStorageSpec{Type: "cassandra",
-				EsIndexCleaner: v1.JaegerEsIndexCleanerSpec{Enabled: &trueVar}},
+				EsIndexCleaner: v1.JaegerEsIndexCleanerSpec{Enabled: &trueVar, NumberOfDays: &days}},
 		}}, sparkCronJobEnabled: false},
 		{jaeger: &v1.Jaeger{Spec: v1.JaegerSpec{
 			Storage: v1.JaegerStorageSpec{Type: "kafka",
-				EsIndexCleaner: v1.JaegerEsIndexCleanerSpec{Enabled: &trueVar}},
+				EsIndexCleaner: v1.JaegerEsIndexCleanerSpec{Enabled: &trueVar, NumberOfDays: &days}},
 		}}, sparkCronJobEnabled: false},
 		{jaeger: &v1.Jaeger{Spec: v1.JaegerSpec{
 			Storage: v1.JaegerStorageSpec{Type: "elasticsearch"},

--- a/pkg/strategy/controller.go
+++ b/pkg/strategy/controller.go
@@ -116,8 +116,9 @@ func normalizeIndexCleaner(spec *v1.JaegerEsIndexCleanerSpec, storage string) {
 	if spec.Schedule == "" {
 		spec.Schedule = "55 23 * * *"
 	}
-	if spec.NumberOfDays == 0 {
-		spec.NumberOfDays = 7
+	if spec.NumberOfDays == nil {
+		defDays := 7
+		spec.NumberOfDays = &defDays
 	}
 }
 

--- a/pkg/strategy/controller_test.go
+++ b/pkg/strategy/controller_test.go
@@ -169,14 +169,16 @@ func TestNormalizeIndexCleaner(t *testing.T) {
 	defer viper.Reset()
 	trueVar := true
 	falseVar := false
+	days7 := 7
+	days55 := 55
 	tests := []struct {
 		underTest v1.JaegerEsIndexCleanerSpec
 		expected  v1.JaegerEsIndexCleanerSpec
 	}{
 		{underTest: v1.JaegerEsIndexCleanerSpec{},
-			expected: v1.JaegerEsIndexCleanerSpec{Image: "foo", Schedule: "55 23 * * *", NumberOfDays: 7, Enabled: &trueVar}},
-		{underTest: v1.JaegerEsIndexCleanerSpec{Image: "bla", Schedule: "lol", NumberOfDays: 55, Enabled: &falseVar},
-			expected: v1.JaegerEsIndexCleanerSpec{Image: "bla", Schedule: "lol", NumberOfDays: 55, Enabled: &falseVar}},
+			expected: v1.JaegerEsIndexCleanerSpec{Image: "foo", Schedule: "55 23 * * *", NumberOfDays: &days7, Enabled: &trueVar}},
+		{underTest: v1.JaegerEsIndexCleanerSpec{Image: "bla", Schedule: "lol", NumberOfDays: &days55, Enabled: &falseVar},
+			expected: v1.JaegerEsIndexCleanerSpec{Image: "bla", Schedule: "lol", NumberOfDays: &days55, Enabled: &falseVar}},
 	}
 	for _, test := range tests {
 		normalizeIndexCleaner(&test.underTest, "elasticsearch")

--- a/test/e2e/es_index_cleaner_test.go
+++ b/test/e2e/es_index_cleaner_test.go
@@ -98,6 +98,16 @@ func esIndexCleanerTest(t *testing.T, f *framework.Framework, testCtx *framework
 		return fmt.Errorf("jaeger-span index not found prior to es-index-cleaner: err = %v", err)
 	}
 
+	err = WaitForCronJob(t, f.KubeClient, namespace, fmt.Sprintf("%s-es-index-cleaner", name), retryInterval, timeout)
+	if err != nil {
+		return err
+	}
+
+	err = WaitForJobOfAnOwner(t, f.KubeClient, namespace, fmt.Sprintf("%s-es-index-cleaner", name), retryInterval, timeout)
+	if err != nil {
+		return err
+	}
+
 	return wait.Poll(retryInterval, timeout, func() (done bool, err error) {
 		flag, err := hasIndex(t)
 		return !flag, err


### PR DESCRIPTION
Existing test only verifies that the cronjob completes successfully.

This PR extends the test to verify that the job has correctly triggered the es-index-cleaner image and that the task has been performed correctly (i.e. the indices have been removed).

Signed-off-by: Gary Brown <gary@brownuk.com>