### PR TITLE
As of OCP 4.1.2 elasticsearch urls need to be fully qualified

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ e2e-tests-es: prepare-e2e-tests es
 .PHONY: e2e-tests-self-provisioned-es
 e2e-tests-self-provisioned-es: prepare-e2e-tests deploy-es-operator
 	@echo Running Self provisioned Elasticsearch end-to-end tests...
-	@go test -tags=self_provisioned_elasticsearch ./test/e2e/... $(TEST_OPTIONS)
+	@STORAGE_NAMESPACE=$(STORAGE_NAMESPACE) go test -tags=self_provisioned_elasticsearch ./test/e2e/... $(TEST_OPTIONS)
 
 .PHONY: e2e-tests-streaming
 e2e-tests-streaming: prepare-e2e-tests es kafka

--- a/test/e2e/elasticsearch_test.go
+++ b/test/e2e/elasticsearch_test.go
@@ -44,6 +44,10 @@ func(suite *ElasticSearchTestSuite) SetupSuite() {
 	require.NotNil(t, namespace, "GetNamespace failed")
 
 	addToFrameworkSchemeForSmokeTests(t)
+
+	if isOpenShift(t) {
+		esServerUrls = "http://elasticsearch." + storageNamespace + ".svc.cluster.local:9200"
+	}
 }
 
 func (suite *ElasticSearchTestSuite) TearDownSuite() {

--- a/test/e2e/self_provisioned_elasticsearch_test.go
+++ b/test/e2e/self_provisioned_elasticsearch_test.go
@@ -52,6 +52,10 @@ func(suite *SelfProvisionedTestSuite) SetupSuite() {
 	fw = framework.Global
 	namespace, _ = ctx.GetNamespace()
 	require.NotNil(t, namespace, "GetNamespace failed")
+
+	if isOpenShift(t) {
+		esServerUrls = "http://elasticsearch." + storageNamespace + ".svc.cluster.local:9200"
+	}
 }
 
 func (suite *SelfProvisionedTestSuite) TearDownSuite() {
@@ -112,6 +116,9 @@ func getJaegerSimpleProd() *v1.Jaeger {
 			Strategy: "production",
 			Storage: v1.JaegerStorageSpec{
 				Type: "elasticsearch",
+				Options: v1.NewOptions(map[string]interface{}{
+					"es.server-urls": esServerUrls,
+				}),
 			},
 		},
 	}


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com>