### PR TITLE
Fix rbac policy issue with blockOwnerDeletion

### DIFF
--- a/pkg/cmd/start/main.go
+++ b/pkg/cmd/start/main.go
@@ -250,12 +250,11 @@ func setOwnerReference(operatorService *corev1.Service) error {
 	flag := true
 	operatorService.OwnerReferences = []metav1.OwnerReference{
 		metav1.OwnerReference{
-			APIVersion:         "apps/v1",
-			Kind:               "Deployment",
-			Name:               deployment.Name,
-			UID:                deployment.UID,
-			Controller:         &flag,
-			BlockOwnerDeletion: &flag,
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+			Name:       deployment.Name,
+			UID:        deployment.UID,
+			Controller: &flag,
 		},
 	}
 


### PR DESCRIPTION
Fixes #383 

Tested on minishift and minikube - to make sure operator deploys ok, but also that the service jaeger-operator is still removed when operator uninstalled.

Signed-off-by: Gary Brown <gary@brownuk.com>