### PR TITLE
Changed to always use namespace when a name is involved

### DIFF
--- a/pkg/account/main_test.go
+++ b/pkg/account/main_test.go
@@ -4,12 +4,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 )
 
 func TestWithSecurityNil(t *testing.T) {
-	jaeger := v1.NewJaeger("TestWithOAuthProxyNil")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestWithOAuthProxyNil"})
 	assert.Equal(t, v1.IngressSecurityNone, jaeger.Spec.Ingress.Security)
 	sas := Get(jaeger)
 	assert.Len(t, sas, 1)
@@ -17,7 +18,7 @@ func TestWithSecurityNil(t *testing.T) {
 }
 
 func TestWithSecurityNone(t *testing.T) {
-	jaeger := v1.NewJaeger("TestWithOAuthProxyFalse")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestWithOAuthProxyFalse"})
 	jaeger.Spec.Ingress.Security = v1.IngressSecurityNone
 	sas := Get(jaeger)
 	assert.Len(t, sas, 1)
@@ -25,14 +26,14 @@ func TestWithSecurityNone(t *testing.T) {
 }
 
 func TestWithSecurityOAuthProxy(t *testing.T) {
-	jaeger := v1.NewJaeger("TestWithOAuthProxyTrue")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestWithOAuthProxyTrue"})
 	jaeger.Spec.Ingress.Security = v1.IngressSecurityOAuthProxy
 
 	assert.Len(t, Get(jaeger), 2)
 }
 
 func TestJaegerName(t *testing.T) {
-	jaeger := v1.NewJaeger("foo")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "foo"})
 	jaeger.Spec.ServiceAccount = "bar"
 	jaeger.Spec.Collector.ServiceAccount = "col-sa"
 	jaeger.Spec.Query.ServiceAccount = "query-sa"

--- a/pkg/account/oauth_proxy_test.go
+++ b/pkg/account/oauth_proxy_test.go
@@ -5,19 +5,20 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 )
 
 func TestOAuthRedirectReference(t *testing.T) {
-	jaeger := v1.NewJaeger("TestOAuthRedirectReference")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestOAuthRedirectReference"})
 	jaeger.Spec.Ingress.Security = v1.IngressSecurityOAuthProxy
 
 	assert.Contains(t, getOAuthRedirectReference(jaeger), jaeger.Name)
 }
 
 func TestOAuthProxy(t *testing.T) {
-	jaeger := v1.NewJaeger("TestOAuthProxy")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestOAuthProxy"})
 	jaeger.Spec.Ingress.Security = v1.IngressSecurityOAuthProxy
 
 	assert.Equal(t, OAuthProxy(jaeger).Name, fmt.Sprintf("%s-ui-proxy", jaeger.Name))

--- a/pkg/apis/jaegertracing/v1/builder.go
+++ b/pkg/apis/jaegertracing/v1/builder.go
@@ -1,12 +1,16 @@
 package v1
 
-import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
 
 // NewJaeger returns a new Jaeger instance with the given name
-func NewJaeger(name string) *Jaeger {
+func NewJaeger(nsn types.NamespacedName) *Jaeger {
 	return &Jaeger{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
+			Name:      nsn.Name,
+			Namespace: nsn.Namespace,
 		},
 	}
 }

--- a/pkg/config/sampling/sampling_test.go
+++ b/pkg/config/sampling/sampling_test.go
@@ -4,12 +4,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
 
 	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 )
 
 func TestNoSamplingConfig(t *testing.T) {
-	jaeger := v1.NewJaeger("TestNoSamplingConfig")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestNoSamplingConfig"})
 
 	config := NewConfig(jaeger)
 	cm := config.Get()
@@ -19,7 +20,7 @@ func TestNoSamplingConfig(t *testing.T) {
 
 func TestWithEmptySamplingConfig(t *testing.T) {
 	uiconfig := v1.NewFreeForm(map[string]interface{}{})
-	jaeger := v1.NewJaeger("TestWithEmptySamplingConfig")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestWithEmptySamplingConfig"})
 	jaeger.Spec.UI.Options = uiconfig
 
 	config := NewConfig(jaeger)
@@ -36,7 +37,7 @@ func TestWithSamplingConfig(t *testing.T) {
 		},
 	})
 	json := `{"default_strategy":{"param":"20","type":"probabilistic"}}`
-	jaeger := v1.NewJaeger("TestWithSamplingConfig")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestWithSamplingConfig"})
 	jaeger.Spec.Sampling.Options = samplingconfig
 
 	config := NewConfig(jaeger)
@@ -45,7 +46,7 @@ func TestWithSamplingConfig(t *testing.T) {
 }
 
 func TestUpdateNoSamplingConfig(t *testing.T) {
-	jaeger := v1.NewJaeger("TestUpdateNoSamplingConfig")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestUpdateNoSamplingConfig"})
 
 	commonSpec := v1.JaegerCommonSpec{}
 	options := []string{}
@@ -65,7 +66,7 @@ func TestUpdateWithSamplingConfig(t *testing.T) {
 			"gaID": "UA-000000-2",
 		},
 	})
-	jaeger := v1.NewJaeger("TestUpdateWithSamplingConfig")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestUpdateWithSamplingConfig"})
 	jaeger.Spec.UI.Options = uiconfig
 
 	commonSpec := v1.JaegerCommonSpec{}

--- a/pkg/config/ui/ui_test.go
+++ b/pkg/config/ui/ui_test.go
@@ -4,12 +4,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
 
 	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 )
 
 func TestNoUIConfig(t *testing.T) {
-	jaeger := v1.NewJaeger("TestNoUIConfig")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestNoUIConfig"})
 
 	config := NewUIConfig(jaeger)
 	dep := config.Get()
@@ -18,7 +19,7 @@ func TestNoUIConfig(t *testing.T) {
 
 func TestWithEmptyUIConfig(t *testing.T) {
 	uiconfig := v1.NewFreeForm(map[string]interface{}{})
-	jaeger := v1.NewJaeger("TestWithEmptyUIConfig")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestWithEmptyUIConfig"})
 	jaeger.Spec.UI.Options = uiconfig
 
 	config := NewUIConfig(jaeger)
@@ -33,7 +34,7 @@ func TestWithUIConfig(t *testing.T) {
 		},
 	})
 	json := `{"tracking":{"gaID":"UA-000000-2"}}`
-	jaeger := v1.NewJaeger("TestWithUIConfig")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestWithUIConfig"})
 	jaeger.Spec.UI.Options = uiconfig
 
 	config := NewUIConfig(jaeger)
@@ -42,7 +43,7 @@ func TestWithUIConfig(t *testing.T) {
 }
 
 func TestUpdateNoUIConfig(t *testing.T) {
-	jaeger := v1.NewJaeger("TestUpdateNoUIConfig")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestUpdateNoUIConfig"})
 
 	commonSpec := v1.JaegerCommonSpec{}
 	options := []string{}
@@ -59,7 +60,7 @@ func TestUpdateWithUIConfig(t *testing.T) {
 			"gaID": "UA-000000-2",
 		},
 	})
-	jaeger := v1.NewJaeger("TestUpdateWithUIConfig")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestUpdateWithUIConfig"})
 	jaeger.Spec.UI.Options = uiconfig
 
 	commonSpec := v1.JaegerCommonSpec{}

