### PR TITLE
Remove sidecar when instance is deleted

### DIFF
--- a/pkg/controller/deployment/deployment_controller.go
+++ b/pkg/controller/deployment/deployment_controller.go
@@ -91,8 +91,9 @@ func (r *ReconcileDeployment) Reconcile(request reconcile.Request) (reconcile.Re
 		}
 
 		jaeger := inject.Select(instance, pods)
-		if jaeger != nil {
+		if jaeger != nil && jaeger.GetDeletionTimestamp() == nil {
 			// a suitable jaeger instance was found! let's inject a sidecar pointing to it then
+			// Verified that jaeger instance was found and is not marked for deletion.
 			log.WithFields(log.Fields{
 				"deployment":       instance.Name,
 				"namespace":        instance.Namespace,

--- a/pkg/controller/jaeger/jaeger_controller_test.go
+++ b/pkg/controller/jaeger/jaeger_controller_test.go
@@ -3,9 +3,13 @@ package jaeger
 import (
 	"context"
 	"testing"
+	"time"
 
 	osv1 "github.com/openshift/api/route/v1"
 	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -14,6 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	"github.com/jaegertracing/jaeger-operator/pkg/inject"
 	esv1 "github.com/jaegertracing/jaeger-operator/pkg/storage/elasticsearch/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/strategy"
 )
@@ -67,6 +72,7 @@ func TestDeletedInstance(t *testing.T) {
 
 	// no known objects
 	cl := fake.NewFakeClient()
+
 	r := &ReconcileJaeger{client: cl, scheme: s}
 
 	req := reconcile.Request{
@@ -87,6 +93,79 @@ func TestDeletedInstance(t *testing.T) {
 	err = cl.Get(context.Background(), req.NamespacedName, persisted)
 	assert.NotEmpty(t, jaeger.Name)
 	assert.Empty(t, persisted.Name) // this means that the object wasn't found
+}
+
+func TestCleanFinalizer(t *testing.T) {
+	jaeger := v1.NewJaeger(types.NamespacedName{
+		Name:      "TestDeletedInstance",
+		Namespace: "TestNS",
+	})
+	dep := appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						corev1.Container{},
+					},
+				},
+			},
+		},
+	}
+	dep.Name = "mydep"
+	dep.Annotations = map[string]string{inject.Annotation: jaeger.Name}
+	s := scheme.Scheme
+	s.AddKnownTypes(v1.SchemeGroupVersion, jaeger)
+
+	jaeger.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+	jaeger.SetFinalizers([]string{finalizer})
+
+	injectedDep := inject.Sidecar(jaeger, &dep)
+	cl := fake.NewFakeClient(jaeger, injectedDep)
+
+	r := &ReconcileJaeger{client: cl, scheme: nil}
+
+	req := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      jaeger.Name,
+			Namespace: jaeger.Namespace,
+		},
+	}
+
+	// execute finalizer
+	_, err := r.Reconcile(req)
+
+	// verify
+	assert.NoError(t, err)
+	persisted := &appsv1.Deployment{}
+	err = cl.Get(context.Background(), types.NamespacedName{
+		Namespace: dep.Namespace,
+		Name:      dep.Name,
+	}, persisted)
+	assert.Equal(t, len(persisted.Spec.Template.Spec.Containers), 1)
+	assert.NotContains(t, persisted.Labels, inject.Annotation)
+	assert.NotContains(t, persisted.Annotations, inject.Annotation)
+}
+
+func TestAddOnlyOneFinalizer(t *testing.T) {
+	// prepare
+	nsn := types.NamespacedName{
+		Namespace: "Test",
+		Name:      "TestNewJaegerInstance",
+	}
+	jaeger := v1.NewJaeger(nsn)
+	jaeger.SetFinalizers([]string{finalizer})
+	objs := []runtime.Object{
+		jaeger,
+	}
+	req := reconcile.Request{
+		NamespacedName: nsn,
+	}
+	r, cl := getReconciler(objs)
+	r.Reconcile(req)
+	persisted := &v1.Jaeger{}
+	cl.Get(context.Background(), req.NamespacedName, persisted)
+	assert.Equal(t, len(persisted.Finalizers), 1)
 }
 
 func getReconciler(objs []runtime.Object) (*ReconcileJaeger, client.Client) {

--- a/pkg/inject/sidecar_test.go
+++ b/pkg/inject/sidecar_test.go
@@ -313,6 +313,41 @@ func TestSidecarAgentResources(t *testing.T) {
 	assert.Equal(t, *resource.NewQuantity(512, resource.DecimalSI), dep.Spec.Template.Spec.Containers[1].Resources.Requests[corev1.ResourceRequestsEphemeralStorage])
 }
 
+func TestCleanSidecars(t *testing.T) {
+	nsn := types.NamespacedName{
+		Name:      "TestCleanSideCars",
+		Namespace: "Test",
+	}
+	jaeger := v1.NewJaeger(nsn)
+	dep1 := Sidecar(jaeger, dep(map[string]string{Annotation: jaeger.Name}, map[string]string{}))
+	dep2 := Sidecar(jaeger, dep(map[string]string{Annotation: jaeger.Name}, map[string]string{}))
+	dep3 := Sidecar(jaeger, dep(map[string]string{Annotation: jaeger.Name}, map[string]string{}))
+	deployments := []appsv1.Deployment{*dep1, *dep2, *dep3}
+	CleanSidecars(deployments)
+	assert.Equal(t, len(deployments[0].Spec.Template.Spec.Containers), 1)
+	assert.Equal(t, len(deployments[0].Spec.Template.Spec.Containers), 1)
+	assert.Equal(t, len(deployments[0].Spec.Template.Spec.Containers), 1)
+	assert.NotContains(t, deployments[0].Labels, Annotation)
+	assert.NotContains(t, deployments[0].Annotations, Annotation)
+}
+
+func TestSidecarWithLabel(t *testing.T) {
+	nsn := types.NamespacedName{
+		Name:      "TestSidecarWithLabel",
+		Namespace: "Test",
+	}
+	jaeger := v1.NewJaeger(nsn)
+	dep1 := dep(map[string]string{Annotation: jaeger.Name}, map[string]string{})
+	dep1 = Sidecar(jaeger, dep1)
+	assert.Equal(t, dep1.Labels[Annotation], "TestSidecarWithLabel")
+	dep2 := dep(map[string]string{Annotation: jaeger.Name}, map[string]string{})
+	dep2.Labels = map[string]string{"anotherLabel": "anotherValue"}
+	dep2 = Sidecar(jaeger, dep2)
+	assert.Equal(t, len(dep2.Labels), 2)
+	assert.Equal(t, dep2.Labels["anotherLabel"], "anotherValue")
+	assert.Equal(t, dep2.Labels[Annotation], jaeger.Name)
+}
+
 func dep(annotations map[string]string, labels map[string]string) *appsv1.Deployment {
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION

Fixes #443 

I tested and the sidecar was not deleted

I think this is due to the fact that the Kubernetes GC does not delete the sidecar because is part of the pod, also is on the deployment template, which is not a child of the jaeger CR.


This PR implements some logic to "un-inject" the sidecar on the deployment. (but not on existing pods. should we do that??). I used a finalizer here.

@pavolloffay  @jpkrohling  Could you please review? Thank you!!
