### PR TITLE
Empty image on Elasticsearch CR defaults to appropriate logging-elast…

### DIFF
--- a/pkg/cmd/start/main.go
+++ b/pkg/cmd/start/main.go
@@ -70,9 +70,6 @@ func NewStartCommand() *cobra.Command {
 	cmd.Flags().String("jaeger-es-rollover-image", "jaegertracing/jaeger-es-rollover", "The Docker image for the Jaeger Elasticsearch Rollover")
 	viper.BindPFlag("jaeger-es-rollover-image", cmd.Flags().Lookup("jaeger-es-rollover-image"))
 
-	cmd.Flags().String("jaeger-elasticsearch-image", "quay.io/openshift/origin-logging-elasticsearch5:latest", "The Docker image for Elasticsearch")
-	viper.BindPFlag("jaeger-elasticsearch-image", cmd.Flags().Lookup("jaeger-elasticsearch-image"))
-
 	cmd.Flags().String("openshift-oauth-proxy-image", "openshift/oauth-proxy:latest", "The Docker image location definition for the OpenShift OAuth Proxy")
 	viper.BindPFlag("openshift-oauth-proxy-image", cmd.Flags().Lookup("openshift-oauth-proxy-image"))
 

--- a/pkg/strategy/controller.go
+++ b/pkg/strategy/controller.go
@@ -131,9 +131,6 @@ func normalizeElasticsearch(spec *v1.ElasticsearchSpec) {
 	if spec.NodeCount == 0 {
 		spec.NodeCount = 1
 	}
-	if spec.Image == "" {
-		spec.Image = viper.GetString("jaeger-elasticsearch-image")
-	}
 }
 
 func normalizeRollover(spec *v1.JaegerEsRolloverSpec) {

--- a/pkg/strategy/controller_test.go
+++ b/pkg/strategy/controller_test.go
@@ -234,14 +234,12 @@ func TestNormalizeSparkDependencies(t *testing.T) {
 }
 
 func TestNormalizeElasticsearch(t *testing.T) {
-	viper.Set("jaeger-elasticsearch-image", "hoo")
-	defer viper.Reset()
 	tests := []struct {
 		underTest v1.ElasticsearchSpec
 		expected  v1.ElasticsearchSpec
 	}{
 		{underTest: v1.ElasticsearchSpec{},
-			expected: v1.ElasticsearchSpec{Image: "hoo", NodeCount: 1}},
+			expected: v1.ElasticsearchSpec{NodeCount: 1}},
 		{underTest: v1.ElasticsearchSpec{Image: "bla", NodeCount: 150},
 			expected: v1.ElasticsearchSpec{Image: "bla", NodeCount: 150}},
 	}


### PR DESCRIPTION
…icsearch5 image, so doesn't need to be set to a default by Jaeger operator

Signed-off-by: Gary Brown <gary@brownuk.com>