### PR TITLE
Sanitize names that must follow DNS naming rules

### DIFF
--- a/pkg/config/sampling/sampling.go
+++ b/pkg/config/sampling/sampling.go
@@ -6,7 +6,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	"github.com/jaegertracing/jaeger-operator/pkg/util"
 )
 
 const (
@@ -81,7 +82,7 @@ func (u *Config) Get() *corev1.ConfigMap {
 func Update(jaeger *v1.Jaeger, commonSpec *v1.JaegerCommonSpec, options *[]string) {
 
 	volume := corev1.Volume{
-		Name: fmt.Sprintf("%s-sampling-configuration-volume", jaeger.Name),
+		Name: samplingConfigVolumeName(jaeger),
 		VolumeSource: corev1.VolumeSource{
 			ConfigMap: &corev1.ConfigMapVolumeSource{
 				LocalObjectReference: corev1.LocalObjectReference{
@@ -97,11 +98,15 @@ func Update(jaeger *v1.Jaeger, commonSpec *v1.JaegerCommonSpec, options *[]strin
 		},
 	}
 	volumeMount := corev1.VolumeMount{
-		Name:      fmt.Sprintf("%s-sampling-configuration-volume", jaeger.Name),
+		Name:      samplingConfigVolumeName(jaeger),
 		MountPath: "/etc/jaeger/sampling",
 		ReadOnly:  true,
 	}
 	commonSpec.Volumes = append(commonSpec.Volumes, volume)
 	commonSpec.VolumeMounts = append(commonSpec.VolumeMounts, volumeMount)
 	*options = append(*options, "--sampling.strategies-file=/etc/jaeger/sampling/sampling.json")
+}
+
+func samplingConfigVolumeName(jaeger *v1.Jaeger) string {
+	return util.DNSName(fmt.Sprintf("%s-sampling-configuration-volume", jaeger.Name))
 }

--- a/pkg/config/sampling/sampling_test.go
+++ b/pkg/config/sampling/sampling_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 )
 
 func TestNoSamplingConfig(t *testing.T) {
@@ -52,9 +52,9 @@ func TestUpdateNoSamplingConfig(t *testing.T) {
 
 	Update(jaeger, &commonSpec, &options)
 	assert.Len(t, commonSpec.Volumes, 1)
-	assert.Equal(t, "TestUpdateNoSamplingConfig-sampling-configuration-volume", commonSpec.Volumes[0].Name)
+	assert.Equal(t, "testupdatenosamplingconfig-sampling-configuration-volume", commonSpec.Volumes[0].Name)
 	assert.Len(t, commonSpec.VolumeMounts, 1)
-	assert.Equal(t, "TestUpdateNoSamplingConfig-sampling-configuration-volume", commonSpec.VolumeMounts[0].Name)
+	assert.Equal(t, "testupdatenosamplingconfig-sampling-configuration-volume", commonSpec.VolumeMounts[0].Name)
 	assert.Len(t, options, 1)
 	assert.Equal(t, "--sampling.strategies-file=/etc/jaeger/sampling/sampling.json", options[0])
 }
@@ -73,9 +73,9 @@ func TestUpdateWithSamplingConfig(t *testing.T) {
 
 	Update(jaeger, &commonSpec, &options)
 	assert.Len(t, commonSpec.Volumes, 1)
-	assert.Equal(t, "TestUpdateWithSamplingConfig-sampling-configuration-volume", commonSpec.Volumes[0].Name)
+	assert.Equal(t, "testupdatewithsamplingconfig-sampling-configuration-volume", commonSpec.Volumes[0].Name)
 	assert.Len(t, commonSpec.VolumeMounts, 1)
-	assert.Equal(t, "TestUpdateWithSamplingConfig-sampling-configuration-volume", commonSpec.VolumeMounts[0].Name)
+	assert.Equal(t, "testupdatewithsamplingconfig-sampling-configuration-volume", commonSpec.VolumeMounts[0].Name)
 	assert.Len(t, options, 1)
 	assert.Equal(t, "--sampling.strategies-file=/etc/jaeger/sampling/sampling.json", options[0])
 }

--- a/pkg/config/ui/ui.go
+++ b/pkg/config/ui/ui.go
@@ -6,7 +6,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	"github.com/jaegertracing/jaeger-operator/pkg/util"
 )
 
 // UIConfig represents a UI configmap
@@ -76,7 +77,7 @@ func Update(jaeger *v1.Jaeger, commonSpec *v1.JaegerCommonSpec, options *[]strin
 	}
 
 	volume := corev1.Volume{
-		Name: fmt.Sprintf("%s-ui-configuration-volume", jaeger.Name),
+		Name: configurationVolumeName(jaeger),
 		VolumeSource: corev1.VolumeSource{
 			ConfigMap: &corev1.ConfigMapVolumeSource{
 				LocalObjectReference: corev1.LocalObjectReference{
@@ -92,11 +93,15 @@ func Update(jaeger *v1.Jaeger, commonSpec *v1.JaegerCommonSpec, options *[]strin
 		},
 	}
 	volumeMount := corev1.VolumeMount{
-		Name:      fmt.Sprintf("%s-ui-configuration-volume", jaeger.Name),
+		Name:      configurationVolumeName(jaeger),
 		MountPath: "/etc/config",
 		ReadOnly:  true,
 	}
 	commonSpec.Volumes = append(commonSpec.Volumes, volume)
 	commonSpec.VolumeMounts = append(commonSpec.VolumeMounts, volumeMount)
 	*options = append(*options, "--query.ui-config=/etc/config/ui.json")
+}
+
+func configurationVolumeName(jaeger *v1.Jaeger) string {
+	return util.DNSName(fmt.Sprintf("%s-ui-configuration-volume", jaeger.Name))
 }

--- a/pkg/config/ui/ui_test.go
+++ b/pkg/config/ui/ui_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 )
 
 func TestNoUIConfig(t *testing.T) {

--- a/pkg/ingress/query_test.go
+++ b/pkg/ingress/query_test.go
@@ -1,12 +1,11 @@
 package ingress
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 )
 
 func TestQueryIngress(t *testing.T) {
@@ -16,7 +15,7 @@ func TestQueryIngress(t *testing.T) {
 
 	dep := ingress.Get()
 
-	assert.Contains(t, dep.Spec.Backend.ServiceName, fmt.Sprintf("%s-query", name))
+	assert.Contains(t, dep.Spec.Backend.ServiceName, "testqueryingress-query")
 }
 
 func TestQueryIngressDisabled(t *testing.T) {

--- a/pkg/route/query_test.go
+++ b/pkg/route/query_test.go
@@ -1,13 +1,12 @@
 package route
 
 import (
-	"fmt"
 	"testing"
 
 	corev1 "github.com/openshift/api/route/v1"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 )
 
 func TestQueryRoute(t *testing.T) {
@@ -17,7 +16,7 @@ func TestQueryRoute(t *testing.T) {
 
 	dep := route.Get()
 
-	assert.Contains(t, dep.Spec.To.Name, fmt.Sprintf("%s-query", name))
+	assert.Contains(t, dep.Spec.To.Name, "testqueryroute-query")
 }
 
 func TestQueryRouteDisabled(t *testing.T) {

--- a/pkg/service/agent.go
+++ b/pkg/service/agent.go
@@ -6,7 +6,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	"github.com/jaegertracing/jaeger-operator/pkg/util"
 )
 
 // NewAgentService returns a new Kubernetes service for Jaeger Agent backed by the pods matching the selector
@@ -19,7 +20,7 @@ func NewAgentService(jaeger *v1.Jaeger, selector map[string]string) *corev1.Serv
 			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-agent", jaeger.Name),
+			Name:      util.DNSName(fmt.Sprintf("%s-agent", jaeger.Name)),
 			Namespace: jaeger.Namespace,
 			Labels: map[string]string{
 				"app":                          "jaeger",

--- a/pkg/service/agent_test.go
+++ b/pkg/service/agent_test.go
@@ -1,12 +1,11 @@
 package service
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 )
 
 func TestAgentServiceNameAndPorts(t *testing.T) {
@@ -15,7 +14,7 @@ func TestAgentServiceNameAndPorts(t *testing.T) {
 
 	jaeger := v1.NewJaeger(name)
 	svc := NewAgentService(jaeger, selector)
-	assert.Equal(t, svc.ObjectMeta.Name, fmt.Sprintf("%s-agent", name))
+	assert.Equal(t, "testagentservicenameandports-agent", svc.ObjectMeta.Name)
 
 	ports := map[int32]bool{
 		5775: false,

--- a/pkg/service/collector.go
+++ b/pkg/service/collector.go
@@ -6,7 +6,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	"github.com/jaegertracing/jaeger-operator/pkg/util"
 )
 
 // NewCollectorServices returns a new Kubernetes service for Jaeger Collector backed by the pods matching the selector
@@ -87,10 +88,10 @@ func collectorService(jaeger *v1.Jaeger, selector map[string]string) *corev1.Ser
 
 // GetNameForCollectorService returns the service name for the collector in this Jaeger instance
 func GetNameForCollectorService(jaeger *v1.Jaeger) string {
-	return fmt.Sprintf("%s-collector", jaeger.Name)
+	return util.DNSName(fmt.Sprintf("%s-collector", jaeger.Name))
 }
 
 // GetNameForHeadlessCollectorService returns the headless service name for the collector in this Jaeger instance
 func GetNameForHeadlessCollectorService(jaeger *v1.Jaeger) string {
-	return fmt.Sprintf("%s-collector-headless", jaeger.Name)
+	return util.DNSName(fmt.Sprintf("%s-collector-headless", jaeger.Name))
 }

--- a/pkg/service/collector_test.go
+++ b/pkg/service/collector_test.go
@@ -1,12 +1,11 @@
 package service
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 )
 
 func TestCollectorServiceNameAndPorts(t *testing.T) {
@@ -16,8 +15,8 @@ func TestCollectorServiceNameAndPorts(t *testing.T) {
 	jaeger := v1.NewJaeger(name)
 	svcs := NewCollectorServices(jaeger, selector)
 
-	assert.Equal(t, svcs[0].Name, fmt.Sprintf("%s-collector-headless", name))
-	assert.Equal(t, svcs[1].Name, fmt.Sprintf("%s-collector", name))
+	assert.Equal(t, "testcollectorservicenameandports-collector-headless", svcs[0].Name)
+	assert.Equal(t, "testcollectorservicenameandports-collector", svcs[1].Name)
 
 	ports := map[int32]bool{
 		9411:  false,

--- a/pkg/service/query.go
+++ b/pkg/service/query.go
@@ -7,7 +7,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	"github.com/jaegertracing/jaeger-operator/pkg/util"
 )
 
 // NewQueryService returns a new Kubernetes service for Jaeger Query backed by the pods matching the selector
@@ -62,7 +63,7 @@ func NewQueryService(jaeger *v1.Jaeger, selector map[string]string) *corev1.Serv
 
 // GetNameForQueryService returns the query service name for this Jaeger instance
 func GetNameForQueryService(jaeger *v1.Jaeger) string {
-	return fmt.Sprintf("%s-query", jaeger.Name)
+	return util.DNSName(fmt.Sprintf("%s-query", jaeger.Name))
 }
 
 // GetTLSSecretNameForQueryService returns the auto-generated TLS secret name for the Query Service for the given Jaeger instance

--- a/pkg/service/query_test.go
+++ b/pkg/service/query_test.go
@@ -1,13 +1,12 @@
 package service
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 )
 
 func TestQueryServiceNameAndPorts(t *testing.T) {
@@ -17,11 +16,21 @@ func TestQueryServiceNameAndPorts(t *testing.T) {
 	jaeger := v1.NewJaeger(name)
 	svc := NewQueryService(jaeger, selector)
 
-	assert.Equal(t, fmt.Sprintf("%s-query", name), svc.ObjectMeta.Name)
+	assert.Equal(t, "testqueryservicenameandports-query", svc.ObjectMeta.Name)
 	assert.Len(t, svc.Spec.Ports, 1)
 	assert.Equal(t, int32(16686), svc.Spec.Ports[0].Port)
 	assert.Equal(t, intstr.FromInt(16686), svc.Spec.Ports[0].TargetPort)
 	assert.Len(t, svc.Spec.ClusterIP, 0) // make sure we get a cluster IP
+}
+
+func TestQueryDottedServiceName(t *testing.T) {
+	name := "TestQueryDottedServiceName.With.Dots"
+	selector := map[string]string{"app": "myapp", "jaeger": name, "jaeger-component": "query"}
+
+	jaeger := v1.NewJaeger(name)
+	svc := NewQueryService(jaeger, selector)
+
+	assert.Equal(t, "testquerydottedservicename-with-dots-query", svc.ObjectMeta.Name)
 }
 
 func TestQueryServiceNameAndPortsWithOAuthProxy(t *testing.T) {
@@ -32,7 +41,7 @@ func TestQueryServiceNameAndPortsWithOAuthProxy(t *testing.T) {
 	jaeger.Spec.Ingress.Security = v1.IngressSecurityOAuthProxy
 	svc := NewQueryService(jaeger, selector)
 
-	assert.Equal(t, fmt.Sprintf("%s-query", name), svc.ObjectMeta.Name)
+	assert.Equal(t, "testqueryservicenameandportswithoauthproxy-query", svc.ObjectMeta.Name)
 	assert.Len(t, svc.Spec.Ports, 1)
 	assert.Equal(t, int32(443), svc.Spec.Ports[0].Port)
 	assert.Equal(t, intstr.FromInt(8443), svc.Spec.Ports[0].TargetPort)

--- a/pkg/strategy/all-in-one_test.go
+++ b/pkg/strategy/all-in-one_test.go
@@ -2,12 +2,13 @@ package strategy
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/storage"
 )
 
@@ -93,9 +94,9 @@ func assertDeploymentsAndServicesForAllInOne(t *testing.T, name string, s S, has
 
 	// and these services
 	services := map[string]bool{
-		fmt.Sprintf("%s-agent", name):     false,
-		fmt.Sprintf("%s-collector", name): false,
-		fmt.Sprintf("%s-query", name):     false,
+		fmt.Sprintf("%s-agent", strings.ToLower(name)):     false,
+		fmt.Sprintf("%s-collector", strings.ToLower(name)): false,
+		fmt.Sprintf("%s-query", strings.ToLower(name)):     false,
 	}
 
 	// the ingress rule, if we are not on openshift

--- a/pkg/strategy/production_test.go
+++ b/pkg/strategy/production_test.go
@@ -12,7 +12,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/storage"
 )
 
@@ -139,8 +139,8 @@ func assertDeploymentsAndServicesForProduction(t *testing.T, name string, s S, h
 	}
 
 	services := map[string]bool{
-		fmt.Sprintf("%s-collector", name): false,
-		fmt.Sprintf("%s-query", name):     false,
+		fmt.Sprintf("%s-collector", strings.ToLower(name)): false,
+		fmt.Sprintf("%s-query", strings.ToLower(name)):     false,
 	}
 
 	ingresses := map[string]bool{}

--- a/pkg/strategy/streaming_test.go
+++ b/pkg/strategy/streaming_test.go
@@ -11,7 +11,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/storage"
 )
 
@@ -156,8 +156,8 @@ func assertDeploymentsAndServicesForStreaming(t *testing.T, name string, s S, ha
 	}
 
 	services := map[string]bool{
-		fmt.Sprintf("%s-collector", name): false,
-		fmt.Sprintf("%s-query", name):     false,
+		fmt.Sprintf("%s-collector", strings.ToLower(name)): false,
+		fmt.Sprintf("%s-query", strings.ToLower(name)):     false,
 	}
 
 	ingresses := map[string]bool{}

--- a/pkg/util/dns_name.go
+++ b/pkg/util/dns_name.go
@@ -6,11 +6,12 @@ import (
 	"unicode/utf8"
 )
 
+var regex = regexp.MustCompile(`[a-z0-9]`)
+
 // DNSName returns a dns-safe string for the given name.
 // Any char that is not [a-z0-9] is replaced by "-".
 // If the final name starts with "-", "a" is added as prefix. Similarly, if it ends with "-", "z" is added.
 func DNSName(name string) string {
-	var regex = regexp.MustCompile(`[a-z0-9]`)
 	var d []rune
 
 	first := true

--- a/pkg/util/dns_name.go
+++ b/pkg/util/dns_name.go
@@ -1,0 +1,36 @@
+package util
+
+import (
+	"regexp"
+	"strings"
+	"unicode/utf8"
+)
+
+// DNSName returns a dns-safe string for the given name.
+// Any char that is not [a-z0-9] is replaced by "-".
+// If the final name starts with "-", "a" is added as prefix. Similarly, if it ends with "-", "z" is added.
+func DNSName(name string) string {
+	var regex = regexp.MustCompile(`[a-z0-9]`)
+	var d []rune
+
+	first := true
+	for _, x := range strings.ToLower(name) {
+		if regex.Match([]byte(string(x))) {
+			d = append(d, x)
+		} else {
+			if first {
+				d = append(d, 'a')
+			}
+			d = append(d, '-')
+
+			if len(d) == utf8.RuneCountInString(name) {
+				// we had to replace the last char, so, it's "-". DNS names can't end with dash.
+				d = append(d, 'z')
+			}
+		}
+
+		first = false
+	}
+
+	return string(d)
+}

--- a/pkg/util/dns_name_test.go
+++ b/pkg/util/dns_name_test.go
@@ -16,6 +16,7 @@ func TestDnsName(t *testing.T) {
 		{"instance.with.dots-collector-headless", "instance-with-dots-collector-headless"},
 		{"TestQueryDottedServiceName.With.Dots", "testquerydottedservicename-with-dots"},
 		{"Service🦄", "service-z"},
+		{"📈Stock-Tracker", "a-stock-tracker"},
 	}
 
 	for _, tt := range tests {

--- a/pkg/util/dns_name_test.go
+++ b/pkg/util/dns_name_test.go
@@ -1,0 +1,28 @@
+package util
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDnsName(t *testing.T) {
+	var tests = []struct {
+		in  string
+		out string
+	}{
+		{"simplest", "simplest"},
+		{"instance.with.dots-collector-headless", "instance-with-dots-collector-headless"},
+		{"TestQueryDottedServiceName.With.Dots", "testquerydottedservicename-with-dots"},
+		{"Service🦄", "service-z"},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.out, DNSName(tt.in))
+
+		matched, err := regexp.MatchString(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`, tt.out)
+		assert.NoError(t, err)
+		assert.True(t, matched, "%v is not a valid name", tt.out)
+	}
+}


### PR DESCRIPTION
Closes #466 by making the sanitizing names for services and volumes, to be DNS-compliant. Apart from this change, a name such as `jaegerqe.test` is now possible and yields no errors.

The bigger topic of "validation" in general isn't being touched by this PR. 

cc @jkandasa 

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>