### PR TITLE
Make sure to call ctx.cleanup if prepare() fails

### DIFF
--- a/test/e2e/all_in_one_test.go
+++ b/test/e2e/all_in_one_test.go
@@ -35,7 +35,12 @@ type AllInOneTestSuite struct {
 
 func(suite *AllInOneTestSuite) SetupSuite() {
 	t = suite.T()
-	ctx = prepare(t)
+	var err error
+	ctx, err = prepare(t)
+	if (err != nil) {
+		ctx.Cleanup()
+		require.FailNow(t, "Failed in prepare")
+	}
 	fw = framework.Global
 	namespace, _ = ctx.GetNamespace()
 	require.NotNil(t, namespace, "GetNamespace failed")

--- a/test/e2e/cassandra.go
+++ b/test/e2e/cassandra.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
 	log "github.com/sirupsen/logrus"
@@ -15,7 +16,11 @@ import (
 
 // Cassandra runs a test with Cassandra as the backing storage
 func Cassandra(t *testing.T) {
-	ctx := prepare(t)
+	ctx, err := prepare(t)
+	if (err != nil) {
+		ctx.Cleanup()
+		require.FailNow(t, "Failed in prepare")
+	}
 	defer ctx.Cleanup()
 
 	if err := cassandraTest(t, framework.Global, ctx); err != nil {

--- a/test/e2e/daemonset_test.go
+++ b/test/e2e/daemonset_test.go
@@ -35,7 +35,12 @@ type DaemonSetTestSuite struct {
 
 func(suite *DaemonSetTestSuite) SetupSuite() {
 	t = suite.T()
-	ctx = prepare(t)
+	var err error
+	ctx, err = prepare(t)
+	if (err != nil) {
+		ctx.Cleanup()
+		require.FailNow(t, "Failed in prepare")
+	}
 	fw = framework.Global
 	namespace, _ = ctx.GetNamespace()
 	require.NotNil(t, namespace, "GetNamespace failed")

--- a/test/e2e/es_index_cleaner_test.go
+++ b/test/e2e/es_index_cleaner_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,7 +18,11 @@ import (
 )
 
 func EsIndexCleaner(t *testing.T) {
-	testCtx := prepare(t)
+	testCtx, err := prepare(t)
+	if (err != nil) {
+		ctx.Cleanup()
+		require.FailNow(t, "Failed in prepare")
+	}
 	defer testCtx.Cleanup()
 	if err := esIndexCleanerTest(t, framework.Global, testCtx); err != nil {
 		t.Fatal(err)

--- a/test/e2e/production_test.go
+++ b/test/e2e/production_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -13,7 +14,11 @@ import (
 )
 
 func SimpleProd(t *testing.T) {
-	ctx := prepare(t)
+	ctx, err := prepare(t)
+	if (err != nil) {
+		ctx.Cleanup()
+		require.FailNow(t, "Failed in prepare")
+	}
 	defer ctx.Cleanup()
 
 	if err := simpleProd(t, framework.Global, ctx); err != nil {

--- a/test/e2e/self_provisioned_elasticsearch.go
+++ b/test/e2e/self_provisioned_elasticsearch.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -14,7 +15,11 @@ import (
 )
 
 func SelfProvisionedESSmokeTest(t *testing.T) {
-	ctx := prepare(t)
+	ctx, err := prepare(t)
+	if (err != nil) {
+		ctx.Cleanup()
+		require.FailNow(t, "Failed in prepare")
+	}
 	defer ctx.Cleanup()
 
 	if err := selfProvisionedESSmokeTest(t, framework.Global, ctx); err != nil {

--- a/test/e2e/sidecar_test.go
+++ b/test/e2e/sidecar_test.go
@@ -31,7 +31,12 @@ type SidecarTestSuite struct {
 
 func(suite *SidecarTestSuite) SetupSuite() {
 	t = suite.T()
-	ctx = prepare(t)
+	var err error
+	ctx, err = prepare(t)
+	if (err != nil) {
+		ctx.Cleanup()
+		require.FailNow(t, "Failed in prepare")
+	}
 	fw = framework.Global
 	namespace, _ = ctx.GetNamespace()
 	require.NotNil(t, namespace, "GetNamespace failed")

--- a/test/e2e/simplest_test.go
+++ b/test/e2e/simplest_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -13,7 +14,11 @@ import (
 )
 
 func SimplestJaeger(t *testing.T) {
-	ctx := prepare(t)
+	ctx, err := prepare(t)
+	if (err != nil) {
+		ctx.Cleanup()
+		require.FailNow(t, "Failed in prepare")
+	}
 	defer ctx.Cleanup()
 
 	if err := simplest(t, framework.Global, ctx); err != nil {

--- a/test/e2e/spark_dependencies_test.go
+++ b/test/e2e/spark_dependencies_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -13,7 +14,11 @@ import (
 )
 
 func SparkDependenciesElasticsearch(t *testing.T) {
-	testCtx := prepare(t)
+	testCtx, err := prepare(t)
+	if (err != nil) {
+		testCtx.Cleanup()
+		require.FailNow(t, "Failed in prepare")
+	}
 	defer testCtx.Cleanup()
 	storage := v1.JaegerStorageSpec{
 		Type: "elasticsearch",
@@ -27,7 +32,11 @@ func SparkDependenciesElasticsearch(t *testing.T) {
 }
 
 func SparkDependenciesCassandra(t *testing.T) {
-	testCtx := prepare(t)
+	testCtx, err := prepare(t)
+	if (err != nil) {
+		testCtx.Cleanup()
+		require.FailNow(t, "Failed in prepare")
+	}
 	defer testCtx.Cleanup()
 
 	storage := v1.JaegerStorageSpec{

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -7,19 +7,19 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-	"k8s.io/client-go/discovery"
-	"k8s.io/client-go/rest"
-	framework "github.com/operator-framework/operator-sdk/pkg/test"
-	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	osv1 "github.com/openshift/api/route/v1"
 	osv1sec "github.com/openshift/api/security/v1"
+	framework "github.com/operator-framework/operator-sdk/pkg/test"
+	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/apis"
+	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 )
 
 var (
@@ -52,7 +52,7 @@ func GetPod(namespace, namePrefix, containsImage string, kubeclient kubernetes.I
 	return corev1.Pod{}, fmt.Errorf("could not find pod with image %s", containsImage)
 }
 
-func prepare(t *testing.T) *framework.TestCtx {
+func prepare(t *testing.T) (*framework.TestCtx, error) {
 	ctx := framework.NewTestCtx(t)
 	err := ctx.InitializeClusterResources(&framework.CleanupOptions{TestContext: ctx, Timeout: timeout, RetryInterval: retryInterval})
 	if err != nil {
@@ -70,10 +70,10 @@ func prepare(t *testing.T) *framework.TestCtx {
 	// wait for the operator to be ready
 	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "jaeger-operator", 1, retryInterval, timeout)
 	if err != nil {
-		t.Fatal(err)
+		return nil, err
 	}
 
-	return ctx
+	return ctx, nil
 }
 
 func isOpenShift(t *testing.T) bool {


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com>

This fixed #388   Currently if tests fail during the prepare() call ctx.cleanup() will not be called and the namespace created for the test does not get cleaned up.
