### PR TITLE
Fix race condition in test, remove hard-coded namespace

### DIFF
--- a/test/e2e/es_index_cleaner_test.go
+++ b/test/e2e/es_index_cleaner_test.go
@@ -83,7 +83,7 @@ func esIndexCleanerTest(t *testing.T, f *framework.Framework, testCtx *framework
 		return err
 	}
 
-	esPod, err := GetPod("default", "elasticsearch", "elasticsearch", f.KubeClient)
+	esPod, err := GetPod(storageNamespace, "elasticsearch", "elasticsearch", f.KubeClient)
 	if err != nil {
 		return err
 	}

--- a/test/e2e/smoketest.go
+++ b/test/e2e/smoketest.go
@@ -43,12 +43,10 @@ func SmokeTest(apiTracesEndpoint, collectorEndpoint, serviceName string, interva
 		bodyBytes, err := ioutil.ReadAll(resp.Body)
 		bodyString := string(bodyBytes)
 
+
 		if !strings.Contains(bodyString, "errors\":null") {
 			return false, errors.New("query service returns errors")
-		} else if (strings.Contains(bodyString, tStr)) {
-			return true, nil
-		} else {
-			return false, nil
 		}
+		return strings.Contains(bodyString, tStr), nil
 	})
 }

--- a/test/e2e/smoketest.go
+++ b/test/e2e/smoketest.go
@@ -43,12 +43,12 @@ func SmokeTest(apiTracesEndpoint, collectorEndpoint, serviceName string, interva
 		bodyBytes, err := ioutil.ReadAll(resp.Body)
 		bodyString := string(bodyBytes)
 
-		if (strings.Contains(bodyString, tStr)) {
-			return true, nil
-		} else if !strings.Contains(bodyString, "errors\":null") {
+		if !strings.Contains(bodyString, "errors\":null") {
 			return false, errors.New("query service returns errors")
+		} else if (strings.Contains(bodyString, tStr)) {
+			return true, nil
+		} else {
+			return false, nil
 		}
-
-		return false, nil
 	})
 }

--- a/test/e2e/smoketest.go
+++ b/test/e2e/smoketest.go
@@ -43,12 +43,12 @@ func SmokeTest(apiTracesEndpoint, collectorEndpoint, serviceName string, interva
 		bodyBytes, err := ioutil.ReadAll(resp.Body)
 		bodyString := string(bodyBytes)
 
-		if !strings.Contains(bodyString, "errors\":null") {
+		if (strings.Contains(bodyString, tStr)) {
+			return true, nil
+		} else if !strings.Contains(bodyString, "errors\":null") {
 			return false, errors.New("query service returns errors")
 		}
-		if !strings.Contains(bodyString, tStr) {
-			return false, errors.New("query service does not return spans")
-		}
-		return true, nil
+
+		return false, nil
 	})
 }


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com>

This fixes #380 where the test would fail if we did the http get before the span got flushed.  I've also removed the hardcoded namespace of "default" from the es_index_cleaner_test.