### PR TITLE
Enable running unit tests in verbose mode for better reporting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ push:
 .PHONY: unit-tests
 unit-tests:
 	@echo Running unit tests...
-	@go test $(PACKAGES) -cover -coverprofile=cover.out
+	@go test $(VERBOSE) $(PACKAGES) -cover -coverprofile=cover.out
 
 .PHONY: e2e-tests
 e2e-tests: prepare-e2e-tests e2e-tests-smoke e2e-tests-cassandra e2e-tests-es e2e-tests-self-provisioned-es e2e-tests-streaming


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com>