### PR TITLE
Correct usage of testing.T

### DIFF
--- a/test/e2e/all_in_one_test.go
+++ b/test/e2e/all_in_one_test.go
@@ -34,7 +34,7 @@ type AllInOneTestSuite struct {
 }
 
 func(suite *AllInOneTestSuite) SetupSuite() {
-	t := suite.T()
+	t = suite.T()
 	var err error
 	ctx, err = prepare(t)
 	if (err != nil) {
@@ -59,8 +59,11 @@ func TestAllInOneSuite(t *testing.T) {
 	suite.Run(t, new(AllInOneTestSuite))
 }
 
+func (suite *AllInOneTestSuite) SetupTest() {
+	t = suite.T()
+}
+
 func (suite *AllInOneTestSuite) TestAllInOne() {
-	t := suite.T()
 	// create jaeger custom resource
 	exampleJaeger := getJaegerAllInOneDefinition(namespace, "my-jaeger")
 
@@ -73,7 +76,6 @@ func (suite *AllInOneTestSuite) TestAllInOne() {
 }
 
 func (suite *AllInOneTestSuite) TestAllInOneWithIngress()  {
-	t := suite.T()
 	// create jaeger custom resource
 	ingressEnabled := true
 	name := "my-jaeger-with-ingress"
@@ -146,7 +148,6 @@ func (suite *AllInOneTestSuite) TestAllInOneWithIngress()  {
 }
 
 func (suite *AllInOneTestSuite)  TestAllInOneWithUIConfig()  {
-	t := suite.T()
 	cleanupOptions := &framework.CleanupOptions{TestContext: ctx, Timeout: timeout, RetryInterval: retryInterval}
 	basePath := "/jaeger"
 

--- a/test/e2e/all_in_one_test.go
+++ b/test/e2e/all_in_one_test.go
@@ -34,7 +34,7 @@ type AllInOneTestSuite struct {
 }
 
 func(suite *AllInOneTestSuite) SetupSuite() {
-	t = suite.T()
+	t := suite.T()
 	var err error
 	ctx, err = prepare(t)
 	if (err != nil) {
@@ -60,6 +60,7 @@ func TestAllInOneSuite(t *testing.T) {
 }
 
 func (suite *AllInOneTestSuite) TestAllInOne() {
+	t := suite.T()
 	// create jaeger custom resource
 	exampleJaeger := getJaegerAllInOneDefinition(namespace, "my-jaeger")
 
@@ -72,6 +73,7 @@ func (suite *AllInOneTestSuite) TestAllInOne() {
 }
 
 func (suite *AllInOneTestSuite) TestAllInOneWithIngress()  {
+	t := suite.T()
 	// create jaeger custom resource
 	ingressEnabled := true
 	name := "my-jaeger-with-ingress"
@@ -144,6 +146,7 @@ func (suite *AllInOneTestSuite) TestAllInOneWithIngress()  {
 }
 
 func (suite *AllInOneTestSuite)  TestAllInOneWithUIConfig()  {
+	t := suite.T()
 	cleanupOptions := &framework.CleanupOptions{TestContext: ctx, Timeout: timeout, RetryInterval: retryInterval}
 	basePath := "/jaeger"
 

--- a/test/e2e/cassandra_test.go
+++ b/test/e2e/cassandra_test.go
@@ -21,7 +21,7 @@ type CassandraTestSuite struct {
 }
 
 func(suite *CassandraTestSuite) SetupSuite() {
-	t = suite.T()
+	t := suite.T()
 	var err error
 	ctx, err = prepare(t)
 	if (err != nil) {
@@ -48,6 +48,7 @@ func TestCassandraSuite(t *testing.T) {
 
 // Cassandra runs a test with Cassandra as the backing storage
 func (suite *CassandraTestSuite) TestCassandra()  {
+	t := suite.T()
 	cleanupOptions := &framework.CleanupOptions{TestContext: ctx, Timeout: timeout, RetryInterval: retryInterval}
 	j := getJaegerWithCassandra(namespace)
 
@@ -73,6 +74,7 @@ func (suite *CassandraTestSuite) TestCassandra()  {
 }
 
 func (suite *CassandraTestSuite) TestCassandraSparkDependencies()  {
+	t := suite.T()
 	storage := v1.JaegerStorageSpec{
 		Type: "cassandra",
 		Options: v1.NewOptions(map[string]interface{}{"cassandra.servers": cassandraServiceName, "cassandra.keyspace": "jaeger_v1_datacenter1"}),

--- a/test/e2e/cassandra_test.go
+++ b/test/e2e/cassandra_test.go
@@ -21,7 +21,7 @@ type CassandraTestSuite struct {
 }
 
 func(suite *CassandraTestSuite) SetupSuite() {
-	t := suite.T()
+	t = suite.T()
 	var err error
 	ctx, err = prepare(t)
 	if (err != nil) {
@@ -46,9 +46,12 @@ func TestCassandraSuite(t *testing.T) {
 	suite.Run(t, new(CassandraTestSuite))
 }
 
+func (suite *CassandraTestSuite) SetupTest() {
+	t = suite.T()
+}
+
 // Cassandra runs a test with Cassandra as the backing storage
 func (suite *CassandraTestSuite) TestCassandra()  {
-	t := suite.T()
 	cleanupOptions := &framework.CleanupOptions{TestContext: ctx, Timeout: timeout, RetryInterval: retryInterval}
 	j := getJaegerWithCassandra(namespace)
 
@@ -74,7 +77,6 @@ func (suite *CassandraTestSuite) TestCassandra()  {
 }
 
 func (suite *CassandraTestSuite) TestCassandraSparkDependencies()  {
-	t := suite.T()
 	storage := v1.JaegerStorageSpec{
 		Type: "cassandra",
 		Options: v1.NewOptions(map[string]interface{}{"cassandra.servers": cassandraServiceName, "cassandra.keyspace": "jaeger_v1_datacenter1"}),

--- a/test/e2e/daemonset_test.go
+++ b/test/e2e/daemonset_test.go
@@ -34,7 +34,7 @@ type DaemonSetTestSuite struct {
 }
 
 func(suite *DaemonSetTestSuite) SetupSuite() {
-	t = suite.T()
+	t := suite.T()
 	var err error
 	ctx, err = prepare(t)
 	if (err != nil) {
@@ -61,6 +61,7 @@ func TestDaemonSetSuite(t *testing.T) {
 
 // DaemonSet runs a test with the agent as DaemonSet
 func (suite *DaemonSetTestSuite) TestDaemonSet()  {
+	t := suite.T()
 	cleanupOptions := &framework.CleanupOptions{TestContext: ctx, Timeout: timeout, RetryInterval: retryInterval}
 
 	if isOpenShift(t) {

--- a/test/e2e/daemonset_test.go
+++ b/test/e2e/daemonset_test.go
@@ -34,7 +34,7 @@ type DaemonSetTestSuite struct {
 }
 
 func(suite *DaemonSetTestSuite) SetupSuite() {
-	t := suite.T()
+	t = suite.T()
 	var err error
 	ctx, err = prepare(t)
 	if (err != nil) {
@@ -59,9 +59,12 @@ func TestDaemonSetSuite(t *testing.T) {
 	suite.Run(t, new(DaemonSetTestSuite))
 }
 
+func (suite *DaemonSetTestSuite) SetupTest() {
+	t = suite.T()
+}
+
 // DaemonSet runs a test with the agent as DaemonSet
 func (suite *DaemonSetTestSuite) TestDaemonSet()  {
-	t := suite.T()
 	cleanupOptions := &framework.CleanupOptions{TestContext: ctx, Timeout: timeout, RetryInterval: retryInterval}
 
 	if isOpenShift(t) {

--- a/test/e2e/elasticsearch_test.go
+++ b/test/e2e/elasticsearch_test.go
@@ -27,7 +27,7 @@ type ElasticSearchTestSuite struct {
 }
 
 func(suite *ElasticSearchTestSuite) SetupSuite() {
-	t = suite.T()
+	t := suite.T()
 	var err error
 	ctx, err = prepare(t)
 	if (err != nil) {
@@ -53,6 +53,7 @@ func TestElasticSearchSuite(t *testing.T) {
 }
 
 func (suite *ElasticSearchTestSuite) TestSparkDependenciesES() {
+	t := suite.T()
 	storage := v1.JaegerStorageSpec{
 		Type: "elasticsearch",
 		Options: v1.NewOptions(map[string]interface{}{
@@ -64,6 +65,7 @@ func (suite *ElasticSearchTestSuite) TestSparkDependenciesES() {
 }
 
 func (suite *ElasticSearchTestSuite) TestSimpleProd() {
+	t := suite.T()
 	err := WaitForStatefulset(t, fw.KubeClient, storageNamespace, "elasticsearch", retryInterval, timeout)
 	require.NoError(t, err, "Error waiting for elasticsearch")
 
@@ -99,6 +101,7 @@ func (suite *ElasticSearchTestSuite) TestSimpleProd() {
 }
 
 func (suite *ElasticSearchTestSuite) TestEsIndexCleaner() {
+	t := suite.T()
 	name := "test-es-index-cleaner"
 	j := getJaegerAllInOne(name)
 

--- a/test/e2e/elasticsearch_test.go
+++ b/test/e2e/elasticsearch_test.go
@@ -103,7 +103,6 @@ func (suite *ElasticSearchTestSuite) TestSimpleProd() {
 }
 
 func (suite *ElasticSearchTestSuite) TestEsIndexCleaner() {
-	t := suite.T()
 	name := "test-es-index-cleaner"
 	j := getJaegerAllInOne(name)
 

--- a/test/e2e/elasticsearch_test.go
+++ b/test/e2e/elasticsearch_test.go
@@ -27,7 +27,7 @@ type ElasticSearchTestSuite struct {
 }
 
 func(suite *ElasticSearchTestSuite) SetupSuite() {
-	t := suite.T()
+	t = suite.T()
 	var err error
 	ctx, err = prepare(t)
 	if (err != nil) {
@@ -52,8 +52,11 @@ func TestElasticSearchSuite(t *testing.T) {
 	suite.Run(t, new(ElasticSearchTestSuite))
 }
 
+func (suite *ElasticSearchTestSuite) SetupTest() {
+	t = suite.T()
+}
+
 func (suite *ElasticSearchTestSuite) TestSparkDependenciesES() {
-	t := suite.T()
 	storage := v1.JaegerStorageSpec{
 		Type: "elasticsearch",
 		Options: v1.NewOptions(map[string]interface{}{
@@ -65,7 +68,6 @@ func (suite *ElasticSearchTestSuite) TestSparkDependenciesES() {
 }
 
 func (suite *ElasticSearchTestSuite) TestSimpleProd() {
-	t := suite.T()
 	err := WaitForStatefulset(t, fw.KubeClient, storageNamespace, "elasticsearch", retryInterval, timeout)
 	require.NoError(t, err, "Error waiting for elasticsearch")
 

--- a/test/e2e/self_provisioned_elasticsearch_test.go
+++ b/test/e2e/self_provisioned_elasticsearch_test.go
@@ -23,7 +23,7 @@ type SelfProvisionedTestSuite struct {
 }
 
 func(suite *SelfProvisionedTestSuite) SetupSuite() {
-	t = suite.T()
+	t := suite.T()
 	if !isOpenShift(t) {
 		t.Skipf("Test %s is currently supported only on OpenShift because es-operator runs only on OpenShift\n", t.Name())
 	}
@@ -63,6 +63,7 @@ func TestSelfProvisionedSuite(t *testing.T) {
 }
 
 func (suite *SelfProvisionedTestSuite) TestSelfProvisionedESSmokeTest() {
+	t := suite.T()
 	// create jaeger custom resource
 	exampleJaeger := getJaegerSimpleProd()
 	err := fw.Client.Create(goctx.TODO(), exampleJaeger, &framework.CleanupOptions{TestContext: ctx, Timeout: timeout, RetryInterval: retryInterval})

--- a/test/e2e/self_provisioned_elasticsearch_test.go
+++ b/test/e2e/self_provisioned_elasticsearch_test.go
@@ -23,7 +23,7 @@ type SelfProvisionedTestSuite struct {
 }
 
 func(suite *SelfProvisionedTestSuite) SetupSuite() {
-	t := suite.T()
+	t = suite.T()
 	if !isOpenShift(t) {
 		t.Skipf("Test %s is currently supported only on OpenShift because es-operator runs only on OpenShift\n", t.Name())
 	}
@@ -62,8 +62,11 @@ func TestSelfProvisionedSuite(t *testing.T) {
 	suite.Run(t, new(SelfProvisionedTestSuite))
 }
 
+func (suite *SelfProvisionedTestSuite) SetupTest() {
+	t = suite.T()
+}
+
 func (suite *SelfProvisionedTestSuite) TestSelfProvisionedESSmokeTest() {
-	t := suite.T()
 	// create jaeger custom resource
 	exampleJaeger := getJaegerSimpleProd()
 	err := fw.Client.Create(goctx.TODO(), exampleJaeger, &framework.CleanupOptions{TestContext: ctx, Timeout: timeout, RetryInterval: retryInterval})

--- a/test/e2e/sidecar_test.go
+++ b/test/e2e/sidecar_test.go
@@ -30,7 +30,7 @@ type SidecarTestSuite struct {
 }
 
 func(suite *SidecarTestSuite) SetupSuite() {
-	t := suite.T()
+	t = suite.T()
 	var err error
 	ctx, err = prepare(t)
 	if (err != nil) {
@@ -55,9 +55,12 @@ func TestSidecarSuite(t *testing.T) {
 	suite.Run(t, new(SidecarTestSuite))
 }
 
+func (suite *SidecarTestSuite) SetupTest() {
+	t = suite.T()
+}
+
 // Sidecar runs a test with the agent as sidecar
 func (suite *SidecarTestSuite) TestSidecar() {
-	t := suite.T()
 	cleanupOptions := &framework.CleanupOptions{TestContext: ctx, Timeout: timeout, RetryInterval: retryInterval}
 
 	j := getJaegerAgentAsSidecarDefinition(namespace)

--- a/test/e2e/sidecar_test.go
+++ b/test/e2e/sidecar_test.go
@@ -30,7 +30,7 @@ type SidecarTestSuite struct {
 }
 
 func(suite *SidecarTestSuite) SetupSuite() {
-	t = suite.T()
+	t := suite.T()
 	var err error
 	ctx, err = prepare(t)
 	if (err != nil) {
@@ -57,6 +57,7 @@ func TestSidecarSuite(t *testing.T) {
 
 // Sidecar runs a test with the agent as sidecar
 func (suite *SidecarTestSuite) TestSidecar() {
+	t := suite.T()
 	cleanupOptions := &framework.CleanupOptions{TestContext: ctx, Timeout: timeout, RetryInterval: retryInterval}
 
 	j := getJaegerAgentAsSidecarDefinition(namespace)

--- a/test/e2e/streaming_test.go
+++ b/test/e2e/streaming_test.go
@@ -21,7 +21,7 @@ type StreamingTestSuite struct {
 }
 
 func (suite *StreamingTestSuite) SetupSuite() {
-	t := suite.T()
+	t = suite.T()
 	var err error
 	ctx, err = prepare(t)
 	if err != nil {
@@ -46,8 +46,11 @@ func TestStreamingSuite(t *testing.T) {
 	suite.Run(t, new(StreamingTestSuite))
 }
 
+func (suite *StreamingTestSuite) SetupTest() {
+	t = suite.T()
+}
+
 func (suite *StreamingTestSuite) TestStreaming() {
-	t := suite.T()
 	err := WaitForStatefulset(t, fw.KubeClient, storageNamespace, "elasticsearch", retryInterval, timeout)
 	require.NoError(t, err, "Error waiting for elasticsearch")
 

--- a/test/e2e/streaming_test.go
+++ b/test/e2e/streaming_test.go
@@ -21,7 +21,7 @@ type StreamingTestSuite struct {
 }
 
 func (suite *StreamingTestSuite) SetupSuite() {
-	t = suite.T()
+	t := suite.T()
 	var err error
 	ctx, err = prepare(t)
 	if err != nil {
@@ -47,6 +47,7 @@ func TestStreamingSuite(t *testing.T) {
 }
 
 func (suite *StreamingTestSuite) TestStreaming() {
+	t := suite.T()
 	err := WaitForStatefulset(t, fw.KubeClient, storageNamespace, "elasticsearch", retryInterval, timeout)
 	require.NoError(t, err, "Error waiting for elasticsearch")
 

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -32,6 +32,7 @@ var (
 	ctx                  *framework.TestCtx
 	fw                   *framework.Framework
 	namespace            string
+	t                    *testing.T
 )
 
 // GetPod returns pod name

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -32,7 +32,6 @@ var (
 	ctx                  *framework.TestCtx
 	fw                   *framework.Framework
 	namespace            string
-	t                    *testing.T
 )
 
 // GetPod returns pod name


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com>

This fixes #423 We should get t on a per test case basis rather than on a per suite basis.  Otherwise test suites will terminate on the first failure and not run all test cases.
