### PR TITLE
Check that context is not nil before calling cleanup

### DIFF
--- a/test/e2e/all_in_one_test.go
+++ b/test/e2e/all_in_one_test.go
@@ -38,7 +38,9 @@ func(suite *AllInOneTestSuite) SetupSuite() {
 	var err error
 	ctx, err = prepare(t)
 	if (err != nil) {
-		ctx.Cleanup()
+		if ctx != nil {
+			ctx.Cleanup()
+		}
 		require.FailNow(t, "Failed in prepare")
 	}
 	fw = framework.Global

--- a/test/e2e/cassandra_test.go
+++ b/test/e2e/cassandra_test.go
@@ -25,7 +25,9 @@ func(suite *CassandraTestSuite) SetupSuite() {
 	var err error
 	ctx, err = prepare(t)
 	if (err != nil) {
-		ctx.Cleanup()
+		if ctx != nil {
+			ctx.Cleanup()
+		}
 		require.FailNow(t, "Failed in prepare")
 	}
 	fw = framework.Global

--- a/test/e2e/daemonset_test.go
+++ b/test/e2e/daemonset_test.go
@@ -38,7 +38,9 @@ func(suite *DaemonSetTestSuite) SetupSuite() {
 	var err error
 	ctx, err = prepare(t)
 	if (err != nil) {
-		ctx.Cleanup()
+		if ctx != nil {
+			ctx.Cleanup()
+		}
 		require.FailNow(t, "Failed in prepare")
 	}
 	fw = framework.Global

--- a/test/e2e/elasticsearch_test.go
+++ b/test/e2e/elasticsearch_test.go
@@ -31,7 +31,9 @@ func(suite *ElasticSearchTestSuite) SetupSuite() {
 	var err error
 	ctx, err = prepare(t)
 	if (err != nil) {
-		ctx.Cleanup()
+		if ctx != nil {
+			ctx.Cleanup()
+		}
 		require.FailNow(t, "Failed in prepare")
 	}
 	fw = framework.Global

--- a/test/e2e/sidecar_test.go
+++ b/test/e2e/sidecar_test.go
@@ -34,7 +34,9 @@ func(suite *SidecarTestSuite) SetupSuite() {
 	var err error
 	ctx, err = prepare(t)
 	if (err != nil) {
-		ctx.Cleanup()
+		if ctx != nil {
+			ctx.Cleanup()
+		}
 		require.FailNow(t, "Failed in prepare")
 	}
 	fw = framework.Global

--- a/test/e2e/spark_dependencies_test.go
+++ b/test/e2e/spark_dependencies_test.go
@@ -16,7 +16,9 @@ import (
 func SparkDependenciesElasticsearch(t *testing.T) {
 	testCtx, err := prepare(t)
 	if (err != nil) {
-		testCtx.Cleanup()
+		if testCtx != nil {
+			testCtx.Cleanup()
+		}
 		require.FailNow(t, "Failed in prepare")
 	}
 	defer testCtx.Cleanup()

--- a/test/e2e/streaming_test.go
+++ b/test/e2e/streaming_test.go
@@ -25,7 +25,9 @@ func (suite *StreamingTestSuite) SetupSuite() {
 	var err error
 	ctx, err = prepare(t)
 	if err != nil {
-		ctx.Cleanup()
+		if ctx != nil {
+			ctx.Cleanup()
+		}
 		require.FailNow(t, "Failed in prepare")
 	}
 	fw = framework.Global


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com>

If prepare fails verify that the context is not nil before calling cleanup.
