### PR TITLE
Improve error message when queries fail

### DIFF
--- a/test/e2e/smoketest.go
+++ b/test/e2e/smoketest.go
@@ -45,7 +45,7 @@ func SmokeTest(apiTracesEndpoint, collectorEndpoint, serviceName string, interva
 
 
 		if !strings.Contains(bodyString, "errors\":null") {
-			return false, errors.New("query service returns errors")
+			return false, errors.New("query service returns errors: " + bodyString)
 		}
 		return strings.Contains(bodyString, tStr), nil
 	})


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com>

If the smoketest fails it will now return the body of the response so we can see what caused the failure.