--- a/pkg/controller/jaeger/account.go
+++ b/pkg/controller/jaeger/account.go
@@ -3,15 +3,16 @@ package jaeger
 import (
 	"context"
 
+	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/inventory"
 )
 
 func (r *ReconcileJaeger) applyAccounts(jaeger v1.Jaeger, desired []corev1.ServiceAccount) error {
-	opts := client.MatchingLabels(map[string]string{
+	opts := client.InNamespace(jaeger.Namespace).MatchingLabels(map[string]string{
 		"app.kubernetes.io/instance":   jaeger.Name,
 		"app.kubernetes.io/managed-by": "jaeger-operator",
 	})
@@ -22,21 +23,30 @@ func (r *ReconcileJaeger) applyAccounts(jaeger v1.Jaeger, desired []corev1.Servi
 
 	inv := inventory.ForAccounts(list.Items, desired)
 	for _, d := range inv.Create {
-		jaeger.Logger().WithField("account", d.Name).Debug("creating service account")
+		jaeger.Logger().WithFields(log.Fields{
+			"account":   d.Name,
+			"namespace": d.Namespace,
+		}).Debug("creating service account")
 		if err := r.client.Create(context.Background(), &d); err != nil {
 			return err
 		}
 	}
 
 	for _, d := range inv.Update {
-		jaeger.Logger().WithField("account", d.Name).Debug("updating service account")
+		jaeger.Logger().WithFields(log.Fields{
+			"account":   d.Name,
+			"namespace": d.Namespace,
+		}).Debug("updating service account")
 		if err := r.client.Update(context.Background(), &d); err != nil {
 			return err
 		}
 	}
 
 	for _, d := range inv.Delete {
-		jaeger.Logger().WithField("account", d.Name).Debug("deleting service account")
+		jaeger.Logger().WithFields(log.Fields{
+			"account":   d.Name,
+			"namespace": d.Namespace,
+		}).Debug("deleting service account")
 		if err := r.client.Delete(context.Background(), &d); err != nil {
 			return err
 		}

--- a/pkg/controller/jaeger/account_test.go
+++ b/pkg/controller/jaeger/account_test.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/strategy"
 )
 
@@ -22,7 +22,7 @@ func TestServiceAccountCreate(t *testing.T) {
 	}
 
 	objs := []runtime.Object{
-		v1.NewJaeger(nsn.Name),
+		v1.NewJaeger(nsn),
 	}
 
 	r, cl := getReconciler(objs)
@@ -67,7 +67,7 @@ func TestServiceAccountUpdate(t *testing.T) {
 	orig.Annotations = map[string]string{"key": "value"}
 
 	objs := []runtime.Object{
-		v1.NewJaeger(nsn.Name),
+		v1.NewJaeger(nsn),
 		&orig,
 	}
 
@@ -106,7 +106,7 @@ func TestServiceAccountDelete(t *testing.T) {
 	orig.Name = nsn.Name
 
 	objs := []runtime.Object{
-		v1.NewJaeger(nsn.Name),
+		v1.NewJaeger(nsn),
 		&orig,
 	}
 
@@ -128,4 +128,61 @@ func TestServiceAccountDelete(t *testing.T) {
 	err = cl.Get(context.Background(), persistedName, persisted)
 	assert.Empty(t, persisted.Name)
 	assert.Error(t, err) // not found
+}
+
+func TestAccountCreateExistingNameInAnotherNamespace(t *testing.T) {
+	// prepare
+	nsn := types.NamespacedName{
+		Name:      "TestAccountCreateExistingNameInAnotherNamespace",
+		Namespace: "tenant1",
+	}
+	nsnExisting := types.NamespacedName{
+		Name:      "TestAccountCreateExistingNameInAnotherNamespace",
+		Namespace: "tenant2",
+	}
+
+	objs := []runtime.Object{
+		v1.NewJaeger(nsn),
+		v1.NewJaeger(nsnExisting),
+		&corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      nsnExisting.Name,
+				Namespace: nsnExisting.Namespace,
+			},
+		},
+	}
+
+	req := reconcile.Request{
+		NamespacedName: nsn,
+	}
+
+	r, cl := getReconciler(objs)
+	r.strategyChooser = func(jaeger *v1.Jaeger) strategy.S {
+		s := strategy.New().WithAccounts([]corev1.ServiceAccount{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      nsn.Name,
+				Namespace: nsn.Namespace,
+			},
+		}})
+		return s
+	}
+
+	// test
+	res, err := r.Reconcile(req)
+
+	// verify
+	assert.NoError(t, err)
+	assert.False(t, res.Requeue, "We don't requeue for now")
+
+	persisted := &corev1.ServiceAccount{}
+	err = cl.Get(context.Background(), nsn, persisted)
+	assert.NoError(t, err)
+	assert.Equal(t, nsn.Name, persisted.Name)
+	assert.Equal(t, nsn.Namespace, persisted.Namespace)
+
+	persistedExisting := &corev1.ServiceAccount{}
+	err = cl.Get(context.Background(), nsnExisting, persistedExisting)
+	assert.NoError(t, err)
+	assert.Equal(t, nsnExisting.Name, persistedExisting.Name)
+	assert.Equal(t, nsnExisting.Namespace, persistedExisting.Namespace)
 }

--- a/pkg/controller/jaeger/configmap.go
+++ b/pkg/controller/jaeger/configmap.go
@@ -3,15 +3,16 @@ package jaeger
 import (
 	"context"
 
+	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/inventory"
 )
 
 func (r *ReconcileJaeger) applyConfigMaps(jaeger v1.Jaeger, desired []corev1.ConfigMap) error {
-	opts := client.MatchingLabels(map[string]string{
+	opts := client.InNamespace(jaeger.Namespace).MatchingLabels(map[string]string{
 		"app.kubernetes.io/instance":   jaeger.Name,
 		"app.kubernetes.io/managed-by": "jaeger-operator",
 	})
@@ -22,21 +23,30 @@ func (r *ReconcileJaeger) applyConfigMaps(jaeger v1.Jaeger, desired []corev1.Con
 
 	inv := inventory.ForConfigMaps(list.Items, desired)
 	for _, d := range inv.Create {
-		jaeger.Logger().WithField("configMap", d.Name).Debug("creating config maps")
+		jaeger.Logger().WithFields(log.Fields{
+			"configMap": d.Name,
+			"namespace": d.Namespace,
+		}).Debug("creating config maps")
 		if err := r.client.Create(context.Background(), &d); err != nil {
 			return err
 		}
 	}
 
 	for _, d := range inv.Update {
-		jaeger.Logger().WithField("configMap", d.Name).Debug("updating config maps")
+		jaeger.Logger().WithFields(log.Fields{
+			"configMap": d.Name,
+			"namespace": d.Namespace,
+		}).Debug("updating config maps")
 		if err := r.client.Update(context.Background(), &d); err != nil {
 			return err
 		}
 	}
 
 	for _, d := range inv.Delete {
-		jaeger.Logger().WithField("configMap", d.Name).Debug("deleting config maps")
+		jaeger.Logger().WithFields(log.Fields{
+			"configMap": d.Name,
+			"namespace": d.Namespace,
+		}).Debug("deleting config maps")
 		if err := r.client.Delete(context.Background(), &d); err != nil {
 			return err
 		}

--- a/pkg/controller/jaeger/configmap_test.go
+++ b/pkg/controller/jaeger/configmap_test.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/strategy"
 )
 
@@ -22,7 +22,7 @@ func TestConfigMapsCreate(t *testing.T) {
 	}
 
 	objs := []runtime.Object{
-		v1.NewJaeger(nsn.Name),
+		v1.NewJaeger(nsn),
 	}
 
 	req := reconcile.Request{
@@ -67,7 +67,7 @@ func TestConfigMapsUpdate(t *testing.T) {
 	orig.Annotations = map[string]string{"key": "value"}
 
 	objs := []runtime.Object{
-		v1.NewJaeger(nsn.Name),
+		v1.NewJaeger(nsn),
 		&orig,
 	}
 
@@ -106,7 +106,7 @@ func TestConfigMapsDelete(t *testing.T) {
 	orig.Name = nsn.Name
 
 	objs := []runtime.Object{
-		v1.NewJaeger(nsn.Name),
+		v1.NewJaeger(nsn),
 		&orig,
 	}
 
@@ -128,4 +128,61 @@ func TestConfigMapsDelete(t *testing.T) {
 	err = cl.Get(context.Background(), persistedName, persisted)
 	assert.Empty(t, persisted.Name)
 	assert.Error(t, err) // not found
+}
+
+func TestConfigMapCreateExistingNameInAnotherNamespace(t *testing.T) {
+	// prepare
+	nsn := types.NamespacedName{
+		Name:      "TestConfigMapCreateExistingNameInAnotherNamespace",
+		Namespace: "tenant1",
+	}
+	nsnExisting := types.NamespacedName{
+		Name:      "TestConfigMapCreateExistingNameInAnotherNamespace",
+		Namespace: "tenant2",
+	}
+
+	objs := []runtime.Object{
+		v1.NewJaeger(nsn),
+		v1.NewJaeger(nsnExisting),
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      nsnExisting.Name,
+				Namespace: nsnExisting.Namespace,
+			},
+		},
+	}
+
+	req := reconcile.Request{
+		NamespacedName: nsn,
+	}
+
+	r, cl := getReconciler(objs)
+	r.strategyChooser = func(jaeger *v1.Jaeger) strategy.S {
+		s := strategy.New().WithConfigMaps([]corev1.ConfigMap{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      nsn.Name,
+				Namespace: nsn.Namespace,
+			},
+		}})
+		return s
+	}
+
+	// test
+	res, err := r.Reconcile(req)
+
+	// verify
+	assert.NoError(t, err)
+	assert.False(t, res.Requeue, "We don't requeue for now")
+
+	persisted := &corev1.ConfigMap{}
+	err = cl.Get(context.Background(), nsn, persisted)
+	assert.NoError(t, err)
+	assert.Equal(t, nsn.Name, persisted.Name)
+	assert.Equal(t, nsn.Namespace, persisted.Namespace)
+
+	persistedExisting := &corev1.ConfigMap{}
+	err = cl.Get(context.Background(), nsnExisting, persistedExisting)
+	assert.NoError(t, err)
+	assert.Equal(t, nsnExisting.Name, persistedExisting.Name)
+	assert.Equal(t, nsnExisting.Namespace, persistedExisting.Namespace)
 }

--- a/pkg/controller/jaeger/cronjob.go
+++ b/pkg/controller/jaeger/cronjob.go
@@ -3,15 +3,16 @@ package jaeger
 import (
 	"context"
 
+	log "github.com/sirupsen/logrus"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/inventory"
 )
 
 func (r *ReconcileJaeger) applyCronJobs(jaeger v1.Jaeger, desired []batchv1beta1.CronJob) error {
-	opts := client.MatchingLabels(map[string]string{
+	opts := client.InNamespace(jaeger.Namespace).MatchingLabels(map[string]string{
 		"app.kubernetes.io/instance":   jaeger.Name,
 		"app.kubernetes.io/managed-by": "jaeger-operator",
 	})
@@ -22,21 +23,30 @@ func (r *ReconcileJaeger) applyCronJobs(jaeger v1.Jaeger, desired []batchv1beta1
 
 	inv := inventory.ForCronJobs(list.Items, desired)
 	for _, d := range inv.Create {
-		jaeger.Logger().WithField("cronjob", d.Name).Debug("creating cronjob")
+		jaeger.Logger().WithFields(log.Fields{
+			"cronjob":   d.Name,
+			"namespace": d.Namespace,
+		}).Debug("creating cronjob")
 		if err := r.client.Create(context.Background(), &d); err != nil {
 			return err
 		}
 	}
 
 	for _, d := range inv.Update {
-		jaeger.Logger().WithField("cronjob", d.Name).Debug("updating cronjob")
+		jaeger.Logger().WithFields(log.Fields{
+			"cronjob":   d.Name,
+			"namespace": d.Namespace,
+		}).Debug("updating cronjob")
 		if err := r.client.Update(context.Background(), &d); err != nil {
 			return err
 		}
 	}
 
 	for _, d := range inv.Delete {
-		jaeger.Logger().WithField("cronjob", d.Name).Debug("deleting cronjob")
+		jaeger.Logger().WithFields(log.Fields{
+			"cronjob":   d.Name,
+			"namespace": d.Namespace,
+		}).Debug("deleting cronjob")
 		if err := r.client.Delete(context.Background(), &d); err != nil {
 			return err
 		}

--- a/pkg/controller/jaeger/cronjob_test.go
+++ b/pkg/controller/jaeger/cronjob_test.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/strategy"
 )
 
@@ -22,7 +22,7 @@ func TestCronJobsCreate(t *testing.T) {
 	}
 
 	objs := []runtime.Object{
-		v1.NewJaeger(nsn.Name),
+		v1.NewJaeger(nsn),
 	}
 
 	req := reconcile.Request{
@@ -67,7 +67,7 @@ func TestCronJobsUpdate(t *testing.T) {
 	orig.Annotations = map[string]string{"key": "value"}
 
 	objs := []runtime.Object{
-		v1.NewJaeger(nsn.Name),
+		v1.NewJaeger(nsn),
 		&orig,
 	}
 
@@ -106,7 +106,7 @@ func TestCronJobsDelete(t *testing.T) {
 	orig.Name = nsn.Name
 
 	objs := []runtime.Object{
-		v1.NewJaeger(nsn.Name),
+		v1.NewJaeger(nsn),
 		&orig,
 	}
 
@@ -128,4 +128,61 @@ func TestCronJobsDelete(t *testing.T) {
 	err = cl.Get(context.Background(), persistedName, persisted)
 	assert.Empty(t, persisted.Name)
 	assert.Error(t, err) // not found
+}
+
+func TestCronJobsCreateExistingNameInAnotherNamespace(t *testing.T) {
+	// prepare
+	nsn := types.NamespacedName{
+		Name:      "TestCronJobsCreateExistingNameInAnotherNamespace",
+		Namespace: "tenant1",
+	}
+	nsnExisting := types.NamespacedName{
+		Name:      "TestCronJobsCreateExistingNameInAnotherNamespace",
+		Namespace: "tenant2",
+	}
+
+	objs := []runtime.Object{
+		v1.NewJaeger(nsn),
+		v1.NewJaeger(nsnExisting),
+		&batchv1beta1.CronJob{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      nsnExisting.Name,
+				Namespace: nsnExisting.Namespace,
+			},
+		},
+	}
+
+	req := reconcile.Request{
+		NamespacedName: nsn,
+	}
+
+	r, cl := getReconciler(objs)
+	r.strategyChooser = func(jaeger *v1.Jaeger) strategy.S {
+		s := strategy.New().WithCronJobs([]batchv1beta1.CronJob{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      nsn.Name,
+				Namespace: nsn.Namespace,
+			},
+		}})
+		return s
+	}
+
+	// test
+	res, err := r.Reconcile(req)
+
+	// verify
+	assert.NoError(t, err)
+	assert.False(t, res.Requeue, "We don't requeue for now")
+
+	persisted := &batchv1beta1.CronJob{}
+	err = cl.Get(context.Background(), nsn, persisted)
+	assert.NoError(t, err)
+	assert.Equal(t, nsn.Name, persisted.Name)
+	assert.Equal(t, nsn.Namespace, persisted.Namespace)
+
+	persistedExisting := &batchv1beta1.CronJob{}
+	err = cl.Get(context.Background(), nsnExisting, persistedExisting)
+	assert.NoError(t, err)
+	assert.Equal(t, nsnExisting.Name, persistedExisting.Name)
+	assert.Equal(t, nsnExisting.Namespace, persistedExisting.Namespace)
 }

--- a/pkg/controller/jaeger/daemonset.go
+++ b/pkg/controller/jaeger/daemonset.go
@@ -3,15 +3,16 @@ package jaeger
 import (
 	"context"
 
+	log "github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/inventory"
 )
 
 func (r *ReconcileJaeger) applyDaemonSets(jaeger v1.Jaeger, desired []appsv1.DaemonSet) error {
-	opts := client.MatchingLabels(map[string]string{
+	opts := client.InNamespace(jaeger.Namespace).MatchingLabels(map[string]string{
 		"app.kubernetes.io/instance":   jaeger.Name,
 		"app.kubernetes.io/managed-by": "jaeger-operator",
 	})
@@ -22,21 +23,30 @@ func (r *ReconcileJaeger) applyDaemonSets(jaeger v1.Jaeger, desired []appsv1.Dae
 
 	inv := inventory.ForDaemonSets(list.Items, desired)
 	for _, d := range inv.Create {
-		jaeger.Logger().WithField("daemonset", d.Name).Debug("creating daemonset")
+		jaeger.Logger().WithFields(log.Fields{
+			"daemonset": d.Name,
+			"namespace": d.Namespace,
+		}).Debug("creating daemonset")
 		if err := r.client.Create(context.Background(), &d); err != nil {
 			return err
 		}
 	}
 
 	for _, d := range inv.Update {
-		jaeger.Logger().WithField("daemonset", d.Name).Debug("updating daemonset")
+		jaeger.Logger().WithFields(log.Fields{
+			"daemonset": d.Name,
+			"namespace": d.Namespace,
+		}).Debug("updating daemonset")
 		if err := r.client.Update(context.Background(), &d); err != nil {
 			return err
 		}
 	}
 
 	for _, d := range inv.Delete {
-		jaeger.Logger().WithField("daemonset", d.Name).Debug("deleting daemonset")
+		jaeger.Logger().WithFields(log.Fields{
+			"daemonset": d.Name,
+			"namespace": d.Namespace,
+		}).Debug("deleting daemonset")
 		if err := r.client.Delete(context.Background(), &d); err != nil {
 			return err
 		}

--- a/pkg/controller/jaeger/daemonset_test.go
+++ b/pkg/controller/jaeger/daemonset_test.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/strategy"
 )
 
@@ -22,7 +22,7 @@ func TestDaemonSetsCreate(t *testing.T) {
 	}
 
 	objs := []runtime.Object{
-		v1.NewJaeger(nsn.Name),
+		v1.NewJaeger(nsn),
 	}
 
 	req := reconcile.Request{
@@ -67,7 +67,7 @@ func TestDaemonSetsUpdate(t *testing.T) {
 	orig.Annotations = map[string]string{"key": "value"}
 
 	objs := []runtime.Object{
-		v1.NewJaeger(nsn.Name),
+		v1.NewJaeger(nsn),
 		&orig,
 	}
 
@@ -106,7 +106,7 @@ func TestDaemonSetsDelete(t *testing.T) {
 	orig.Name = nsn.Name
 
 	objs := []runtime.Object{
-		v1.NewJaeger(nsn.Name),
+		v1.NewJaeger(nsn),
 		&orig,
 	}
 
@@ -128,4 +128,61 @@ func TestDaemonSetsDelete(t *testing.T) {
 	err = cl.Get(context.Background(), persistedName, persisted)
 	assert.Empty(t, persisted.Name)
 	assert.Error(t, err) // not found
+}
+
+func TestDaemonSetsCreateExistingNameInAnotherNamespace(t *testing.T) {
+	// prepare
+	nsn := types.NamespacedName{
+		Name:      "TestDaemonSetsCreateExistingNameInAnotherNamespace",
+		Namespace: "tenant1",
+	}
+	nsnExisting := types.NamespacedName{
+		Name:      "TestDaemonSetsCreateExistingNameInAnotherNamespace",
+		Namespace: "tenant2",
+	}
+
+	objs := []runtime.Object{
+		v1.NewJaeger(nsn),
+		v1.NewJaeger(nsnExisting),
+		&appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      nsnExisting.Name,
+				Namespace: nsnExisting.Namespace,
+			},
+		},
+	}
+
+	req := reconcile.Request{
+		NamespacedName: nsn,
+	}
+
+	r, cl := getReconciler(objs)
+	r.strategyChooser = func(jaeger *v1.Jaeger) strategy.S {
+		s := strategy.New().WithDaemonSets([]appsv1.DaemonSet{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      nsn.Name,
+				Namespace: nsn.Namespace,
+			},
+		}})
+		return s
+	}
+
+	// test
+	res, err := r.Reconcile(req)
+
+	// verify
+	assert.NoError(t, err)
+	assert.False(t, res.Requeue, "We don't requeue for now")
+
+	persisted := &appsv1.DaemonSet{}
+	err = cl.Get(context.Background(), nsn, persisted)
+	assert.NoError(t, err)
+	assert.Equal(t, nsn.Name, persisted.Name)
+	assert.Equal(t, nsn.Namespace, persisted.Namespace)
+
+	persistedExisting := &appsv1.DaemonSet{}
+	err = cl.Get(context.Background(), nsnExisting, persistedExisting)
+	assert.NoError(t, err)
+	assert.Equal(t, nsnExisting.Name, persistedExisting.Name)
+	assert.Equal(t, nsnExisting.Namespace, persistedExisting.Namespace)
 }

--- a/pkg/controller/jaeger/dependencies_test.go
+++ b/pkg/controller/jaeger/dependencies_test.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/strategy"
 )
 
@@ -22,7 +22,7 @@ func TestHandleDependencies(t *testing.T) {
 		Name: "TestHandleDependencies",
 	}
 
-	objs := []runtime.Object{v1.NewJaeger(nsn.Name)}
+	objs := []runtime.Object{v1.NewJaeger(nsn)}
 
 	dep := batchv1.Job{}
 	dep.Name = nsn.Name

--- a/pkg/controller/jaeger/deployment_test.go
+++ b/pkg/controller/jaeger/deployment_test.go
@@ -204,11 +204,11 @@ func TestDeploymentDeleteAfterCreate(t *testing.T) {
 func TestDeploymentCreateExistingNameInAnotherNamespace(t *testing.T) {
 	// prepare
 	nsn := types.NamespacedName{
-		Name:      "TestDeploymentCreate",
+		Name:      "TestDeploymentCreateExistingNameInAnotherNamespace",
 		Namespace: "tenant1",
 	}
 	nsnExisting := types.NamespacedName{
-		Name:      "TestDeploymentCreate",
+		Name:      "TestDeploymentCreateExistingNameInAnotherNamespace",
 		Namespace: "tenant2",
 	}
 

--- a/pkg/controller/jaeger/deployment_test.go
+++ b/pkg/controller/jaeger/deployment_test.go
@@ -13,18 +13,19 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/strategy"
 )
 
 func TestDeploymentCreate(t *testing.T) {
 	// prepare
 	nsn := types.NamespacedName{
-		Name: "TestDeploymentCreate",
+		Name:      "TestDeploymentCreate",
+		Namespace: "tenant1",
 	}
 
 	objs := []runtime.Object{
-		v1.NewJaeger(nsn.Name),
+		v1.NewJaeger(nsn),
 	}
 
 	req := reconcile.Request{
@@ -35,7 +36,8 @@ func TestDeploymentCreate(t *testing.T) {
 	r.strategyChooser = func(jaeger *v1.Jaeger) strategy.S {
 		s := strategy.New().WithDeployments([]appsv1.Deployment{{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: nsn.Name,
+				Name:      nsn.Name,
+				Namespace: nsn.Namespace,
 			},
 		}})
 		return s
@@ -61,15 +63,17 @@ func TestDeploymentCreate(t *testing.T) {
 func TestDeploymentUpdate(t *testing.T) {
 	// prepare
 	nsn := types.NamespacedName{
-		Name: "TestDeploymentUpdate",
+		Name:      "TestDeploymentUpdate",
+		Namespace: "tenant1",
 	}
 
 	depOriginal := appsv1.Deployment{}
 	depOriginal.Name = nsn.Name
+	depOriginal.Namespace = nsn.Namespace
 	depOriginal.Annotations = map[string]string{"key": "value"}
 
 	objs := []runtime.Object{
-		v1.NewJaeger(nsn.Name),
+		v1.NewJaeger(nsn),
 		&depOriginal,
 	}
 
@@ -77,6 +81,7 @@ func TestDeploymentUpdate(t *testing.T) {
 	r.strategyChooser = func(jaeger *v1.Jaeger) strategy.S {
 		depUpdated := appsv1.Deployment{}
 		depUpdated.Name = depOriginal.Name
+		depUpdated.Namespace = depOriginal.Namespace
 		depUpdated.Annotations = map[string]string{"key": "new-value"}
 
 		s := strategy.New().WithDeployments([]appsv1.Deployment{depUpdated})
@@ -108,7 +113,7 @@ func TestDeploymentDelete(t *testing.T) {
 	depOriginal.Name = nsn.Name
 
 	objs := []runtime.Object{
-		v1.NewJaeger(nsn.Name),
+		v1.NewJaeger(nsn),
 		&depOriginal,
 	}
 
@@ -145,7 +150,7 @@ func TestDeploymentDeleteAfterCreate(t *testing.T) {
 		"app.kubernetes.io/instance":   nsn.Name,
 		"app.kubernetes.io/managed-by": "jaeger-operator",
 	}
-	objs := []runtime.Object{v1.NewJaeger(nsn.Name), &depToDelete}
+	objs := []runtime.Object{v1.NewJaeger(nsn), &depToDelete}
 
 	// the deployment to be created
 	dep := appsv1.Deployment{}
@@ -194,4 +199,61 @@ func TestDeploymentDeleteAfterCreate(t *testing.T) {
 	persistedDelete = &appsv1.Deployment{}
 	assert.Error(t, cl.Get(context.Background(), types.NamespacedName{Name: depToDelete.Name, Namespace: depToDelete.Namespace}, persistedDelete))
 	assert.Empty(t, persistedDelete.Name)
+}
+
+func TestDeploymentCreateExistingNameInAnotherNamespace(t *testing.T) {
+	// prepare
+	nsn := types.NamespacedName{
+		Name:      "TestDeploymentCreate",
+		Namespace: "tenant1",
+	}
+	nsnExisting := types.NamespacedName{
+		Name:      "TestDeploymentCreate",
+		Namespace: "tenant2",
+	}
+
+	objs := []runtime.Object{
+		v1.NewJaeger(nsn),
+		v1.NewJaeger(nsnExisting),
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      nsnExisting.Name,
+				Namespace: nsnExisting.Namespace,
+			},
+		},
+	}
+
+	req := reconcile.Request{
+		NamespacedName: nsn,
+	}
+
+	r, cl := getReconciler(objs)
+	r.strategyChooser = func(jaeger *v1.Jaeger) strategy.S {
+		s := strategy.New().WithDeployments([]appsv1.Deployment{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      nsn.Name,
+				Namespace: nsn.Namespace,
+			},
+		}})
+		return s
+	}
+
+	// test
+	res, err := r.Reconcile(req)
+
+	// verify
+	assert.NoError(t, err)
+	assert.False(t, res.Requeue, "We don't requeue for now")
+
+	persisted := &appsv1.Deployment{}
+	err = cl.Get(context.Background(), nsn, persisted)
+	assert.NoError(t, err)
+	assert.Equal(t, nsn.Name, persisted.Name)
+	assert.Equal(t, nsn.Namespace, persisted.Namespace)
+
+	persistedExisting := &appsv1.Deployment{}
+	err = cl.Get(context.Background(), nsnExisting, persistedExisting)
+	assert.NoError(t, err)
+	assert.Equal(t, nsnExisting.Name, persistedExisting.Name)
+	assert.Equal(t, nsnExisting.Namespace, persistedExisting.Namespace)
 }

--- a/pkg/controller/jaeger/elasticsearch_test.go
+++ b/pkg/controller/jaeger/elasticsearch_test.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 	esv1 "github.com/jaegertracing/jaeger-operator/pkg/storage/elasticsearch/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/strategy"
 )
@@ -26,7 +26,7 @@ func TestElasticsearchesCreate(t *testing.T) {
 	}
 
 	objs := []runtime.Object{
-		v1.NewJaeger(nsn.Name),
+		v1.NewJaeger(nsn),
 	}
 
 	req := reconcile.Request{
@@ -74,7 +74,7 @@ func TestElasticsearchesUpdate(t *testing.T) {
 	orig.Annotations = map[string]string{"key": "value"}
 
 	objs := []runtime.Object{
-		v1.NewJaeger(nsn.Name),
+		v1.NewJaeger(nsn),
 		&orig,
 	}
 
@@ -116,7 +116,7 @@ func TestElasticsearchesDelete(t *testing.T) {
 	orig.Name = nsn.Name
 
 	objs := []runtime.Object{
-		v1.NewJaeger(nsn.Name),
+		v1.NewJaeger(nsn),
 		&orig,
 	}
 
@@ -138,4 +138,64 @@ func TestElasticsearchesDelete(t *testing.T) {
 	err = cl.Get(context.Background(), persistedName, persisted)
 	assert.Empty(t, persisted.Name)
 	assert.Error(t, err) // not found
+}
+
+func TestElasticsearchesCreateExistingNameInAnotherNamespace(t *testing.T) {
+	// prepare
+	viper.Set("es-provision", v1.FlagProvisionElasticsearchTrue)
+	defer viper.Reset()
+
+	nsn := types.NamespacedName{
+		Name:      "TestDaemonSetsCreateExistingNameInAnotherNamespace",
+		Namespace: "tenant1",
+	}
+	nsnExisting := types.NamespacedName{
+		Name:      "TestDaemonSetsCreateExistingNameInAnotherNamespace",
+		Namespace: "tenant2",
+	}
+
+	objs := []runtime.Object{
+		v1.NewJaeger(nsn),
+		v1.NewJaeger(nsnExisting),
+		&esv1.Elasticsearch{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      nsnExisting.Name,
+				Namespace: nsnExisting.Namespace,
+			},
+		},
+	}
+
+	req := reconcile.Request{
+		NamespacedName: nsn,
+	}
+
+	r, cl := getReconciler(objs)
+	r.strategyChooser = func(jaeger *v1.Jaeger) strategy.S {
+		s := strategy.New().WithElasticsearches([]esv1.Elasticsearch{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      nsn.Name,
+				Namespace: nsn.Namespace,
+			},
+		}})
+		return s
+	}
+
+	// test
+	res, err := r.Reconcile(req)
+
+	// verify
+	assert.NoError(t, err)
+	assert.False(t, res.Requeue, "We don't requeue for now")
+
+	persisted := &esv1.Elasticsearch{}
+	err = cl.Get(context.Background(), nsn, persisted)
+	assert.NoError(t, err)
+	assert.Equal(t, nsn.Name, persisted.Name)
+	assert.Equal(t, nsn.Namespace, persisted.Namespace)
+
+	persistedExisting := &esv1.Elasticsearch{}
+	err = cl.Get(context.Background(), nsnExisting, persistedExisting)
+	assert.NoError(t, err)
+	assert.Equal(t, nsnExisting.Name, persistedExisting.Name)
+	assert.Equal(t, nsnExisting.Namespace, persistedExisting.Namespace)
 }

--- a/pkg/controller/jaeger/elasticsearch_test.go
+++ b/pkg/controller/jaeger/elasticsearch_test.go
@@ -146,11 +146,11 @@ func TestElasticsearchesCreateExistingNameInAnotherNamespace(t *testing.T) {
 	defer viper.Reset()
 
 	nsn := types.NamespacedName{
-		Name:      "TestDaemonSetsCreateExistingNameInAnotherNamespace",
+		Name:      "TestElasticsearchesCreateExistingNameInAnotherNamespace",
 		Namespace: "tenant1",
 	}
 	nsnExisting := types.NamespacedName{
-		Name:      "TestDaemonSetsCreateExistingNameInAnotherNamespace",
+		Name:      "TestElasticsearchesCreateExistingNameInAnotherNamespace",
 		Namespace: "tenant2",
 	}
 

--- a/pkg/controller/jaeger/jaeger_controller_test.go
+++ b/pkg/controller/jaeger/jaeger_controller_test.go
@@ -13,7 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 	esv1 "github.com/jaegertracing/jaeger-operator/pkg/storage/elasticsearch/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/strategy"
 )
@@ -25,7 +25,7 @@ func TestNewJaegerInstance(t *testing.T) {
 	}
 
 	objs := []runtime.Object{
-		v1.NewJaeger(nsn.Name),
+		v1.NewJaeger(nsn),
 	}
 
 	req := reconcile.Request{
@@ -61,7 +61,7 @@ func TestDeletedInstance(t *testing.T) {
 
 	// we should just not fail, as there won't be anything to do
 	// all our objects should have an OwnerReference, so that when the jaeger object is deleted, the owned objects are deleted as well
-	jaeger := v1.NewJaeger("TestDeletedInstance")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestDeletedInstance"})
 	s := scheme.Scheme
 	s.AddKnownTypes(v1.SchemeGroupVersion, jaeger)
 

--- a/pkg/controller/jaeger/route.go
+++ b/pkg/controller/jaeger/route.go
@@ -4,14 +4,15 @@ import (
 	"context"
 
 	osv1 "github.com/openshift/api/route/v1"
+	log "github.com/sirupsen/logrus"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/inventory"
 )
 
 func (r *ReconcileJaeger) applyRoutes(jaeger v1.Jaeger, desired []osv1.Route) error {
-	opts := client.MatchingLabels(map[string]string{
+	opts := client.InNamespace(jaeger.Namespace).MatchingLabels(map[string]string{
 		"app.kubernetes.io/instance":   jaeger.Name,
 		"app.kubernetes.io/managed-by": "jaeger-operator",
 	})
@@ -22,21 +23,30 @@ func (r *ReconcileJaeger) applyRoutes(jaeger v1.Jaeger, desired []osv1.Route) er
 
 	inv := inventory.ForRoutes(list.Items, desired)
 	for _, d := range inv.Create {
-		jaeger.Logger().WithField("route", d.Name).Debug("creating route")
+		jaeger.Logger().WithFields(log.Fields{
+			"route":     d.Name,
+			"namespace": d.Namespace,
+		}).Debug("creating route")
 		if err := r.client.Create(context.Background(), &d); err != nil {
 			return err
 		}
 	}
 
 	for _, d := range inv.Update {
-		jaeger.Logger().WithField("route", d.Name).Debug("updating route")
+		jaeger.Logger().WithFields(log.Fields{
+			"route":     d.Name,
+			"namespace": d.Namespace,
+		}).Debug("updating route")
 		if err := r.client.Update(context.Background(), &d); err != nil {
 			return err
 		}
 	}
 
 	for _, d := range inv.Delete {
-		jaeger.Logger().WithField("route", d.Name).Debug("deleting route")
+		jaeger.Logger().WithFields(log.Fields{
+			"route":     d.Name,
+			"namespace": d.Namespace,
+		}).Debug("deleting route")
 		if err := r.client.Delete(context.Background(), &d); err != nil {
 			return err
 		}

--- a/pkg/controller/jaeger/secret.go
+++ b/pkg/controller/jaeger/secret.go
@@ -3,15 +3,16 @@ package jaeger
 import (
 	"context"
 
+	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/inventory"
 )
 
 func (r *ReconcileJaeger) applySecrets(jaeger v1.Jaeger, desired []corev1.Secret) error {
-	opts := client.MatchingLabels(map[string]string{
+	opts := client.InNamespace(jaeger.Namespace).MatchingLabels(map[string]string{
 		"app.kubernetes.io/instance":   jaeger.Name,
 		"app.kubernetes.io/managed-by": "jaeger-operator",
 	})
@@ -22,21 +23,30 @@ func (r *ReconcileJaeger) applySecrets(jaeger v1.Jaeger, desired []corev1.Secret
 
 	inv := inventory.ForSecrets(list.Items, desired)
 	for _, d := range inv.Create {
-		jaeger.Logger().WithField("secret", d.Name).Debug("creating secrets")
+		jaeger.Logger().WithFields(log.Fields{
+			"secret":    d.Name,
+			"namespace": d.Namespace,
+		}).Debug("creating secrets")
 		if err := r.client.Create(context.Background(), &d); err != nil {
 			return err
 		}
 	}
 
 	for _, d := range inv.Update {
-		jaeger.Logger().WithField("secret", d.Name).Debug("updating secrets")
+		jaeger.Logger().WithFields(log.Fields{
+			"secret":    d.Name,
+			"namespace": d.Namespace,
+		}).Debug("updating secrets")
 		if err := r.client.Update(context.Background(), &d); err != nil {
 			return err
 		}
 	}
 
 	for _, d := range inv.Delete {
-		jaeger.Logger().WithField("secret", d.Name).Debug("deleting secrets")
+		jaeger.Logger().WithFields(log.Fields{
+			"secret":    d.Name,
+			"namespace": d.Namespace,
+		}).Debug("deleting secrets")
 		if err := r.client.Delete(context.Background(), &d); err != nil {
 			return err
 		}

--- a/pkg/controller/jaeger/secret_test.go
+++ b/pkg/controller/jaeger/secret_test.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/strategy"
 )
 
@@ -22,7 +22,7 @@ func TestSecretsCreate(t *testing.T) {
 	}
 
 	objs := []runtime.Object{
-		v1.NewJaeger(nsn.Name),
+		v1.NewJaeger(nsn),
 	}
 
 	req := reconcile.Request{
@@ -67,7 +67,7 @@ func TestSecretsUpdate(t *testing.T) {
 	orig.Annotations = map[string]string{"key": "value"}
 
 	objs := []runtime.Object{
-		v1.NewJaeger(nsn.Name),
+		v1.NewJaeger(nsn),
 		&orig,
 	}
 
@@ -106,7 +106,7 @@ func TestSecretsDelete(t *testing.T) {
 	orig.Name = nsn.Name
 
 	objs := []runtime.Object{
-		v1.NewJaeger(nsn.Name),
+		v1.NewJaeger(nsn),
 		&orig,
 	}
 
@@ -128,4 +128,61 @@ func TestSecretsDelete(t *testing.T) {
 	err = cl.Get(context.Background(), persistedName, persisted)
 	assert.Empty(t, persisted.Name)
 	assert.Error(t, err) // not found
+}
+
+func TestSecretsCreateExistingNameInAnotherNamespace(t *testing.T) {
+	// prepare
+	nsn := types.NamespacedName{
+		Name:      "TestSecretsCreateExistingNameInAnotherNamespace",
+		Namespace: "tenant1",
+	}
+	nsnExisting := types.NamespacedName{
+		Name:      "TestSecretsCreateExistingNameInAnotherNamespace",
+		Namespace: "tenant2",
+	}
+
+	objs := []runtime.Object{
+		v1.NewJaeger(nsn),
+		v1.NewJaeger(nsnExisting),
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      nsnExisting.Name,
+				Namespace: nsnExisting.Namespace,
+			},
+		},
+	}
+
+	req := reconcile.Request{
+		NamespacedName: nsn,
+	}
+
+	r, cl := getReconciler(objs)
+	r.strategyChooser = func(jaeger *v1.Jaeger) strategy.S {
+		s := strategy.New().WithSecrets([]corev1.Secret{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      nsn.Name,
+				Namespace: nsn.Namespace,
+			},
+		}})
+		return s
+	}
+
+	// test
+	res, err := r.Reconcile(req)
+
+	// verify
+	assert.NoError(t, err)
+	assert.False(t, res.Requeue, "We don't requeue for now")
+
+	persisted := &corev1.Secret{}
+	err = cl.Get(context.Background(), nsn, persisted)
+	assert.NoError(t, err)
+	assert.Equal(t, nsn.Name, persisted.Name)
+	assert.Equal(t, nsn.Namespace, persisted.Namespace)
+
+	persistedExisting := &corev1.Secret{}
+	err = cl.Get(context.Background(), nsnExisting, persistedExisting)
+	assert.NoError(t, err)
+	assert.Equal(t, nsnExisting.Name, persistedExisting.Name)
+	assert.Equal(t, nsnExisting.Namespace, persistedExisting.Namespace)
 }

--- a/pkg/controller/jaeger/service.go
+++ b/pkg/controller/jaeger/service.go
@@ -3,15 +3,16 @@ package jaeger
 import (
 	"context"
 
+	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/inventory"
 )
 
 func (r *ReconcileJaeger) applyServices(jaeger v1.Jaeger, desired []corev1.Service) error {
-	opts := client.MatchingLabels(map[string]string{
+	opts := client.InNamespace(jaeger.Namespace).MatchingLabels(map[string]string{
 		"app.kubernetes.io/instance":   jaeger.Name,
 		"app.kubernetes.io/managed-by": "jaeger-operator",
 	})
@@ -22,21 +23,30 @@ func (r *ReconcileJaeger) applyServices(jaeger v1.Jaeger, desired []corev1.Servi
 
 	inv := inventory.ForServices(list.Items, desired)
 	for _, d := range inv.Create {
-		jaeger.Logger().WithField("service", d.Name).Debug("creating service")
+		jaeger.Logger().WithFields(log.Fields{
+			"service":   d.Name,
+			"namespace": d.Namespace,
+		}).Debug("creating service")
 		if err := r.client.Create(context.Background(), &d); err != nil {
 			return err
 		}
 	}
 
 	for _, d := range inv.Update {
-		jaeger.Logger().WithField("service", d.Name).Debug("updating service")
+		jaeger.Logger().WithFields(log.Fields{
+			"service":   d.Name,
+			"namespace": d.Namespace,
+		}).Debug("updating service")
 		if err := r.client.Update(context.Background(), &d); err != nil {
 			return err
 		}
 	}
 
 	for _, d := range inv.Delete {
-		jaeger.Logger().WithField("service", d.Name).Debug("deleting service")
+		jaeger.Logger().WithFields(log.Fields{
+			"service":   d.Name,
+			"namespace": d.Namespace,
+		}).Debug("deleting service")
 		if err := r.client.Delete(context.Background(), &d); err != nil {
 			return err
 		}

--- a/pkg/controller/jaeger/service_test.go
+++ b/pkg/controller/jaeger/service_test.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/strategy"
 )
 
@@ -22,7 +22,7 @@ func TestServicesCreate(t *testing.T) {
 	}
 
 	objs := []runtime.Object{
-		v1.NewJaeger(nsn.Name),
+		v1.NewJaeger(nsn),
 	}
 
 	req := reconcile.Request{
@@ -67,7 +67,7 @@ func TestServicesUpdate(t *testing.T) {
 	orig.Annotations = map[string]string{"key": "value"}
 
 	objs := []runtime.Object{
-		v1.NewJaeger(nsn.Name),
+		v1.NewJaeger(nsn),
 		&orig,
 	}
 
@@ -106,7 +106,7 @@ func TestServicesDelete(t *testing.T) {
 	orig.Name = nsn.Name
 
 	objs := []runtime.Object{
-		v1.NewJaeger(nsn.Name),
+		v1.NewJaeger(nsn),
 		&orig,
 	}
 
@@ -128,4 +128,61 @@ func TestServicesDelete(t *testing.T) {
 	err = cl.Get(context.Background(), persistedName, persisted)
 	assert.Empty(t, persisted.Name)
 	assert.Error(t, err) // not found
+}
+
+func TestServicesCreateExistingNameInAnotherNamespace(t *testing.T) {
+	// prepare
+	nsn := types.NamespacedName{
+		Name:      "TestServicesCreateExistingNameInAnotherNamespace",
+		Namespace: "tenant1",
+	}
+	nsnExisting := types.NamespacedName{
+		Name:      "TestServicesCreateExistingNameInAnotherNamespace",
+		Namespace: "tenant2",
+	}
+
+	objs := []runtime.Object{
+		v1.NewJaeger(nsn),
+		v1.NewJaeger(nsnExisting),
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      nsnExisting.Name,
+				Namespace: nsnExisting.Namespace,
+			},
+		},
+	}
+
+	req := reconcile.Request{
+		NamespacedName: nsn,
+	}
+
+	r, cl := getReconciler(objs)
+	r.strategyChooser = func(jaeger *v1.Jaeger) strategy.S {
+		s := strategy.New().WithServices([]corev1.Service{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      nsn.Name,
+				Namespace: nsn.Namespace,
+			},
+		}})
+		return s
+	}
+
+	// test
+	res, err := r.Reconcile(req)
+
+	// verify
+	assert.NoError(t, err)
+	assert.False(t, res.Requeue, "We don't requeue for now")
+
+	persisted := &corev1.Service{}
+	err = cl.Get(context.Background(), nsn, persisted)
+	assert.NoError(t, err)
+	assert.Equal(t, nsn.Name, persisted.Name)
+	assert.Equal(t, nsn.Namespace, persisted.Namespace)
+
+	persistedExisting := &corev1.Service{}
+	err = cl.Get(context.Background(), nsnExisting, persistedExisting)
+	assert.NoError(t, err)
+	assert.Equal(t, nsnExisting.Name, persistedExisting.Name)
+	assert.Equal(t, nsnExisting.Namespace, persistedExisting.Namespace)
 }

--- a/pkg/cronjob/es_index_cleaner_test.go
+++ b/pkg/cronjob/es_index_cleaner_test.go
@@ -4,8 +4,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 )
 
 func TestCreateEsIndexCleaner(t *testing.T) {
@@ -26,7 +27,7 @@ func TestCreateEsIndexCleaner(t *testing.T) {
 }
 
 func TestEsIndexCleanerSecrets(t *testing.T) {
-	jaeger := v1.NewJaeger("TestEsIndexCleanerSecrets")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestEsIndexCleanerSecrets"})
 	secret := "mysecret"
 	jaeger.Spec.Storage.SecretName = secret
 

--- a/pkg/cronjob/es_rollover_test.go
+++ b/pkg/cronjob/es_rollover_test.go
@@ -7,18 +7,19 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/util"
 )
 
 func TestCreateRollover(t *testing.T) {
-	cj := CreateRollover(v1.NewJaeger("pikachu"))
+	cj := CreateRollover(v1.NewJaeger(types.NamespacedName{Name: "pikachu"}))
 	assert.Equal(t, 2, len(cj))
 }
 
 func TestRollover(t *testing.T) {
-	j := v1.NewJaeger("eevee")
+	j := v1.NewJaeger(types.NamespacedName{Name: "eevee"})
 	j.Namespace = "kitchen"
 	j.Spec.Storage.Rollover.Image = "wohooo"
 	j.Spec.Storage.Rollover.Conditions = "weheee"
@@ -38,7 +39,7 @@ func TestRollover(t *testing.T) {
 }
 
 func TestLookback(t *testing.T) {
-	j := v1.NewJaeger("squirtle")
+	j := v1.NewJaeger(types.NamespacedName{Name: "squirtle"})
 	j.Namespace = "kitchen"
 	j.Spec.Storage.Rollover.Image = "wohooo"
 	j.Spec.Storage.Rollover.ReadTTL = "2h"

--- a/pkg/deployment/agent_test.go
+++ b/pkg/deployment/agent_test.go
@@ -9,8 +9,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 )
 
 func setDefaults() {
@@ -28,7 +29,7 @@ func reset() {
 }
 
 func TestNewAgent(t *testing.T) {
-	jaeger := v1.NewJaeger("TestNewAgent")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestNewAgent"})
 	NewAgent(jaeger)
 	assert.Contains(t, jaeger.Spec.Agent.Image, "jaeger-agent")
 }
@@ -38,26 +39,26 @@ func TestDefaultAgentImage(t *testing.T) {
 	viper.Set("jaeger-version", "123")
 	defer reset()
 
-	jaeger := v1.NewJaeger("TestNewAgent")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestNewAgent"})
 	NewAgent(jaeger)
 	assert.Equal(t, "org/custom-agent-image:123", jaeger.Spec.Agent.Image)
 }
 
 func TestGetDefaultAgentDeployment(t *testing.T) {
-	jaeger := v1.NewJaeger("TestNewAgent")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestNewAgent"})
 	agent := NewAgent(jaeger)
 	assert.Nil(t, agent.Get()) // it's not implemented yet
 }
 
 func TestGetSidecarDeployment(t *testing.T) {
-	jaeger := v1.NewJaeger("TestNewAgent")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestNewAgent"})
 	jaeger.Spec.Agent.Strategy = "sidecar"
 	agent := NewAgent(jaeger)
 	assert.Nil(t, agent.Get()) // it's not implemented yet
 }
 
 func TestGetDaemonSetDeployment(t *testing.T) {
-	jaeger := v1.NewJaeger("TestNewAgent")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestNewAgent"})
 	jaeger.Spec.Agent.Strategy = "daemonset"
 	agent := NewAgent(jaeger)
 
@@ -66,7 +67,7 @@ func TestGetDaemonSetDeployment(t *testing.T) {
 }
 
 func TestDaemonSetAgentAnnotations(t *testing.T) {
-	jaeger := v1.NewJaeger("TestDaemonSetAgentAnnotations")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestDaemonSetAgentAnnotations"})
 	jaeger.Spec.Agent.Strategy = "daemonset"
 	jaeger.Spec.Annotations = map[string]string{
 		"name":  "operator",
@@ -87,7 +88,7 @@ func TestDaemonSetAgentAnnotations(t *testing.T) {
 }
 
 func TestDaemonSetAgentLabels(t *testing.T) {
-	jaeger := v1.NewJaeger("TestDaemonSetAgentLabels")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestDaemonSetAgentLabels"})
 	jaeger.Spec.Agent.Strategy = "daemonset"
 	jaeger.Spec.Labels = map[string]string{
 		"name":  "operator",
@@ -107,7 +108,7 @@ func TestDaemonSetAgentLabels(t *testing.T) {
 }
 
 func TestDaemonSetAgentResources(t *testing.T) {
-	jaeger := v1.NewJaeger("TestDaemonSetAgentResources")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestDaemonSetAgentResources"})
 	jaeger.Spec.Agent.Strategy = "daemonset"
 	jaeger.Spec.Resources = corev1.ResourceRequirements{
 		Limits: corev1.ResourceList{
@@ -142,7 +143,7 @@ func TestDaemonSetAgentResources(t *testing.T) {
 }
 
 func TestAgentLabels(t *testing.T) {
-	jaeger := v1.NewJaeger("TestAgentLabels")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestAgentLabels"})
 	jaeger.Spec.Agent.Strategy = "daemonset"
 	a := NewAgent(jaeger)
 	dep := a.Get()
@@ -153,7 +154,7 @@ func TestAgentLabels(t *testing.T) {
 }
 
 func TestAgentOrderOfArguments(t *testing.T) {
-	jaeger := v1.NewJaeger("TestAgentOrderOfArguments")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestAgentOrderOfArguments"})
 	jaeger.Spec.Agent.Strategy = "daemonset"
 	jaeger.Spec.Agent.Options = v1.NewOptions(map[string]interface{}{
 		"b-option": "b-value",
@@ -176,7 +177,7 @@ func TestAgentOrderOfArguments(t *testing.T) {
 }
 
 func TestAgentOverrideReporterType(t *testing.T) {
-	jaeger := v1.NewJaeger("TestAgentOrderOfArguments")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestAgentOrderOfArguments"})
 	jaeger.Spec.Agent.Strategy = "daemonset"
 	jaeger.Spec.Agent.Options = v1.NewOptions(map[string]interface{}{
 		"reporter.type":             "thrift",

--- a/pkg/deployment/all-in-one_test.go
+++ b/pkg/deployment/all-in-one_test.go
@@ -8,8 +8,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 )
 
 func init() {
@@ -22,7 +23,7 @@ func TestDefaultAllInOneImage(t *testing.T) {
 	viper.Set("jaeger-version", "123")
 	defer viper.Reset()
 
-	d := NewAllInOne(v1.NewJaeger("TestAllInOneDefaultImage")).Get()
+	d := NewAllInOne(v1.NewJaeger(types.NamespacedName{Name: "TestAllInOneDefaultImage"})).Get()
 
 	assert.Len(t, d.Spec.Template.Spec.Containers, 1)
 	assert.Equal(t, "org/custom-all-in-one-image:123", d.Spec.Template.Spec.Containers[0].Image)
@@ -41,7 +42,7 @@ func TestDefaultAllInOneImage(t *testing.T) {
 }
 
 func TestAllInOneAnnotations(t *testing.T) {
-	jaeger := v1.NewJaeger("TestAllInOneAnnotations")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestAllInOneAnnotations"})
 	jaeger.Spec.Annotations = map[string]string{
 		"name":  "operator",
 		"hello": "jaeger",
@@ -61,7 +62,7 @@ func TestAllInOneAnnotations(t *testing.T) {
 }
 
 func TestAllInOneLabels(t *testing.T) {
-	jaeger := v1.NewJaeger("TestAllInOneLabels")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestAllInOneLabels"})
 	jaeger.Spec.Labels = map[string]string{
 		"name":  "operator",
 		"hello": "jaeger",
@@ -81,13 +82,13 @@ func TestAllInOneLabels(t *testing.T) {
 
 func TestAllInOneHasOwner(t *testing.T) {
 	name := "TestAllInOneHasOwner"
-	a := NewAllInOne(v1.NewJaeger(name))
+	a := NewAllInOne(v1.NewJaeger(types.NamespacedName{Name: name}))
 	assert.Equal(t, name, a.Get().ObjectMeta.Name)
 }
 
 func TestAllInOneNumberOfServices(t *testing.T) {
 	name := "TestNumberOfServices"
-	services := NewAllInOne(v1.NewJaeger(name)).Services()
+	services := NewAllInOne(v1.NewJaeger(types.NamespacedName{Name: name})).Services()
 	assert.Len(t, services, 4) // collector (headless and cluster IP), query, agent
 
 	for _, svc := range services {
@@ -117,7 +118,7 @@ func TestAllInOneVolumeMountsWithVolumes(t *testing.T) {
 		Name: "allInOneVolume",
 	}}
 
-	jaeger := v1.NewJaeger(name)
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: name})
 	jaeger.Spec.Volumes = globalVolumes
 	jaeger.Spec.VolumeMounts = globalVolumeMounts
 	jaeger.Spec.AllInOne.Volumes = allInOneVolumes
@@ -136,7 +137,7 @@ func TestAllInOneVolumeMountsWithVolumes(t *testing.T) {
 }
 
 func TestAllInOneSecrets(t *testing.T) {
-	jaeger := v1.NewJaeger("TestAllInOneSecrets")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestAllInOneSecrets"})
 	secret := "mysecret"
 	jaeger.Spec.Storage.SecretName = secret
 
@@ -159,7 +160,7 @@ func TestAllInOneMountGlobalVolumes(t *testing.T) {
 		ReadOnly: true,
 	}}
 
-	jaeger := v1.NewJaeger(name)
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: name})
 	jaeger.Spec.Volumes = globalVolumes
 	jaeger.Spec.AllInOne.VolumeMounts = allInOneVolumeMounts
 	podSpec := NewAllInOne(jaeger).Get().Spec.Template.Spec
@@ -183,7 +184,7 @@ func TestAllInOneVolumeMountsWithSameName(t *testing.T) {
 		ReadOnly: false,
 	}}
 
-	jaeger := v1.NewJaeger(name)
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: name})
 	jaeger.Spec.VolumeMounts = globalVolumeMounts
 	jaeger.Spec.AllInOne.VolumeMounts = allInOneVolumeMounts
 	podSpec := NewAllInOne(jaeger).Get().Spec.Template.Spec
@@ -207,7 +208,7 @@ func TestAllInOneVolumeWithSameName(t *testing.T) {
 		VolumeSource: corev1.VolumeSource{HostPath: &corev1.HostPathVolumeSource{Path: "/data2"}},
 	}}
 
-	jaeger := v1.NewJaeger(name)
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: name})
 	jaeger.Spec.Volumes = globalVolumes
 	jaeger.Spec.AllInOne.Volumes = allInOneVolumes
 	podSpec := NewAllInOne(jaeger).Get().Spec.Template.Spec
@@ -219,7 +220,7 @@ func TestAllInOneVolumeWithSameName(t *testing.T) {
 }
 
 func TestAllInOneResources(t *testing.T) {
-	jaeger := v1.NewJaeger("TestAllInOneResources")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestAllInOneResources"})
 	jaeger.Spec.Resources = corev1.ResourceRequirements{
 		Limits: corev1.ResourceList{
 			corev1.ResourceLimitsCPU:              *resource.NewQuantity(1024, resource.BinarySI),
@@ -253,7 +254,7 @@ func TestAllInOneResources(t *testing.T) {
 }
 
 func TestAllInOneStandardLabels(t *testing.T) {
-	a := NewAllInOne(v1.NewJaeger("TestAllInOneStandardLabels"))
+	a := NewAllInOne(v1.NewJaeger(types.NamespacedName{Name: "TestAllInOneStandardLabels"}))
 	dep := a.Get()
 	assert.Equal(t, "jaeger-operator", dep.Spec.Template.Labels["app.kubernetes.io/managed-by"])
 	assert.Equal(t, "all-in-one", dep.Spec.Template.Labels["app.kubernetes.io/component"])
@@ -262,7 +263,7 @@ func TestAllInOneStandardLabels(t *testing.T) {
 }
 
 func TestAllInOneOrderOfArguments(t *testing.T) {
-	jaeger := v1.NewJaeger("TestAllInOneOrderOfArguments")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestAllInOneOrderOfArguments"})
 	jaeger.Spec.AllInOne.Options = v1.NewOptions(map[string]interface{}{
 		"b-option": "b-value",
 		"a-option": "a-value",

--- a/pkg/deployment/args_test.go
+++ b/pkg/deployment/args_test.go
@@ -5,13 +5,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 )
 
 func TestArgs(t *testing.T) {
 	// prepare
-	jaeger := v1.NewJaeger("TestArgs")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestArgs"})
 	jaeger.Spec.Storage.Options = v1.NewOptions(map[string]interface{}{"memory.max-traces": 10000})
 	jaeger.Spec.AllInOne.Options = v1.NewOptions(map[string]interface{}{"collector.http-port": 14268})
 

--- a/pkg/deployment/collector_test.go
+++ b/pkg/deployment/collector_test.go
@@ -10,8 +10,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 )
 
 func init() {
@@ -20,7 +21,7 @@ func init() {
 }
 
 func TestNegativeSize(t *testing.T) {
-	jaeger := v1.NewJaeger("TestNegativeSize")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestNegativeSize"})
 	jaeger.Spec.Collector.Size = -1
 
 	collector := NewCollector(jaeger)
@@ -30,7 +31,7 @@ func TestNegativeSize(t *testing.T) {
 
 func TestNegativeReplicas(t *testing.T) {
 	size := int32(-1)
-	jaeger := v1.NewJaeger("TestNegativeReplicas")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestNegativeReplicas"})
 	jaeger.Spec.Collector.Replicas = &size
 
 	collector := NewCollector(jaeger)
@@ -39,7 +40,7 @@ func TestNegativeReplicas(t *testing.T) {
 }
 
 func TestDefaultSize(t *testing.T) {
-	jaeger := v1.NewJaeger("TestDefaultSize")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestDefaultSize"})
 
 	collector := NewCollector(jaeger)
 	dep := collector.Get()
@@ -48,7 +49,7 @@ func TestDefaultSize(t *testing.T) {
 
 func TestReplicaSize(t *testing.T) {
 	size := int32(0)
-	jaeger := v1.NewJaeger("TestReplicaSize")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestReplicaSize"})
 	jaeger.Spec.Collector.Replicas = &size
 
 	collector := NewCollector(jaeger)
@@ -57,7 +58,7 @@ func TestReplicaSize(t *testing.T) {
 }
 
 func TestSize(t *testing.T) {
-	jaeger := v1.NewJaeger("TestSize")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestSize"})
 	jaeger.Spec.Collector.Size = 2
 
 	collector := NewCollector(jaeger)
@@ -67,7 +68,7 @@ func TestSize(t *testing.T) {
 
 func TestReplicaWinsOverSize(t *testing.T) {
 	size := int32(3)
-	jaeger := v1.NewJaeger("TestReplicaWinsOverSize")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestReplicaWinsOverSize"})
 	jaeger.Spec.Collector.Size = 2
 	jaeger.Spec.Collector.Replicas = &size
 
@@ -77,13 +78,13 @@ func TestReplicaWinsOverSize(t *testing.T) {
 }
 
 func TestName(t *testing.T) {
-	collector := NewCollector(v1.NewJaeger("TestName"))
+	collector := NewCollector(v1.NewJaeger(types.NamespacedName{Name: "TestName"}))
 	dep := collector.Get()
 	assert.Equal(t, "TestName-collector", dep.ObjectMeta.Name)
 }
 
 func TestCollectorServices(t *testing.T) {
-	collector := NewCollector(v1.NewJaeger("TestName"))
+	collector := NewCollector(v1.NewJaeger(types.NamespacedName{Name: "TestName"}))
 	svcs := collector.Services()
 	assert.Len(t, svcs, 2) // headless and cluster IP
 }
@@ -93,7 +94,7 @@ func TestDefaultCollectorImage(t *testing.T) {
 	viper.Set("jaeger-version", "123")
 	defer viper.Reset()
 
-	collector := NewCollector(v1.NewJaeger("TestCollectorImage"))
+	collector := NewCollector(v1.NewJaeger(types.NamespacedName{Name: "TestCollectorImage"}))
 	dep := collector.Get()
 
 	containers := dep.Spec.Template.Spec.Containers
@@ -114,7 +115,7 @@ func TestDefaultCollectorImage(t *testing.T) {
 }
 
 func TestCollectorAnnotations(t *testing.T) {
-	jaeger := v1.NewJaeger("TestCollectorAnnotations")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestCollectorAnnotations"})
 	jaeger.Spec.Annotations = map[string]string{
 		"name":  "operator",
 		"hello": "jaeger",
@@ -134,7 +135,7 @@ func TestCollectorAnnotations(t *testing.T) {
 }
 
 func TestCollectorLabels(t *testing.T) {
-	jaeger := v1.NewJaeger("TestCollectorLabels")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestCollectorLabels"})
 	jaeger.Spec.Labels = map[string]string{
 		"name":  "operator",
 		"hello": "jaeger",
@@ -153,7 +154,7 @@ func TestCollectorLabels(t *testing.T) {
 }
 
 func TestCollectorSecrets(t *testing.T) {
-	jaeger := v1.NewJaeger("TestCollectorSecrets")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestCollectorSecrets"})
 	secret := "mysecret"
 	jaeger.Spec.Storage.SecretName = secret
 
@@ -192,7 +193,7 @@ func TestCollectorVolumeMountsWithVolumes(t *testing.T) {
 		},
 	}
 
-	jaeger := v1.NewJaeger(name)
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: name})
 	jaeger.Spec.Volumes = globalVolumes
 	jaeger.Spec.VolumeMounts = globalVolumeMounts
 	jaeger.Spec.Collector.Volumes = collectorVolumes
@@ -227,7 +228,7 @@ func TestCollectorMountGlobalVolumes(t *testing.T) {
 		},
 	}
 
-	jaeger := v1.NewJaeger(name)
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: name})
 	jaeger.Spec.Volumes = globalVolumes
 	jaeger.Spec.Collector.VolumeMounts = collectorVolumeMounts
 	podSpec := NewCollector(jaeger).Get().Spec.Template.Spec
@@ -255,7 +256,7 @@ func TestCollectorVolumeMountsWithSameName(t *testing.T) {
 		},
 	}
 
-	jaeger := v1.NewJaeger(name)
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: name})
 	jaeger.Spec.VolumeMounts = globalVolumeMounts
 	jaeger.Spec.Collector.VolumeMounts = collectorVolumeMounts
 	podSpec := NewCollector(jaeger).Get().Spec.Template.Spec
@@ -283,7 +284,7 @@ func TestCollectorVolumeWithSameName(t *testing.T) {
 		},
 	}
 
-	jaeger := v1.NewJaeger(name)
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: name})
 	jaeger.Spec.Volumes = globalVolumes
 	jaeger.Spec.Collector.Volumes = collectorVolumes
 	podSpec := NewCollector(jaeger).Get().Spec.Template.Spec
@@ -295,7 +296,7 @@ func TestCollectorVolumeWithSameName(t *testing.T) {
 }
 
 func TestCollectorResources(t *testing.T) {
-	jaeger := v1.NewJaeger("TestCollectorResources")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestCollectorResources"})
 	jaeger.Spec.Resources = corev1.ResourceRequirements{
 		Limits: corev1.ResourceList{
 			corev1.ResourceLimitsCPU:              *resource.NewQuantity(1024, resource.BinarySI),
@@ -329,7 +330,7 @@ func TestCollectorResources(t *testing.T) {
 }
 
 func TestCollectorStandardLabels(t *testing.T) {
-	c := NewCollector(v1.NewJaeger("TestCollectorStandardLabels"))
+	c := NewCollector(v1.NewJaeger(types.NamespacedName{Name: "TestCollectorStandardLabels"}))
 	dep := c.Get()
 	assert.Equal(t, "jaeger-operator", dep.Spec.Template.Labels["app.kubernetes.io/managed-by"])
 	assert.Equal(t, "collector", dep.Spec.Template.Labels["app.kubernetes.io/component"])
@@ -444,7 +445,7 @@ func TestCollectorWithIngesterNoOptionsStorageType(t *testing.T) {
 }
 
 func TestCollectorOrderOfArguments(t *testing.T) {
-	jaeger := v1.NewJaeger("TestCollectorOrderOfArguments")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestCollectorOrderOfArguments"})
 	jaeger.Spec.Collector.Options = v1.NewOptions(map[string]interface{}{
 		"b-option": "b-value",
 		"a-option": "a-value",

--- a/pkg/deployment/ingester_test.go
+++ b/pkg/deployment/ingester_test.go
@@ -10,8 +10,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 )
 
 func init() {
@@ -20,7 +21,7 @@ func init() {
 }
 
 func TestIngesterNotDefined(t *testing.T) {
-	jaeger := v1.NewJaeger("TestIngesterNotDefined")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestIngesterNotDefined"})
 
 	ingester := NewIngester(jaeger)
 	assert.Nil(t, ingester.Get())

--- a/pkg/deployment/query_test.go
+++ b/pkg/deployment/query_test.go
@@ -9,8 +9,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 )
 
 func init() {
@@ -19,7 +20,7 @@ func init() {
 }
 
 func TestQueryNegativeSize(t *testing.T) {
-	jaeger := v1.NewJaeger("TestQueryNegativeSize")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestQueryNegativeSize"})
 	jaeger.Spec.Query.Size = -1
 
 	query := NewQuery(jaeger)
@@ -29,7 +30,7 @@ func TestQueryNegativeSize(t *testing.T) {
 
 func TestQueryNegativeReplicas(t *testing.T) {
 	size := int32(-1)
-	jaeger := v1.NewJaeger("TestQueryNegativeReplicas")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestQueryNegativeReplicas"})
 	jaeger.Spec.Query.Replicas = &size
 
 	query := NewQuery(jaeger)
@@ -38,7 +39,7 @@ func TestQueryNegativeReplicas(t *testing.T) {
 }
 
 func TestQueryDefaultSize(t *testing.T) {
-	jaeger := v1.NewJaeger("TestQueryDefaultSize")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestQueryDefaultSize"})
 
 	query := NewQuery(jaeger)
 	dep := query.Get()
@@ -47,7 +48,7 @@ func TestQueryDefaultSize(t *testing.T) {
 
 func TestQueryReplicaSize(t *testing.T) {
 	size := int32(0)
-	jaeger := v1.NewJaeger("TestQueryReplicaSize")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestQueryReplicaSize"})
 	jaeger.Spec.Query.Replicas = &size
 
 	ingester := NewQuery(jaeger)
@@ -56,7 +57,7 @@ func TestQueryReplicaSize(t *testing.T) {
 }
 
 func TestQuerySize(t *testing.T) {
-	jaeger := v1.NewJaeger("TestQuerySize")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestQuerySize"})
 	jaeger.Spec.Query.Size = 2
 
 	query := NewQuery(jaeger)
@@ -66,7 +67,7 @@ func TestQuerySize(t *testing.T) {
 
 func TestQueryReplicaWinsOverSize(t *testing.T) {
 	size := int32(3)
-	jaeger := v1.NewJaeger("TestQueryReplicaWinsOverSize")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestQueryReplicaWinsOverSize"})
 	jaeger.Spec.Query.Size = 2
 	jaeger.Spec.Query.Replicas = &size
 
@@ -80,7 +81,7 @@ func TestDefaultQueryImage(t *testing.T) {
 	viper.Set("jaeger-version", "123")
 	defer viper.Reset()
 
-	query := NewQuery(v1.NewJaeger("TestQueryImage"))
+	query := NewQuery(v1.NewJaeger(types.NamespacedName{Name: "TestQueryImage"}))
 	dep := query.Get()
 	containers := dep.Spec.Template.Spec.Containers
 
@@ -89,7 +90,7 @@ func TestDefaultQueryImage(t *testing.T) {
 }
 
 func TestQueryAnnotations(t *testing.T) {
-	jaeger := v1.NewJaeger("TestQueryAnnotations")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestQueryAnnotations"})
 	jaeger.Spec.Annotations = map[string]string{
 		"name":  "operator",
 		"hello": "jaeger",
@@ -109,7 +110,7 @@ func TestQueryAnnotations(t *testing.T) {
 }
 
 func TestQueryLabels(t *testing.T) {
-	jaeger := v1.NewJaeger("TestQueryLabels")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestQueryLabels"})
 	jaeger.Spec.Labels = map[string]string{
 		"name":  "operator",
 		"hello": "jaeger",
@@ -128,7 +129,7 @@ func TestQueryLabels(t *testing.T) {
 }
 
 func TestQuerySecrets(t *testing.T) {
-	jaeger := v1.NewJaeger("TestQuerySecrets")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestQuerySecrets"})
 	secret := "mysecret"
 	jaeger.Spec.Storage.SecretName = secret
 
@@ -140,14 +141,14 @@ func TestQuerySecrets(t *testing.T) {
 
 func TestQueryPodName(t *testing.T) {
 	name := "TestQueryPodName"
-	query := NewQuery(v1.NewJaeger(name))
+	query := NewQuery(v1.NewJaeger(types.NamespacedName{Name: name}))
 	dep := query.Get()
 
 	assert.Contains(t, dep.ObjectMeta.Name, fmt.Sprintf("%s-query", name))
 }
 
 func TestQueryServices(t *testing.T) {
-	query := NewQuery(v1.NewJaeger("TestQueryServices"))
+	query := NewQuery(v1.NewJaeger(types.NamespacedName{Name: "TestQueryServices"}))
 	svcs := query.Services()
 
 	assert.Len(t, svcs, 1)
@@ -182,7 +183,7 @@ func TestQueryVolumeMountsWithVolumes(t *testing.T) {
 		},
 	}
 
-	jaeger := v1.NewJaeger(name)
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: name})
 	jaeger.Spec.Volumes = globalVolumes
 	jaeger.Spec.VolumeMounts = globalVolumeMounts
 	jaeger.Spec.Query.Volumes = queryVolumes
@@ -216,7 +217,7 @@ func TestQueryMountGlobalVolumes(t *testing.T) {
 		},
 	}
 
-	jaeger := v1.NewJaeger(name)
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: name})
 	jaeger.Spec.Volumes = globalVolumes
 	jaeger.Spec.Query.VolumeMounts = queryVolumeMounts
 	podSpec := NewQuery(jaeger).Get().Spec.Template.Spec
@@ -243,7 +244,7 @@ func TestQueryVolumeMountsWithSameName(t *testing.T) {
 		},
 	}
 
-	jaeger := v1.NewJaeger(name)
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: name})
 	jaeger.Spec.VolumeMounts = globalVolumeMounts
 	jaeger.Spec.Query.VolumeMounts = queryVolumeMounts
 	podSpec := NewQuery(jaeger).Get().Spec.Template.Spec
@@ -270,7 +271,7 @@ func TestQueryVolumeWithSameName(t *testing.T) {
 		},
 	}
 
-	jaeger := v1.NewJaeger(name)
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: name})
 	jaeger.Spec.Volumes = globalVolumes
 	jaeger.Spec.Query.Volumes = queryVolumes
 	podSpec := NewQuery(jaeger).Get().Spec.Template.Spec
@@ -281,7 +282,7 @@ func TestQueryVolumeWithSameName(t *testing.T) {
 }
 
 func TestQueryResources(t *testing.T) {
-	jaeger := v1.NewJaeger("TestQueryResources")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestQueryResources"})
 	jaeger.Spec.Resources = corev1.ResourceRequirements{
 		Limits: corev1.ResourceList{
 			corev1.ResourceLimitsCPU:              *resource.NewQuantity(1024, resource.BinarySI),
@@ -315,7 +316,7 @@ func TestQueryResources(t *testing.T) {
 }
 
 func TestQueryStandardLabels(t *testing.T) {
-	query := NewQuery(v1.NewJaeger("TestQueryStandardLabels"))
+	query := NewQuery(v1.NewJaeger(types.NamespacedName{Name: "TestQueryStandardLabels"}))
 	dep := query.Get()
 	assert.Equal(t, "jaeger-operator", dep.Spec.Template.Labels["app.kubernetes.io/managed-by"])
 	assert.Equal(t, "query", dep.Spec.Template.Labels["app.kubernetes.io/component"])
@@ -324,7 +325,7 @@ func TestQueryStandardLabels(t *testing.T) {
 }
 
 func TestQueryOrderOfArguments(t *testing.T) {
-	jaeger := v1.NewJaeger("TestQueryOrderOfArguments")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestQueryOrderOfArguments"})
 	jaeger.Spec.Query.Options = v1.NewOptions(map[string]interface{}{
 		"b-option": "b-value",
 		"a-option": "a-value",

--- a/pkg/ingress/query_test.go
+++ b/pkg/ingress/query_test.go
@@ -4,13 +4,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
 
 	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 )
 
 func TestQueryIngress(t *testing.T) {
 	name := "TestQueryIngress"
-	jaeger := v1.NewJaeger(name)
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: name})
 	ingress := NewQueryIngress(jaeger)
 
 	dep := ingress.Get()
@@ -21,7 +22,7 @@ func TestQueryIngress(t *testing.T) {
 func TestQueryIngressDisabled(t *testing.T) {
 	enabled := false
 	name := "TestQueryIngressDisabled"
-	jaeger := v1.NewJaeger(name)
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: name})
 	jaeger.Spec.Ingress.Enabled = &enabled
 	ingress := NewQueryIngress(jaeger)
 
@@ -33,7 +34,7 @@ func TestQueryIngressDisabled(t *testing.T) {
 func TestQueryIngressEnabled(t *testing.T) {
 	enabled := true
 	name := "TestQueryIngressEnabled"
-	jaeger := v1.NewJaeger(name)
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: name})
 	jaeger.Spec.Ingress.Enabled = &enabled
 	ingress := NewQueryIngress(jaeger)
 
@@ -46,7 +47,7 @@ func TestQueryIngressEnabled(t *testing.T) {
 func TestQueryIngressAllInOneBasePath(t *testing.T) {
 	enabled := true
 	name := "TestQueryIngressAllInOneBasePath"
-	jaeger := v1.NewJaeger(name)
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: name})
 	jaeger.Spec.Ingress.Enabled = &enabled
 	jaeger.Spec.Strategy = "allInOne"
 	jaeger.Spec.AllInOne.Options = v1.NewOptions(map[string]interface{}{"query.base-path": "/jaeger"})
@@ -65,7 +66,7 @@ func TestQueryIngressAllInOneBasePath(t *testing.T) {
 func TestQueryIngressQueryBasePath(t *testing.T) {
 	enabled := true
 	name := "TestQueryIngressQueryBasePath"
-	jaeger := v1.NewJaeger(name)
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: name})
 	jaeger.Spec.Ingress.Enabled = &enabled
 	jaeger.Spec.Strategy = "production"
 	jaeger.Spec.Query.Options = v1.NewOptions(map[string]interface{}{"query.base-path": "/jaeger"})
@@ -82,7 +83,7 @@ func TestQueryIngressQueryBasePath(t *testing.T) {
 }
 
 func TestQueryIngressAnnotations(t *testing.T) {
-	jaeger := v1.NewJaeger("TestQueryIngressAnnotations")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestQueryIngressAnnotations"})
 	jaeger.Spec.Annotations = map[string]string{
 		"name":  "operator",
 		"hello": "jaeger",
@@ -101,7 +102,7 @@ func TestQueryIngressAnnotations(t *testing.T) {
 }
 
 func TestQueryIngressLabels(t *testing.T) {
-	jaeger := v1.NewJaeger("TestQueryIngressLabels")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestQueryIngressLabels"})
 	jaeger.Spec.Labels = map[string]string{
 		"name":  "operator",
 		"hello": "jaeger",

--- a/pkg/inject/oauth-proxy_test.go
+++ b/pkg/inject/oauth-proxy_test.go
@@ -8,21 +8,22 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/deployment"
 	"github.com/jaegertracing/jaeger-operator/pkg/service"
 )
 
 func TestOAuthProxyContainerIsNotAddedByDefault(t *testing.T) {
-	jaeger := v1.NewJaeger("TestOAuthProxyContainerIsNotAddedByDefault")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestOAuthProxyContainerIsNotAddedByDefault"})
 	dep := OAuthProxy(jaeger, deployment.NewQuery(jaeger).Get())
 	assert.Len(t, dep.Spec.Template.Spec.Containers, 1)
 	assert.Equal(t, "jaeger-query", dep.Spec.Template.Spec.Containers[0].Name)
 }
 
 func TestOAuthProxyContainerIsAdded(t *testing.T) {
-	jaeger := v1.NewJaeger("TestOAuthProxyContainerIsAdded")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestOAuthProxyContainerIsAdded"})
 	jaeger.Spec.Ingress.Security = v1.IngressSecurityOAuthProxy
 	dep := OAuthProxy(jaeger, deployment.NewQuery(jaeger).Get())
 	assert.Len(t, dep.Spec.Template.Spec.Containers, 2)
@@ -30,7 +31,7 @@ func TestOAuthProxyContainerIsAdded(t *testing.T) {
 }
 
 func TestOAuthProxyTLSSecretVolumeIsAdded(t *testing.T) {
-	jaeger := v1.NewJaeger("TestOAuthProxyTLSSecretVolumeIsAdded")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestOAuthProxyTLSSecretVolumeIsAdded"})
 	jaeger.Spec.Ingress.Security = v1.IngressSecurityOAuthProxy
 	dep := OAuthProxy(jaeger, deployment.NewQuery(jaeger).Get())
 	assert.Len(t, dep.Spec.Template.Spec.Volumes, 1)
@@ -38,14 +39,14 @@ func TestOAuthProxyTLSSecretVolumeIsAdded(t *testing.T) {
 }
 
 func TestOAuthProxyTLSSecretVolumeIsNotAddedByDefault(t *testing.T) {
-	jaeger := v1.NewJaeger("TestOAuthProxyTLSSecretVolumeIsNotAddedByDefault")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestOAuthProxyTLSSecretVolumeIsNotAddedByDefault"})
 	dep := OAuthProxy(jaeger, deployment.NewQuery(jaeger).Get())
 	assert.Len(t, dep.Spec.Template.Spec.Volumes, 0)
 }
 
 func TestOAuthProxyConsistentServiceAccountName(t *testing.T) {
 	// see https://github.com/openshift/oauth-proxy/issues/95
-	jaeger := v1.NewJaeger("TestOAuthProxyConsistentServiceAccountName")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestOAuthProxyConsistentServiceAccountName"})
 	jaeger.Spec.Ingress.Security = v1.IngressSecurityOAuthProxy
 	dep := OAuthProxy(jaeger, deployment.NewQuery(jaeger).Get())
 
@@ -59,7 +60,7 @@ func TestOAuthProxyConsistentServiceAccountName(t *testing.T) {
 }
 
 func TestOAuthProxyOrderOfArguments(t *testing.T) {
-	jaeger := v1.NewJaeger("TestOAuthProxyConsistentServiceAccountName")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestOAuthProxyConsistentServiceAccountName"})
 	jaeger.Spec.Ingress.Security = v1.IngressSecurityOAuthProxy
 	dep := OAuthProxy(jaeger, deployment.NewQuery(jaeger).Get())
 
@@ -73,7 +74,7 @@ func TestOAuthProxyOrderOfArguments(t *testing.T) {
 }
 
 func TestOAuthProxyResourceLimits(t *testing.T) {
-	jaeger := v1.NewJaeger("TestOAuthProxyResourceLimits")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestOAuthProxyResourceLimits"})
 	jaeger.Spec.Resources = corev1.ResourceRequirements{
 		Limits: corev1.ResourceList{
 			corev1.ResourceLimitsCPU:              *resource.NewQuantity(1024, resource.BinarySI),

--- a/pkg/inject/sidecar_test.go
+++ b/pkg/inject/sidecar_test.go
@@ -10,6 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 )
@@ -29,7 +30,7 @@ func reset() {
 }
 
 func TestInjectSidecar(t *testing.T) {
-	jaeger := v1.NewJaeger("TestInjectSidecar")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestInjectSidecar"})
 	dep := dep(map[string]string{Annotation: jaeger.Name}, map[string]string{})
 	dep = Sidecar(jaeger, dep)
 	assert.Len(t, dep.Spec.Template.Spec.Containers, 2)
@@ -38,7 +39,7 @@ func TestInjectSidecar(t *testing.T) {
 }
 
 func TestInjectSidecarWithLegacyAnnotation(t *testing.T) {
-	jaeger := v1.NewJaeger("TestInjectSidecarWithLegacyAnnotation")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestInjectSidecarWithLegacyAnnotation"})
 	dep := dep(map[string]string{AnnotationLegacy: jaeger.Name}, map[string]string{})
 	dep = Sidecar(jaeger, dep)
 	assert.Len(t, dep.Spec.Template.Spec.Containers, 2)
@@ -47,7 +48,7 @@ func TestInjectSidecarWithLegacyAnnotation(t *testing.T) {
 }
 
 func TestInjectSidecarWithEnvVars(t *testing.T) {
-	jaeger := v1.NewJaeger("TestInjectSidecarWithEnvVars")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestInjectSidecarWithEnvVars"})
 	dep := dep(map[string]string{Annotation: jaeger.Name}, map[string]string{"app": "testapp"})
 	dep = Sidecar(jaeger, dep)
 	assert.Len(t, dep.Spec.Template.Spec.Containers, 2)
@@ -60,7 +61,7 @@ func TestInjectSidecarWithEnvVars(t *testing.T) {
 }
 
 func TestInjectSidecarWithEnvVarsK8sAppName(t *testing.T) {
-	jaeger := v1.NewJaeger("TestInjectSidecarWithEnvVarsK8sAppName")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestInjectSidecarWithEnvVarsK8sAppName"})
 	dep := dep(map[string]string{Annotation: jaeger.Name}, map[string]string{
 		"app":                    "noapp",
 		"app.kubernetes.io/name": "testapp",
@@ -73,7 +74,7 @@ func TestInjectSidecarWithEnvVarsK8sAppName(t *testing.T) {
 }
 
 func TestInjectSidecarWithEnvVarsK8sAppInstance(t *testing.T) {
-	jaeger := v1.NewJaeger("TestInjectSidecarWithEnvVarsK8sAppInstance")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestInjectSidecarWithEnvVarsK8sAppInstance"})
 	dep := dep(map[string]string{Annotation: jaeger.Name}, map[string]string{
 		"app":                        "noapp",
 		"app.kubernetes.io/name":     "noname",
@@ -87,7 +88,7 @@ func TestInjectSidecarWithEnvVarsK8sAppInstance(t *testing.T) {
 }
 
 func TestInjectSidecarWithEnvVarsWithNamespace(t *testing.T) {
-	jaeger := v1.NewJaeger("TestInjectSidecarWithEnvVarsWithNamespace")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestInjectSidecarWithEnvVarsWithNamespace"})
 	dep := dep(map[string]string{Annotation: jaeger.Name}, map[string]string{"app": "testapp"})
 	dep.Namespace = "mynamespace"
 	dep = Sidecar(jaeger, dep)
@@ -101,7 +102,7 @@ func TestInjectSidecarWithEnvVarsWithNamespace(t *testing.T) {
 }
 
 func TestInjectSidecarWithEnvVarsOverrideName(t *testing.T) {
-	jaeger := v1.NewJaeger("TestInjectSidecarWithEnvVarsOverrideName")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestInjectSidecarWithEnvVarsOverrideName"})
 	dep := dep(map[string]string{Annotation: jaeger.Name}, map[string]string{"app": "testapp"})
 	dep.Spec.Template.Spec.Containers[0].Env = append(dep.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
 		Name:  envVarServiceName,
@@ -119,7 +120,7 @@ func TestInjectSidecarWithEnvVarsOverrideName(t *testing.T) {
 }
 
 func TestInjectSidecarWithEnvVarsOverridePropagation(t *testing.T) {
-	jaeger := v1.NewJaeger("TestInjectSidecarWithEnvVarsOverridePropagation")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestInjectSidecarWithEnvVarsOverridePropagation"})
 	dep := dep(map[string]string{Annotation: jaeger.Name}, map[string]string{"app": "testapp"})
 	dep.Spec.Template.Spec.Containers[0].Env = append(dep.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
 		Name:  envVarPropagation,
@@ -137,7 +138,7 @@ func TestInjectSidecarWithEnvVarsOverridePropagation(t *testing.T) {
 }
 
 func TestSkipInjectSidecar(t *testing.T) {
-	jaeger := v1.NewJaeger("TestSkipInjectSidecar")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestSkipInjectSidecar"})
 	dep := dep(map[string]string{Annotation: "non-existing-operator"}, map[string]string{})
 	dep = Sidecar(jaeger, dep)
 	assert.Len(t, dep.Spec.Template.Spec.Containers, 1)
@@ -168,7 +169,7 @@ func TestSidecarNeeded(t *testing.T) {
 func TestHasSidecarAlready(t *testing.T) {
 	dep := dep(map[string]string{Annotation: "TestHasSidecarAlready"}, map[string]string{})
 	assert.True(t, Needed(dep))
-	jaeger := v1.NewJaeger("TestHasSidecarAlready")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestHasSidecarAlready"})
 	dep = Sidecar(jaeger, dep)
 	assert.False(t, Needed(dep))
 }
@@ -241,7 +242,7 @@ func TestSelectBasedOnName(t *testing.T) {
 }
 
 func TestSidecarOrderOfArguments(t *testing.T) {
-	jaeger := v1.NewJaeger("TestQueryOrderOfArguments")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestQueryOrderOfArguments"})
 	jaeger.Spec.Agent.Options = v1.NewOptions(map[string]interface{}{
 		"b-option": "b-value",
 		"a-option": "a-value",
@@ -261,7 +262,7 @@ func TestSidecarOrderOfArguments(t *testing.T) {
 }
 
 func TestSidecarOverrideReporter(t *testing.T) {
-	jaeger := v1.NewJaeger("TestQueryOrderOfArguments")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestQueryOrderOfArguments"})
 	jaeger.Spec.Agent.Options = v1.NewOptions(map[string]interface{}{
 		"reporter.type":             "thrift",
 		"reporter.thrift.host-port": "collector:14267",
@@ -277,7 +278,7 @@ func TestSidecarOverrideReporter(t *testing.T) {
 }
 
 func TestSidecarAgentResources(t *testing.T) {
-	jaeger := v1.NewJaeger("TestSidecarAgentResources")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestSidecarAgentResources"})
 	jaeger.Spec.Resources = corev1.ResourceRequirements{
 		Limits: corev1.ResourceList{
 			corev1.ResourceLimitsCPU:              *resource.NewQuantity(1024, resource.BinarySI),

--- a/pkg/inventory/account.go
+++ b/pkg/inventory/account.go
@@ -1,7 +1,9 @@
 package inventory
 
 import (
-	"k8s.io/api/core/v1"
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
 
 	"github.com/jaegertracing/jaeger-operator/pkg/util"
 )
@@ -54,7 +56,7 @@ func ForAccounts(existing []v1.ServiceAccount, desired []v1.ServiceAccount) Acco
 func accountMap(deps []v1.ServiceAccount) map[string]v1.ServiceAccount {
 	m := map[string]v1.ServiceAccount{}
 	for _, d := range deps {
-		m[d.Name] = d
+		m[fmt.Sprintf("%s.%s", d.Namespace, d.Name)] = d
 	}
 	return m
 }

--- a/pkg/inventory/account_test.go
+++ b/pkg/inventory/account_test.go
@@ -66,8 +66,8 @@ func TestAccountInventoryWithSameNameInstances(t *testing.T) {
 
 	inv := ForAccounts([]v1.ServiceAccount{}, create)
 	assert.Len(t, inv.Create, 2)
-	assert.Contains(t, create, create[0])
-	assert.Contains(t, create, create[1])
+	assert.Contains(t, inv.Create, create[0])
+	assert.Contains(t, inv.Create, create[1])
 	assert.Len(t, inv.Update, 0)
 	assert.Len(t, inv.Delete, 0)
 }

--- a/pkg/inventory/account_test.go
+++ b/pkg/inventory/account_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -49,4 +49,25 @@ func TestAccountInventory(t *testing.T) {
 
 	assert.Len(t, inv.Delete, 1)
 	assert.Equal(t, "to-delete", inv.Delete[0].Name)
+}
+
+func TestAccountInventoryWithSameNameInstances(t *testing.T) {
+	create := []v1.ServiceAccount{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "to-create",
+			Namespace: "tenant1",
+		},
+	}, {
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "to-create",
+			Namespace: "tenant2",
+		},
+	}}
+
+	inv := ForAccounts([]v1.ServiceAccount{}, create)
+	assert.Len(t, inv.Create, 2)
+	assert.Contains(t, create, create[0])
+	assert.Contains(t, create, create[1])
+	assert.Len(t, inv.Update, 0)
+	assert.Len(t, inv.Delete, 0)
 }

--- a/pkg/inventory/configmap.go
+++ b/pkg/inventory/configmap.go
@@ -1,7 +1,9 @@
 package inventory
 
 import (
-	"k8s.io/api/core/v1"
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
 
 	"github.com/jaegertracing/jaeger-operator/pkg/util"
 )
@@ -53,7 +55,7 @@ func ForConfigMaps(existing []v1.ConfigMap, desired []v1.ConfigMap) ConfigMap {
 func configsMap(deps []v1.ConfigMap) map[string]v1.ConfigMap {
 	m := map[string]v1.ConfigMap{}
 	for _, d := range deps {
-		m[d.Name] = d
+		m[fmt.Sprintf("%s.%s", d.Namespace, d.Name)] = d
 	}
 	return m
 }

--- a/pkg/inventory/configmap_test.go
+++ b/pkg/inventory/configmap_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -51,4 +51,25 @@ func TestConfigMapInventory(t *testing.T) {
 
 	assert.Len(t, inv.Delete, 1)
 	assert.Equal(t, "to-delete", inv.Delete[0].Name)
+}
+
+func TestConfigMapInventoryWithSameNameInstances(t *testing.T) {
+	create := []v1.ConfigMap{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "to-create",
+			Namespace: "tenant1",
+		},
+	}, {
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "to-create",
+			Namespace: "tenant2",
+		},
+	}}
+
+	inv := ForConfigMaps([]v1.ConfigMap{}, create)
+	assert.Len(t, inv.Create, 2)
+	assert.Contains(t, create, create[0])
+	assert.Contains(t, create, create[1])
+	assert.Len(t, inv.Update, 0)
+	assert.Len(t, inv.Delete, 0)
 }

--- a/pkg/inventory/configmap_test.go
+++ b/pkg/inventory/configmap_test.go
@@ -68,8 +68,8 @@ func TestConfigMapInventoryWithSameNameInstances(t *testing.T) {
 
 	inv := ForConfigMaps([]v1.ConfigMap{}, create)
 	assert.Len(t, inv.Create, 2)
-	assert.Contains(t, create, create[0])
-	assert.Contains(t, create, create[1])
+	assert.Contains(t, inv.Create, create[0])
+	assert.Contains(t, inv.Create, create[1])
 	assert.Len(t, inv.Update, 0)
 	assert.Len(t, inv.Delete, 0)
 }

--- a/pkg/inventory/cronjob.go
+++ b/pkg/inventory/cronjob.go
@@ -1,6 +1,8 @@
 package inventory
 
 import (
+	"fmt"
+
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 
 	"github.com/jaegertracing/jaeger-operator/pkg/util"
@@ -52,7 +54,7 @@ func ForCronJobs(existing []batchv1beta1.CronJob, desired []batchv1beta1.CronJob
 func jobsMap(deps []batchv1beta1.CronJob) map[string]batchv1beta1.CronJob {
 	m := map[string]batchv1beta1.CronJob{}
 	for _, d := range deps {
-		m[d.Name] = d
+		m[fmt.Sprintf("%s.%s", d.Namespace, d.Name)] = d
 	}
 	return m
 }

--- a/pkg/inventory/cronjob_test.go
+++ b/pkg/inventory/cronjob_test.go
@@ -52,3 +52,24 @@ func TestCronJobInventory(t *testing.T) {
 	assert.Len(t, inv.Delete, 1)
 	assert.Equal(t, "to-delete", inv.Delete[0].Name)
 }
+
+func TestCronJobInventoryWithSameNameInstances(t *testing.T) {
+	create := []batchv1beta1.CronJob{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "to-create",
+			Namespace: "tenant1",
+		},
+	}, {
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "to-create",
+			Namespace: "tenant2",
+		},
+	}}
+
+	inv := ForCronJobs([]batchv1beta1.CronJob{}, create)
+	assert.Len(t, inv.Create, 2)
+	assert.Contains(t, create, create[0])
+	assert.Contains(t, create, create[1])
+	assert.Len(t, inv.Update, 0)
+	assert.Len(t, inv.Delete, 0)
+}

--- a/pkg/inventory/cronjob_test.go
+++ b/pkg/inventory/cronjob_test.go
@@ -68,8 +68,8 @@ func TestCronJobInventoryWithSameNameInstances(t *testing.T) {
 
 	inv := ForCronJobs([]batchv1beta1.CronJob{}, create)
 	assert.Len(t, inv.Create, 2)
-	assert.Contains(t, create, create[0])
-	assert.Contains(t, create, create[1])
+	assert.Contains(t, inv.Create, create[0])
+	assert.Contains(t, inv.Create, create[1])
 	assert.Len(t, inv.Update, 0)
 	assert.Len(t, inv.Delete, 0)
 }

--- a/pkg/inventory/daemonset.go
+++ b/pkg/inventory/daemonset.go
@@ -1,6 +1,8 @@
 package inventory
 
 import (
+	"fmt"
+
 	appsv1 "k8s.io/api/apps/v1"
 
 	"github.com/jaegertracing/jaeger-operator/pkg/util"
@@ -52,7 +54,7 @@ func ForDaemonSets(existing []appsv1.DaemonSet, desired []appsv1.DaemonSet) Daem
 func daemonsetMap(deps []appsv1.DaemonSet) map[string]appsv1.DaemonSet {
 	m := map[string]appsv1.DaemonSet{}
 	for _, d := range deps {
-		m[d.Name] = d
+		m[fmt.Sprintf("%s.%s", d.Namespace, d.Name)] = d
 	}
 	return m
 }

--- a/pkg/inventory/daemonset_test.go
+++ b/pkg/inventory/daemonset_test.go
@@ -68,8 +68,8 @@ func TestDaemonSetInventoryWithSameNameInstances(t *testing.T) {
 
 	inv := ForDaemonSets([]appsv1.DaemonSet{}, create)
 	assert.Len(t, inv.Create, 2)
-	assert.Contains(t, create, create[0])
-	assert.Contains(t, create, create[1])
+	assert.Contains(t, inv.Create, create[0])
+	assert.Contains(t, inv.Create, create[1])
 	assert.Len(t, inv.Update, 0)
 	assert.Len(t, inv.Delete, 0)
 }

--- a/pkg/inventory/daemonset_test.go
+++ b/pkg/inventory/daemonset_test.go
@@ -52,3 +52,24 @@ func TestDaemonSetInventory(t *testing.T) {
 	assert.Len(t, inv.Delete, 1)
 	assert.Equal(t, "to-delete", inv.Delete[0].Name)
 }
+
+func TestDaemonSetInventoryWithSameNameInstances(t *testing.T) {
+	create := []appsv1.DaemonSet{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "to-create",
+			Namespace: "tenant1",
+		},
+	}, {
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "to-create",
+			Namespace: "tenant2",
+		},
+	}}
+
+	inv := ForDaemonSets([]appsv1.DaemonSet{}, create)
+	assert.Len(t, inv.Create, 2)
+	assert.Contains(t, create, create[0])
+	assert.Contains(t, create, create[1])
+	assert.Len(t, inv.Update, 0)
+	assert.Len(t, inv.Delete, 0)
+}

--- a/pkg/inventory/deployment.go
+++ b/pkg/inventory/deployment.go
@@ -1,6 +1,8 @@
 package inventory
 
 import (
+	"fmt"
+
 	appsv1 "k8s.io/api/apps/v1"
 
 	"github.com/jaegertracing/jaeger-operator/pkg/util"
@@ -52,7 +54,7 @@ func ForDeployments(existing []appsv1.Deployment, desired []appsv1.Deployment) D
 func deploymentMap(deps []appsv1.Deployment) map[string]appsv1.Deployment {
 	m := map[string]appsv1.Deployment{}
 	for _, d := range deps {
-		m[d.Name] = d
+		m[fmt.Sprintf("%s.%s", d.Namespace, d.Name)] = d
 	}
 	return m
 }

--- a/pkg/inventory/deployment_test.go
+++ b/pkg/inventory/deployment_test.go
@@ -6,17 +6,21 @@ import (
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/jaegertracing/jaeger-operator/pkg/util"
 )
 
 func TestDeploymentInventory(t *testing.T) {
 	toCreate := appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "to-create",
+			Name:      "to-create",
+			Namespace: "tenant1",
 		},
 	}
 	toUpdate := appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "to-update",
+			Name:      "to-update",
+			Namespace: "tenant1",
 		},
 		Spec: appsv1.DeploymentSpec{
 			MinReadySeconds: 1,
@@ -25,6 +29,7 @@ func TestDeploymentInventory(t *testing.T) {
 	updated := appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "to-update",
+			Namespace:   "tenant1",
 			Annotations: map[string]string{"gopher": "jaeger"},
 			Labels:      map[string]string{"gopher": "jaeger"},
 		},
@@ -34,7 +39,8 @@ func TestDeploymentInventory(t *testing.T) {
 	}
 	toDelete := appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "to-delete",
+			Name:      "to-delete",
+			Namespace: "tenant1",
 		},
 	}
 
@@ -51,4 +57,52 @@ func TestDeploymentInventory(t *testing.T) {
 
 	assert.Len(t, inv.Delete, 1)
 	assert.Equal(t, "to-delete", inv.Delete[0].Name)
+}
+
+func TestDeploymentInventoryWithSameNameInstances(t *testing.T) {
+	create := []appsv1.Deployment{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "to-create",
+			Namespace: "tenant1",
+		},
+	}, {
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "to-create",
+			Namespace: "tenant2",
+		},
+	}}
+
+	inv := ForDeployments([]appsv1.Deployment{}, create)
+	assert.Len(t, inv.Create, 2)
+	assert.Contains(t, create, create[0])
+	assert.Contains(t, create, create[1])
+	assert.Len(t, inv.Update, 0)
+	assert.Len(t, inv.Delete, 0)
+}
+
+func TestDeploymentInventoryNewWithSameNameAsExisting(t *testing.T) {
+	create := appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "to-create",
+			Namespace: "tenant1",
+		},
+	}
+
+	existing := []appsv1.Deployment{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "to-create",
+			Namespace: "tenant2",
+		},
+	}}
+
+	util.InitObjectMeta(&existing[0])
+	inv := ForDeployments(existing, append(existing, create))
+
+	assert.Len(t, inv.Create, 1)
+	assert.Equal(t, inv.Create[0], create)
+
+	assert.Len(t, inv.Update, 1)
+	assert.Equal(t, inv.Update[0], existing[0])
+
+	assert.Len(t, inv.Delete, 0)
 }

--- a/pkg/inventory/elasticsearch.go
+++ b/pkg/inventory/elasticsearch.go
@@ -1,6 +1,8 @@
 package inventory
 
 import (
+	"fmt"
+
 	esv1 "github.com/jaegertracing/jaeger-operator/pkg/storage/elasticsearch/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/util"
 )
@@ -50,7 +52,7 @@ func ForElasticsearches(existing []esv1.Elasticsearch, desired []esv1.Elasticsea
 func esMap(deps []esv1.Elasticsearch) map[string]esv1.Elasticsearch {
 	m := map[string]esv1.Elasticsearch{}
 	for _, d := range deps {
-		m[d.Name] = d
+		m[fmt.Sprintf("%s.%s", d.Namespace, d.Name)] = d
 	}
 	return m
 }

--- a/pkg/inventory/elasticsearch_test.go
+++ b/pkg/inventory/elasticsearch_test.go
@@ -69,8 +69,8 @@ func TestElasticsearchInventoryWithSameNameInstances(t *testing.T) {
 
 	inv := ForElasticsearches([]esv1.Elasticsearch{}, create)
 	assert.Len(t, inv.Create, 2)
-	assert.Contains(t, create, create[0])
-	assert.Contains(t, create, create[1])
+	assert.Contains(t, inv.Create, create[0])
+	assert.Contains(t, inv.Create, create[1])
 	assert.Len(t, inv.Update, 0)
 	assert.Len(t, inv.Delete, 0)
 }

--- a/pkg/inventory/elasticsearch_test.go
+++ b/pkg/inventory/elasticsearch_test.go
@@ -53,3 +53,24 @@ func TestElasticsearchInventory(t *testing.T) {
 	assert.Len(t, inv.Delete, 1)
 	assert.Equal(t, "to-delete", inv.Delete[0].Name)
 }
+
+func TestElasticsearchInventoryWithSameNameInstances(t *testing.T) {
+	create := []esv1.Elasticsearch{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "to-create",
+			Namespace: "tenant1",
+		},
+	}, {
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "to-create",
+			Namespace: "tenant2",
+		},
+	}}
+
+	inv := ForElasticsearches([]esv1.Elasticsearch{}, create)
+	assert.Len(t, inv.Create, 2)
+	assert.Contains(t, create, create[0])
+	assert.Contains(t, create, create[1])
+	assert.Len(t, inv.Update, 0)
+	assert.Len(t, inv.Delete, 0)
+}

--- a/pkg/inventory/ingress.go
+++ b/pkg/inventory/ingress.go
@@ -1,6 +1,8 @@
 package inventory
 
 import (
+	"fmt"
+
 	"k8s.io/api/extensions/v1beta1"
 
 	"github.com/jaegertracing/jaeger-operator/pkg/util"
@@ -52,7 +54,7 @@ func ForIngresses(existing []v1beta1.Ingress, desired []v1beta1.Ingress) Ingress
 func ingressMap(deps []v1beta1.Ingress) map[string]v1beta1.Ingress {
 	m := map[string]v1beta1.Ingress{}
 	for _, d := range deps {
-		m[d.Name] = d
+		m[fmt.Sprintf("%s.%s", d.Namespace, d.Name)] = d
 	}
 	return m
 }

--- a/pkg/inventory/ingress_test.go
+++ b/pkg/inventory/ingress_test.go
@@ -72,8 +72,8 @@ func TestIngressInventoryWithSameNameInstances(t *testing.T) {
 
 	inv := ForIngresses([]v1beta1.Ingress{}, create)
 	assert.Len(t, inv.Create, 2)
-	assert.Contains(t, create, create[0])
-	assert.Contains(t, create, create[1])
+	assert.Contains(t, inv.Create, create[0])
+	assert.Contains(t, inv.Create, create[1])
 	assert.Len(t, inv.Update, 0)
 	assert.Len(t, inv.Delete, 0)
 }

--- a/pkg/inventory/ingress_test.go
+++ b/pkg/inventory/ingress_test.go
@@ -56,3 +56,24 @@ func TestIngressInventory(t *testing.T) {
 	assert.Len(t, inv.Delete, 1)
 	assert.Equal(t, "to-delete", inv.Delete[0].Name)
 }
+
+func TestIngressInventoryWithSameNameInstances(t *testing.T) {
+	create := []v1beta1.Ingress{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "to-create",
+			Namespace: "tenant1",
+		},
+	}, {
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "to-create",
+			Namespace: "tenant2",
+		},
+	}}
+
+	inv := ForIngresses([]v1beta1.Ingress{}, create)
+	assert.Len(t, inv.Create, 2)
+	assert.Contains(t, create, create[0])
+	assert.Contains(t, create, create[1])
+	assert.Len(t, inv.Update, 0)
+	assert.Len(t, inv.Delete, 0)
+}

--- a/pkg/inventory/route.go
+++ b/pkg/inventory/route.go
@@ -1,6 +1,8 @@
 package inventory
 
 import (
+	"fmt"
+
 	osv1 "github.com/openshift/api/route/v1"
 
 	"github.com/jaegertracing/jaeger-operator/pkg/util"
@@ -52,7 +54,7 @@ func ForRoutes(existing []osv1.Route, desired []osv1.Route) Route {
 func routeMap(deps []osv1.Route) map[string]osv1.Route {
 	m := map[string]osv1.Route{}
 	for _, d := range deps {
-		m[d.Name] = d
+		m[fmt.Sprintf("%s.%s", d.Namespace, d.Name)] = d
 	}
 	return m
 }

--- a/pkg/inventory/route_test.go
+++ b/pkg/inventory/route_test.go
@@ -68,8 +68,8 @@ func TestRouteInventoryWithSameNameInstances(t *testing.T) {
 
 	inv := ForRoutes([]osv1.Route{}, create)
 	assert.Len(t, inv.Create, 2)
-	assert.Contains(t, create, create[0])
-	assert.Contains(t, create, create[1])
+	assert.Contains(t, inv.Create, create[0])
+	assert.Contains(t, inv.Create, create[1])
 	assert.Len(t, inv.Update, 0)
 	assert.Len(t, inv.Delete, 0)
 }

--- a/pkg/inventory/route_test.go
+++ b/pkg/inventory/route_test.go
@@ -52,3 +52,24 @@ func TestRouteInventory(t *testing.T) {
 	assert.Len(t, inv.Delete, 1)
 	assert.Equal(t, "to-delete", inv.Delete[0].Name)
 }
+
+func TestRouteInventoryWithSameNameInstances(t *testing.T) {
+	create := []osv1.Route{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "to-create",
+			Namespace: "tenant1",
+		},
+	}, {
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "to-create",
+			Namespace: "tenant2",
+		},
+	}}
+
+	inv := ForRoutes([]osv1.Route{}, create)
+	assert.Len(t, inv.Create, 2)
+	assert.Contains(t, create, create[0])
+	assert.Contains(t, create, create[1])
+	assert.Len(t, inv.Update, 0)
+	assert.Len(t, inv.Delete, 0)
+}

--- a/pkg/inventory/secret.go
+++ b/pkg/inventory/secret.go
@@ -1,7 +1,9 @@
 package inventory
 
 import (
-	"k8s.io/api/core/v1"
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
 
 	"github.com/jaegertracing/jaeger-operator/pkg/util"
 )
@@ -52,7 +54,7 @@ func ForSecrets(existing []v1.Secret, desired []v1.Secret) Secret {
 func secretsMap(deps []v1.Secret) map[string]v1.Secret {
 	m := map[string]v1.Secret{}
 	for _, d := range deps {
-		m[d.Name] = d
+		m[fmt.Sprintf("%s.%s", d.Namespace, d.Name)] = d
 	}
 	return m
 }

--- a/pkg/inventory/secret_test.go
+++ b/pkg/inventory/secret_test.go
@@ -68,8 +68,8 @@ func TestSecretInventoryWithSameNameInstances(t *testing.T) {
 
 	inv := ForSecrets([]v1.Secret{}, create)
 	assert.Len(t, inv.Create, 2)
-	assert.Contains(t, create, create[0])
-	assert.Contains(t, create, create[1])
+	assert.Contains(t, inv.Create, create[0])
+	assert.Contains(t, inv.Create, create[1])
 	assert.Len(t, inv.Update, 0)
 	assert.Len(t, inv.Delete, 0)
 }

--- a/pkg/inventory/secret_test.go
+++ b/pkg/inventory/secret_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -51,4 +51,25 @@ func TestSecretInventory(t *testing.T) {
 
 	assert.Len(t, inv.Delete, 1)
 	assert.Equal(t, "to-delete", inv.Delete[0].Name)
+}
+
+func TestSecretInventoryWithSameNameInstances(t *testing.T) {
+	create := []v1.Secret{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "to-create",
+			Namespace: "tenant1",
+		},
+	}, {
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "to-create",
+			Namespace: "tenant2",
+		},
+	}}
+
+	inv := ForSecrets([]v1.Secret{}, create)
+	assert.Len(t, inv.Create, 2)
+	assert.Contains(t, create, create[0])
+	assert.Contains(t, create, create[1])
+	assert.Len(t, inv.Update, 0)
+	assert.Len(t, inv.Delete, 0)
 }

--- a/pkg/inventory/service.go
+++ b/pkg/inventory/service.go
@@ -1,7 +1,9 @@
 package inventory
 
 import (
-	"k8s.io/api/core/v1"
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
 
 	"github.com/jaegertracing/jaeger-operator/pkg/util"
 )
@@ -59,7 +61,7 @@ func ForServices(existing []v1.Service, desired []v1.Service) Service {
 func serviceMap(deps []v1.Service) map[string]v1.Service {
 	m := map[string]v1.Service{}
 	for _, d := range deps {
-		m[d.Name] = d
+		m[fmt.Sprintf("%s.%s", d.Namespace, d.Name)] = d
 	}
 	return m
 }

--- a/pkg/inventory/service_test.go
+++ b/pkg/inventory/service_test.go
@@ -72,8 +72,8 @@ func TestServiceInventoryWithSameNameInstances(t *testing.T) {
 
 	inv := ForServices([]v1.Service{}, create)
 	assert.Len(t, inv.Create, 2)
-	assert.Contains(t, create, create[0])
-	assert.Contains(t, create, create[1])
+	assert.Contains(t, inv.Create, create[0])
+	assert.Contains(t, inv.Create, create[1])
 	assert.Len(t, inv.Update, 0)
 	assert.Len(t, inv.Delete, 0)
 }

--- a/pkg/inventory/service_test.go
+++ b/pkg/inventory/service_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -55,4 +55,25 @@ func TestServiceInventory(t *testing.T) {
 	assert.Equal(t, "to-delete", inv.Delete[0].Name)
 
 	assert.Equal(t, toUpdate.Spec.ClusterIP, inv.Update[0].Spec.ClusterIP)
+}
+
+func TestServiceInventoryWithSameNameInstances(t *testing.T) {
+	create := []v1.Service{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "to-create",
+			Namespace: "tenant1",
+		},
+	}, {
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "to-create",
+			Namespace: "tenant2",
+		},
+	}}
+
+	inv := ForServices([]v1.Service{}, create)
+	assert.Len(t, inv.Create, 2)
+	assert.Contains(t, create, create[0])
+	assert.Contains(t, create, create[1])
+	assert.Len(t, inv.Update, 0)
+	assert.Len(t, inv.Delete, 0)
 }

--- a/pkg/route/query_test.go
+++ b/pkg/route/query_test.go
@@ -5,13 +5,14 @@ import (
 
 	corev1 "github.com/openshift/api/route/v1"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
 
 	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 )
 
 func TestQueryRoute(t *testing.T) {
 	name := "TestQueryRoute"
-	jaeger := v1.NewJaeger(name)
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: name})
 	route := NewQueryRoute(jaeger)
 
 	dep := route.Get()
@@ -22,7 +23,7 @@ func TestQueryRoute(t *testing.T) {
 func TestQueryRouteDisabled(t *testing.T) {
 	enabled := false
 	name := "TestQueryRouteDisabled"
-	jaeger := v1.NewJaeger(name)
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: name})
 	jaeger.Spec.Ingress.Enabled = &enabled
 	route := NewQueryRoute(jaeger)
 
@@ -34,7 +35,7 @@ func TestQueryRouteDisabled(t *testing.T) {
 func TestQueryRouteEnabled(t *testing.T) {
 	enabled := true
 	name := "TestQueryRouteEnabled"
-	jaeger := v1.NewJaeger(name)
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: name})
 	jaeger.Spec.Ingress.Enabled = &enabled
 	route := NewQueryRoute(jaeger)
 
@@ -44,7 +45,7 @@ func TestQueryRouteEnabled(t *testing.T) {
 }
 
 func TestQueryRouteTerminationTypeWithOAuthProxy(t *testing.T) {
-	jaeger := v1.NewJaeger("TestQueryRouteTerminationTypeWithOAuthProxy")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestQueryRouteTerminationTypeWithOAuthProxy"})
 	jaeger.Spec.Ingress.Security = v1.IngressSecurityOAuthProxy
 	route := NewQueryRoute(jaeger)
 
@@ -53,7 +54,7 @@ func TestQueryRouteTerminationTypeWithOAuthProxy(t *testing.T) {
 }
 
 func TestQueryRouteTerminationTypeWithoutOAuthProxy(t *testing.T) {
-	jaeger := v1.NewJaeger("TestQueryRouteTerminationTypeWithOAuthProxy")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestQueryRouteTerminationTypeWithOAuthProxy"})
 	jaeger.Spec.Ingress.Security = v1.IngressSecurityNone
 	route := NewQueryRoute(jaeger)
 

--- a/pkg/service/agent_test.go
+++ b/pkg/service/agent_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
 
 	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 )
@@ -12,7 +13,7 @@ func TestAgentServiceNameAndPorts(t *testing.T) {
 	name := "TestAgentServiceNameAndPorts"
 	selector := map[string]string{"app": "myapp", "jaeger": name, "jaeger-component": "agent"}
 
-	jaeger := v1.NewJaeger(name)
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: name})
 	svc := NewAgentService(jaeger, selector)
 	assert.Equal(t, "testagentservicenameandports-agent", svc.ObjectMeta.Name)
 

--- a/pkg/service/collector_test.go
+++ b/pkg/service/collector_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
 
 	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 )
@@ -12,7 +13,7 @@ func TestCollectorServiceNameAndPorts(t *testing.T) {
 	name := "TestCollectorServiceNameAndPorts"
 	selector := map[string]string{"app": "myapp", "jaeger": name, "jaeger-component": "collector"}
 
-	jaeger := v1.NewJaeger(name)
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: name})
 	svcs := NewCollectorServices(jaeger, selector)
 
 	assert.Equal(t, "testcollectorservicenameandports-collector-headless", svcs[0].Name)
@@ -42,7 +43,7 @@ func TestCollectorServiceWithClusterIPEmptyAndNone(t *testing.T) {
 	name := "TestCollectorServiceWithClusterIP"
 	selector := map[string]string{"app": "myapp", "jaeger": name, "jaeger-component": "collector"}
 
-	jaeger := v1.NewJaeger(name)
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: name})
 	svcs := NewCollectorServices(jaeger, selector)
 
 	// we want two services, one headless (load balanced by the client, possibly via DNS)

--- a/pkg/service/query_test.go
+++ b/pkg/service/query_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
@@ -13,7 +14,7 @@ func TestQueryServiceNameAndPorts(t *testing.T) {
 	name := "TestQueryServiceNameAndPorts"
 	selector := map[string]string{"app": "myapp", "jaeger": name, "jaeger-component": "query"}
 
-	jaeger := v1.NewJaeger(name)
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: name})
 	svc := NewQueryService(jaeger, selector)
 
 	assert.Equal(t, "testqueryservicenameandports-query", svc.ObjectMeta.Name)
@@ -27,7 +28,7 @@ func TestQueryDottedServiceName(t *testing.T) {
 	name := "TestQueryDottedServiceName.With.Dots"
 	selector := map[string]string{"app": "myapp", "jaeger": name, "jaeger-component": "query"}
 
-	jaeger := v1.NewJaeger(name)
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: name})
 	svc := NewQueryService(jaeger, selector)
 
 	assert.Equal(t, "testquerydottedservicename-with-dots-query", svc.ObjectMeta.Name)
@@ -37,7 +38,7 @@ func TestQueryServiceNameAndPortsWithOAuthProxy(t *testing.T) {
 	name := "TestQueryServiceNameAndPortsWithOAuthProxy"
 	selector := map[string]string{"app": "myapp", "jaeger": name, "jaeger-component": "query"}
 
-	jaeger := v1.NewJaeger(name)
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: name})
 	jaeger.Spec.Ingress.Security = v1.IngressSecurityOAuthProxy
 	svc := NewQueryService(jaeger, selector)
 

--- a/pkg/storage/cassandra_dependencies_test.go
+++ b/pkg/storage/cassandra_dependencies_test.go
@@ -4,14 +4,15 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 )
 
 func TestCassandraCreateSchemaDisabled(t *testing.T) {
 	falseVar := false
 
-	jaeger := v1.NewJaeger("TestCassandraCreateSchemaDisabled")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestCassandraCreateSchemaDisabled"})
 	jaeger.Spec.Storage.CassandraCreateSchema.Enabled = &falseVar
 
 	assert.Len(t, cassandraDeps(jaeger), 0)
@@ -20,14 +21,14 @@ func TestCassandraCreateSchemaDisabled(t *testing.T) {
 func TestCassandraCreateSchemaEnabled(t *testing.T) {
 	trueVar := true
 
-	jaeger := v1.NewJaeger("TestCassandraCreateSchemaEnabled")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestCassandraCreateSchemaEnabled"})
 	jaeger.Spec.Storage.CassandraCreateSchema.Enabled = &trueVar
 
 	assert.Len(t, cassandraDeps(jaeger), 1)
 }
 
 func TestCassandraCreateSchemaEnabledNil(t *testing.T) {
-	jaeger := v1.NewJaeger("TestCassandraCreateSchemaEnabledNil")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestCassandraCreateSchemaEnabledNil"})
 
 	assert.Nil(t, jaeger.Spec.Storage.CassandraCreateSchema.Enabled)
 	assert.Len(t, cassandraDeps(jaeger), 1)
@@ -36,7 +37,7 @@ func TestCassandraCreateSchemaEnabledNil(t *testing.T) {
 func TestCassandraCreateSchemaTTLSecondsAfterFinished(t *testing.T) {
 	trueVar := true
 
-	jaeger := v1.NewJaeger("TestCassandraCreateSchemaTTLSecondsAfterFinished")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestCassandraCreateSchemaTTLSecondsAfterFinished"})
 	jaeger.Spec.Storage.CassandraCreateSchema.Enabled = &trueVar
 	ttlSecondsAfterFinished := int32(100)
 	jaeger.Spec.Storage.CassandraCreateSchema.TTLSecondsAfterFinished = &ttlSecondsAfterFinished

--- a/pkg/storage/dependency_test.go
+++ b/pkg/storage/dependency_test.go
@@ -4,23 +4,24 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 )
 
 func TestDefaultDependencies(t *testing.T) {
-	jaeger := v1.NewJaeger("TestCassandraDependencies")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestCassandraDependencies"})
 	assert.Len(t, Dependencies(jaeger), 0)
 }
 
 func TestCassandraDependencies(t *testing.T) {
-	jaeger := v1.NewJaeger("TestCassandraDependencies")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestCassandraDependencies"})
 	jaeger.Spec.Storage.Type = "CASSANDRA" // should be converted to lowercase
 	assert.Len(t, Dependencies(jaeger), 1)
 }
 
 func TestESDependencies(t *testing.T) {
-	jaeger := v1.NewJaeger("charmander")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "charmander"})
 	jaeger.Spec.Storage.Type = "elasticsearch" // should be converted to lowercase
 	jaeger.Spec.Storage.Options = v1.NewOptions(map[string]interface{}{"es.use-aliases": "true"})
 	deps := Dependencies(jaeger)

--- a/pkg/storage/elasticsearch_dependencies_test.go
+++ b/pkg/storage/elasticsearch_dependencies_test.go
@@ -6,8 +6,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/util"
 )
 
@@ -48,7 +49,7 @@ func TestEnableRollover(t *testing.T) {
 }
 
 func TestElasticsearchDependencies(t *testing.T) {
-	j := v1.NewJaeger("eevee")
+	j := v1.NewJaeger(types.NamespacedName{Name: "eevee"})
 	j.Namespace = "kitchen"
 	j.Spec.Storage.Rollover.Image = "wohooo"
 	j.Spec.Storage.Options = v1.NewOptions(map[string]interface{}{"es.server-urls": "foo,bar", "es.index-prefix": "shortone"})

--- a/pkg/storage/elasticsearch_secrets_test.go
+++ b/pkg/storage/elasticsearch_secrets_test.go
@@ -12,12 +12,13 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 )
 
 func TestCreateESSecretsError(t *testing.T) {
-	j := v1.NewJaeger(t.Name())
+	j := v1.NewJaeger(types.NamespacedName{Name: t.Name()})
 	es := &ElasticsearchDeployment{Jaeger: j, CertScript: "/foo"}
 	err := es.CleanCerts()
 	require.NoError(t, err)
@@ -27,7 +28,7 @@ func TestCreateESSecretsError(t *testing.T) {
 }
 
 func TestCreateESSecrets(t *testing.T) {
-	j := v1.NewJaeger(t.Name())
+	j := v1.NewJaeger(types.NamespacedName{Name: t.Name()})
 	es := &ElasticsearchDeployment{Jaeger: j, CertScript: "../../scripts/cert_generation.sh"}
 	err := es.CleanCerts()
 	require.NoError(t, err)
@@ -55,7 +56,7 @@ func TestCreateESSecrets(t *testing.T) {
 }
 
 func TestCreateSecret(t *testing.T) {
-	j := v1.NewJaeger("foo")
+	j := v1.NewJaeger(types.NamespacedName{Name: "foo"})
 	j.Namespace = "myproject"
 	s := createSecret(j, "bar", map[string][]byte{"foo": {}})
 	assert.Equal(t, "bar", s.ObjectMeta.Name)
@@ -93,7 +94,7 @@ func TestGetFileContent_EmptyPath(t *testing.T) {
 }
 
 func TestExtractSecretsToFile(t *testing.T) {
-	j := v1.NewJaeger(t.Name())
+	j := v1.NewJaeger(types.NamespacedName{Name: t.Name()})
 	caFile := fmt.Sprintf("%s/%s/ca.crt", tmpWorkingDir, j.Name)
 	defer os.Remove(caFile)
 	content := "115dasrez"
@@ -121,7 +122,7 @@ func TestExtractSecretsToFile_FileExists(t *testing.T) {
 	err = ioutil.WriteFile(tmpWorkingDir+"/bar/houdy/ca.crt", []byte(content), os.ModePerm)
 	assert.NoError(t, err)
 
-	j := v1.NewJaeger("houdy")
+	j := v1.NewJaeger(types.NamespacedName{Name: "houdy"})
 	j.Namespace = "bar"
 	err = extractSecretsToFile(
 		j,

--- a/pkg/storage/elasticsearch_test.go
+++ b/pkg/storage/elasticsearch_test.go
@@ -6,8 +6,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 	esv1 "github.com/jaegertracing/jaeger-operator/pkg/storage/elasticsearch/v1"
 )
 
@@ -81,8 +82,7 @@ func TestCreateElasticsearchCR(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		j := v1.NewJaeger("foo")
-		j.Namespace = "myproject"
+		j := v1.NewJaeger(types.NamespacedName{Name: "foo", Namespace: "myproject"})
 		j.Spec.Storage.Elasticsearch = test.jEsSpec
 		es := &ElasticsearchDeployment{Jaeger: j}
 		cr := es.Elasticsearch()
@@ -215,7 +215,7 @@ func TestInject(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		es := &ElasticsearchDeployment{Jaeger: v1.NewJaeger("hoo")}
+		es := &ElasticsearchDeployment{Jaeger: v1.NewJaeger(types.NamespacedName{Name: "hoo"})}
 		es.Jaeger.Spec.Storage.Elasticsearch = test.es
 		es.InjectStorageConfiguration(test.pod)
 		assert.Equal(t, test.expected, test.pod)

--- a/pkg/strategy/all-in-one_test.go
+++ b/pkg/strategy/all-in-one_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
 
 	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/storage"
@@ -19,7 +20,7 @@ func init() {
 
 func TestCreateAllInOneDeployment(t *testing.T) {
 	name := "TestCreateAllInOneDeployment"
-	c := newAllInOneStrategy(v1.NewJaeger(name))
+	c := newAllInOneStrategy(v1.NewJaeger(types.NamespacedName{Name: name}))
 	assertDeploymentsAndServicesForAllInOne(t, name, c, false, false, false)
 }
 
@@ -28,7 +29,7 @@ func TestCreateAllInOneDeploymentOnOpenShift(t *testing.T) {
 	defer viper.Reset()
 	name := "TestCreateAllInOneDeploymentOnOpenShift"
 
-	jaeger := v1.NewJaeger(name)
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: name})
 	normalize(jaeger)
 
 	c := newAllInOneStrategy(jaeger)
@@ -38,7 +39,7 @@ func TestCreateAllInOneDeploymentOnOpenShift(t *testing.T) {
 func TestCreateAllInOneDeploymentWithDaemonSetAgent(t *testing.T) {
 	name := "TestCreateAllInOneDeploymentWithDaemonSetAgent"
 
-	j := v1.NewJaeger(name)
+	j := v1.NewJaeger(types.NamespacedName{Name: name})
 	j.Spec.Agent.Strategy = "DaemonSet"
 
 	c := newAllInOneStrategy(j)
@@ -48,7 +49,7 @@ func TestCreateAllInOneDeploymentWithDaemonSetAgent(t *testing.T) {
 func TestCreateAllInOneDeploymentWithUIConfigMap(t *testing.T) {
 	name := "TestCreateAllInOneDeploymentWithUIConfigMap"
 
-	j := v1.NewJaeger(name)
+	j := v1.NewJaeger(types.NamespacedName{Name: name})
 	j.Spec.UI.Options = v1.NewFreeForm(map[string]interface{}{
 		"tracking": map[string]interface{}{
 			"gaID": "UA-000000-2",
@@ -61,7 +62,7 @@ func TestCreateAllInOneDeploymentWithUIConfigMap(t *testing.T) {
 
 func TestDelegateAllInOneDependencies(t *testing.T) {
 	// for now, we just have storage dependencies
-	j := v1.NewJaeger("TestDelegateAllInOneDependencies")
+	j := v1.NewJaeger(types.NamespacedName{Name: "TestDelegateAllInOneDependencies"})
 	c := newAllInOneStrategy(j)
 	assert.Equal(t, c.Dependencies(), storage.Dependencies(j))
 }

--- a/pkg/strategy/controller_test.go
+++ b/pkg/strategy/controller_test.go
@@ -7,19 +7,20 @@ import (
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 )
 
 func TestNewControllerForAllInOneAsDefault(t *testing.T) {
-	jaeger := v1.NewJaeger("TestNewControllerForAllInOneAsDefault")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestNewControllerForAllInOneAsDefault"})
 
 	ctrl := For(context.TODO(), jaeger, []corev1.Secret{})
 	assert.Equal(t, ctrl.Type(), AllInOne)
 }
 
 func TestNewControllerForAllInOneAsExplicitValue(t *testing.T) {
-	jaeger := v1.NewJaeger("TestNewControllerForAllInOneAsExplicitValue")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestNewControllerForAllInOneAsExplicitValue"})
 	jaeger.Spec.Strategy = "ALL-IN-ONE" // same as 'all-in-one'
 
 	ctrl := For(context.TODO(), jaeger, []corev1.Secret{})
@@ -27,7 +28,7 @@ func TestNewControllerForAllInOneAsExplicitValue(t *testing.T) {
 }
 
 func TestNewControllerForProduction(t *testing.T) {
-	jaeger := v1.NewJaeger("TestNewControllerForProduction")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestNewControllerForProduction"})
 	jaeger.Spec.Strategy = "production"
 	jaeger.Spec.Storage.Type = "elasticsearch"
 
@@ -36,14 +37,14 @@ func TestNewControllerForProduction(t *testing.T) {
 }
 
 func TestUnknownStorage(t *testing.T) {
-	jaeger := v1.NewJaeger("TestNewControllerForProduction")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestNewControllerForProduction"})
 	jaeger.Spec.Storage.Type = "unknown"
 	normalize(jaeger)
 	assert.Equal(t, "memory", jaeger.Spec.Storage.Type)
 }
 
 func TestElasticsearchAsStorageOptions(t *testing.T) {
-	jaeger := v1.NewJaeger("TestElasticsearchAsStorageOptions")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestElasticsearchAsStorageOptions"})
 	jaeger.Spec.Strategy = "production"
 	jaeger.Spec.Storage.Type = "elasticsearch"
 	jaeger.Spec.Storage.Options = v1.NewOptions(map[string]interface{}{
@@ -121,13 +122,13 @@ func TestStorageMemoryOnlyUsedWithAllInOneStrategy(t *testing.T) {
 }
 
 func TestSetSecurityToNoneByDefault(t *testing.T) {
-	jaeger := v1.NewJaeger("TestSetSecurityToNoneByDefault")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestSetSecurityToNoneByDefault"})
 	normalize(jaeger)
 	assert.Equal(t, v1.IngressSecurityNoneExplicit, jaeger.Spec.Ingress.Security)
 }
 
 func TestSetSecurityToNoneWhenExplicitSettingToNone(t *testing.T) {
-	jaeger := v1.NewJaeger("TestSetSecurityToNoneWhenExplicitSettingToNone")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestSetSecurityToNoneWhenExplicitSettingToNone"})
 	jaeger.Spec.Ingress.Security = v1.IngressSecurityNoneExplicit
 	normalize(jaeger)
 	assert.Equal(t, v1.IngressSecurityNoneExplicit, jaeger.Spec.Ingress.Security)
@@ -137,14 +138,14 @@ func TestSetSecurityToOAuthProxyByDefaultOnOpenShift(t *testing.T) {
 	viper.Set("platform", "openshift")
 	defer viper.Reset()
 
-	jaeger := v1.NewJaeger("TestSetSecurityToOAuthProxyByDefaultOnOpenShift")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestSetSecurityToOAuthProxyByDefaultOnOpenShift"})
 	normalize(jaeger)
 
 	assert.Equal(t, v1.IngressSecurityOAuthProxy, jaeger.Spec.Ingress.Security)
 }
 
 func TestSetSecurityToNoneOnNonOpenShift(t *testing.T) {
-	jaeger := v1.NewJaeger("TestSetSecurityToNoneOnNonOpenShift")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestSetSecurityToNoneOnNonOpenShift"})
 	jaeger.Spec.Ingress.Security = v1.IngressSecurityOAuthProxy
 
 	normalize(jaeger)
@@ -156,7 +157,7 @@ func TestAcceptExplicitValueFromSecurityWhenOnOpenShift(t *testing.T) {
 	viper.Set("platform", "openshift")
 	defer viper.Reset()
 
-	jaeger := v1.NewJaeger("TestAcceptExplicitValueFromSecurityWhenOnOpenShift")
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestAcceptExplicitValueFromSecurityWhenOnOpenShift"})
 	jaeger.Spec.Ingress.Security = v1.IngressSecurityNoneExplicit
 
 	normalize(jaeger)

--- a/pkg/strategy/production_test.go
+++ b/pkg/strategy/production_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/storage"
@@ -23,7 +24,7 @@ func init() {
 
 func TestCreateProductionDeployment(t *testing.T) {
 	name := "TestCreateProductionDeployment"
-	c := newProductionStrategy(v1.NewJaeger(name), &storage.ElasticsearchDeployment{})
+	c := newProductionStrategy(v1.NewJaeger(types.NamespacedName{Name: name}), &storage.ElasticsearchDeployment{})
 	assertDeploymentsAndServicesForProduction(t, name, c, false, false, false)
 }
 
@@ -32,7 +33,7 @@ func TestCreateProductionDeploymentOnOpenShift(t *testing.T) {
 	defer viper.Reset()
 	name := "TestCreateProductionDeploymentOnOpenShift"
 
-	jaeger := v1.NewJaeger(name)
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: name})
 	normalize(jaeger)
 
 	c := newProductionStrategy(jaeger, &storage.ElasticsearchDeployment{})
@@ -42,7 +43,7 @@ func TestCreateProductionDeploymentOnOpenShift(t *testing.T) {
 func TestCreateProductionDeploymentWithDaemonSetAgent(t *testing.T) {
 	name := "TestCreateProductionDeploymentWithDaemonSetAgent"
 
-	j := v1.NewJaeger(name)
+	j := v1.NewJaeger(types.NamespacedName{Name: name})
 	j.Spec.Agent.Strategy = "DaemonSet"
 
 	c := newProductionStrategy(j, &storage.ElasticsearchDeployment{})
@@ -52,7 +53,7 @@ func TestCreateProductionDeploymentWithDaemonSetAgent(t *testing.T) {
 func TestCreateProductionDeploymentWithUIConfigMap(t *testing.T) {
 	name := "TestCreateProductionDeploymentWithUIConfigMap"
 
-	j := v1.NewJaeger(name)
+	j := v1.NewJaeger(types.NamespacedName{Name: name})
 	j.Spec.UI.Options = v1.NewFreeForm(map[string]interface{}{
 		"tracking": map[string]interface{}{
 			"gaID": "UA-000000-2",
@@ -108,7 +109,7 @@ func TestOptionsArePassed(t *testing.T) {
 
 func TestDelegateProductionDependencies(t *testing.T) {
 	// for now, we just have storage dependencies
-	j := v1.NewJaeger("TestDelegateProductionDependencies")
+	j := v1.NewJaeger(types.NamespacedName{Name: "TestDelegateProductionDependencies"})
 	j.Spec.Storage.Type = "cassandra"
 	c := newProductionStrategy(j, &storage.ElasticsearchDeployment{})
 	assert.Equal(t, c.Dependencies(), storage.Dependencies(j))
@@ -176,7 +177,7 @@ func TestEsIndexCleanerProduction(t *testing.T) {
 }
 
 func TestAgentSidecarIsInjectedIntoQueryForStreamingForProduction(t *testing.T) {
-	j := v1.NewJaeger("TestAgentSidecarIsInjectedIntoQueryForStreamingForProduction")
+	j := v1.NewJaeger(types.NamespacedName{Name: "TestAgentSidecarIsInjectedIntoQueryForStreamingForProduction"})
 	c := newProductionStrategy(j, &storage.ElasticsearchDeployment{})
 	for _, dep := range c.Deployments() {
 		if strings.HasSuffix(dep.Name, "-query") {
@@ -187,7 +188,7 @@ func TestAgentSidecarIsInjectedIntoQueryForStreamingForProduction(t *testing.T) 
 }
 
 func TestElasticsearchInject(t *testing.T) {
-	j := v1.NewJaeger(t.Name())
+	j := v1.NewJaeger(types.NamespacedName{Name: t.Name()})
 	j.Spec.Storage.Type = "elasticsearch"
 	verdad := true
 	one := int(1)

--- a/pkg/strategy/streaming_test.go
+++ b/pkg/strategy/streaming_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/storage"
@@ -22,7 +23,7 @@ func init() {
 
 func TestCreateStreamingDeployment(t *testing.T) {
 	name := "TestCreateStreamingDeployment"
-	c := newStreamingStrategy(v1.NewJaeger(name))
+	c := newStreamingStrategy(v1.NewJaeger(types.NamespacedName{Name: name}))
 	assertDeploymentsAndServicesForStreaming(t, name, c, false, false, false)
 }
 
@@ -31,7 +32,7 @@ func TestCreateStreamingDeploymentOnOpenShift(t *testing.T) {
 	defer viper.Reset()
 	name := "TestCreateStreamingDeploymentOnOpenShift"
 
-	jaeger := v1.NewJaeger(name)
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: name})
 	normalize(jaeger)
 
 	c := newStreamingStrategy(jaeger)
@@ -41,7 +42,7 @@ func TestCreateStreamingDeploymentOnOpenShift(t *testing.T) {
 func TestCreateStreamingDeploymentWithDaemonSetAgent(t *testing.T) {
 	name := "TestCreateStreamingDeploymentWithDaemonSetAgent"
 
-	j := v1.NewJaeger(name)
+	j := v1.NewJaeger(types.NamespacedName{Name: name})
 	j.Spec.Agent.Strategy = "DaemonSet"
 
 	c := newStreamingStrategy(j)
@@ -51,7 +52,7 @@ func TestCreateStreamingDeploymentWithDaemonSetAgent(t *testing.T) {
 func TestCreateStreamingDeploymentWithUIConfigMap(t *testing.T) {
 	name := "TestCreateStreamingDeploymentWithUIConfigMap"
 
-	j := v1.NewJaeger(name)
+	j := v1.NewJaeger(types.NamespacedName{Name: name})
 	j.Spec.UI.Options = v1.NewFreeForm(map[string]interface{}{
 		"tracking": map[string]interface{}{
 			"gaID": "UA-000000-2",
@@ -126,7 +127,7 @@ func TestStreamingOptionsArePassed(t *testing.T) {
 
 func TestDelegateStreamingDependencies(t *testing.T) {
 	// for now, we just have storage dependencies
-	j := v1.NewJaeger("TestDelegateStreamingDependencies")
+	j := v1.NewJaeger(types.NamespacedName{Name: "TestDelegateStreamingDependencies"})
 	c := newStreamingStrategy(j)
 	assert.Equal(t, c.Dependencies(), storage.Dependencies(j))
 }
@@ -193,7 +194,7 @@ func TestEsIndexClenarStreaming(t *testing.T) {
 }
 
 func TestAgentSidecarIsInjectedIntoQueryForStreaming(t *testing.T) {
-	j := v1.NewJaeger("TestAgentSidecarIsInjectedIntoQueryForStreaming")
+	j := v1.NewJaeger(types.NamespacedName{Name: "TestAgentSidecarIsInjectedIntoQueryForStreaming"})
 	c := newStreamingStrategy(j)
 	for _, dep := range c.Deployments() {
 		if strings.HasSuffix(dep.Name, "-query") {

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -7,8 +7,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 )
 
 func TestRemoveDuplicatedVolumes(t *testing.T) {
@@ -285,7 +286,7 @@ func TestGetEsHostname(t *testing.T) {
 }
 
 func TestAsOwner(t *testing.T) {
-	j := v1.NewJaeger("joe")
+	j := v1.NewJaeger(types.NamespacedName{Name: "joe"})
 	j.Kind = "human"
 	j.APIVersion = "homosapiens"
 	j.UID = "boom!"
@@ -302,7 +303,7 @@ func TestLabels(t *testing.T) {
 		"app.kubernetes.io/component":  "leg",
 		"app.kubernetes.io/part-of":    "jaeger",
 		"app.kubernetes.io/managed-by": "jaeger-operator",
-	}, Labels("joe", "leg", *v1.NewJaeger("thatone")))
+	}, Labels("joe", "leg", *v1.NewJaeger(types.NamespacedName{Name: "thatone"})))
 }
 
 func TestFindItem(t *testing.T) {


### PR DESCRIPTION
Fixes #285 by using namespaces whenever a name is involved. Before this change, deploying a Jaeger instance in a namespace `tenant2` when there's already a Jaeger instance in another namespace (`tenant1`) would cause the underlying objects, such as `Deployment` objects, to be removed in favor of the one in the new namespace.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>