### PR TITLE
Disable the property ttlSecondsAfterFinished

### DIFF
--- a/pkg/apis/jaegertracing/v1/jaeger_types.go
+++ b/pkg/apis/jaegertracing/v1/jaeger_types.go
@@ -1,7 +1,7 @@
 package v1
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	esv1 "github.com/jaegertracing/jaeger-operator/pkg/storage/elasticsearch/v1"
@@ -207,7 +207,7 @@ type JaegerCassandraCreateSchemaSpec struct {
 	Image                   string `json:"image"`
 	Datacenter              string `json:"datacenter"`
 	Mode                    string `json:"mode"`
-	TTLSecondsAfterFinished *int32 `json:"ttlSecondsAfterFinished"`
+	TTLSecondsAfterFinished *int32 `json:"ttlSecondsAfterFinished,omitempty"`
 }
 
 // JaegerDependenciesSpec defined options for running spark-dependencies.
@@ -221,7 +221,7 @@ type JaegerDependenciesSpec struct {
 	CassandraClientAuthEnabled  bool   `json:"cassandraClientAuthEnabled"`
 	ElasticsearchClientNodeOnly bool   `json:"elasticsearchClientNodeOnly"`
 	ElasticsearchNodesWanOnly   bool   `json:"elasticsearchNodesWanOnly"`
-	TTLSecondsAfterFinished     *int32 `json:"ttlSecondsAfterFinished"`
+	TTLSecondsAfterFinished     *int32 `json:"ttlSecondsAfterFinished,omitempty"`
 }
 
 // JaegerEsIndexCleanerSpec holds the options related to es-index-cleaner
@@ -231,7 +231,7 @@ type JaegerEsIndexCleanerSpec struct {
 	NumberOfDays            *int   `json:"numberOfDays"`
 	Schedule                string `json:"schedule"`
 	Image                   string `json:"image"`
-	TTLSecondsAfterFinished *int32 `json:"ttlSecondsAfterFinished"`
+	TTLSecondsAfterFinished *int32 `json:"ttlSecondsAfterFinished,omitempty"`
 }
 
 // JaegerEsRolloverSpec holds the options related to es-rollover
@@ -239,7 +239,7 @@ type JaegerEsRolloverSpec struct {
 	Image                   string `json:"image"`
 	Schedule                string `json:"schedule"`
 	Conditions              string `json:"conditions"`
-	TTLSecondsAfterFinished *int32 `json:"ttlSecondsAfterFinished"`
+	TTLSecondsAfterFinished *int32 `json:"ttlSecondsAfterFinished,omitempty"`
 	// we parse it with time.ParseDuration
 	ReadTTL string `json:"readTTL"`
 }

--- a/pkg/cronjob/es_index_cleaner_test.go
+++ b/pkg/cronjob/es_index_cleaner_test.go
@@ -14,10 +14,7 @@ func TestCreateEsIndexCleaner(t *testing.T) {
 		map[string]interface{}{"es.index-prefix": "tenant1", "es.server-urls": "http://nowhere:666,foo"})}}}
 	days := 0
 	jaeger.Spec.Storage.EsIndexCleaner.NumberOfDays = &days
-	ttlSecondsAfterFinished := int32(100)
-	jaeger.Spec.Storage.EsIndexCleaner.TTLSecondsAfterFinished = &ttlSecondsAfterFinished
 	cronJob := CreateEsIndexCleaner(jaeger)
-	assert.Equal(t, ttlSecondsAfterFinished, *cronJob.Spec.JobTemplate.Spec.TTLSecondsAfterFinished)
 	assert.Equal(t, 2, len(cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Args))
 	// default number of days (7) is applied in normalize in controller
 	assert.Equal(t, []string{"0", "http://nowhere:666"}, cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Args)

--- a/pkg/cronjob/es_rollover.go
+++ b/pkg/cronjob/es_rollover.go
@@ -11,7 +11,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/util"
 )
 
@@ -47,8 +47,7 @@ func rollover(jaeger *v1.Jaeger) batchv1beta1.CronJob {
 			Schedule:          jaeger.Spec.Storage.Rollover.Schedule,
 			JobTemplate: batchv1beta1.JobTemplateSpec{
 				Spec: batchv1.JobSpec{
-					TTLSecondsAfterFinished: jaeger.Spec.Storage.Rollover.TTLSecondsAfterFinished,
-					Parallelism:             &one,
+					Parallelism: &one,
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Annotations: map[string]string{

--- a/pkg/cronjob/es_rollover_test.go
+++ b/pkg/cronjob/es_rollover_test.go
@@ -24,8 +24,6 @@ func TestRollover(t *testing.T) {
 	j.Spec.Storage.Rollover.Image = "wohooo"
 	j.Spec.Storage.Rollover.Conditions = "weheee"
 	j.Spec.Storage.Options = v1.NewOptions(map[string]interface{}{"es.server-urls": "foo,bar", "es.index-prefix": "shortone"})
-	ttlSecondsAfterFinished := int32(100)
-	j.Spec.Storage.Rollover.TTLSecondsAfterFinished = &ttlSecondsAfterFinished
 
 	cjob := rollover(j)
 	assert.Equal(t, j.Namespace, cjob.Namespace)
@@ -35,7 +33,6 @@ func TestRollover(t *testing.T) {
 	assert.Equal(t, j.Spec.Storage.Rollover.Image, cjob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Image)
 	assert.Equal(t, []string{"rollover", "foo"}, cjob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Args)
 	assert.Equal(t, []corev1.EnvVar{{Name: "INDEX_PREFIX", Value: "shortone"}, {Name: "CONDITIONS", Value: "weheee"}}, cjob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Env)
-	assert.Equal(t, ttlSecondsAfterFinished, *cjob.Spec.JobTemplate.Spec.TTLSecondsAfterFinished)
 }
 
 func TestLookback(t *testing.T) {
@@ -44,8 +41,6 @@ func TestLookback(t *testing.T) {
 	j.Spec.Storage.Rollover.Image = "wohooo"
 	j.Spec.Storage.Rollover.ReadTTL = "2h"
 	j.Spec.Storage.Options = v1.NewOptions(map[string]interface{}{"es.server-urls": "foo,bar", "es.index-prefix": "shortone"})
-	ttlSecondsAfterFinished := int32(100)
-	j.Spec.Storage.Rollover.TTLSecondsAfterFinished = &ttlSecondsAfterFinished
 
 	cjob := lookback(j)
 	assert.Equal(t, j.Namespace, cjob.Namespace)
@@ -55,7 +50,6 @@ func TestLookback(t *testing.T) {
 	assert.Equal(t, j.Spec.Storage.Rollover.Image, cjob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Image)
 	assert.Equal(t, []string{"lookback", "foo"}, cjob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Args)
 	assert.Equal(t, []corev1.EnvVar{{Name: "INDEX_PREFIX", Value: "shortone"}, {Name: "UNIT", Value: "hours"}, {Name: "UNIT_COUNT", Value: "2"}}, cjob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Env)
-	assert.Equal(t, ttlSecondsAfterFinished, *cjob.Spec.JobTemplate.Spec.TTLSecondsAfterFinished)
 }
 
 func TestEnvVars(t *testing.T) {

--- a/pkg/cronjob/spark_dependencies.go
+++ b/pkg/cronjob/spark_dependencies.go
@@ -10,7 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/storage"
 )
 
@@ -60,8 +60,7 @@ func CreateSparkDependencies(jaeger *v1.Jaeger) *batchv1beta1.CronJob {
 			Schedule:          jaeger.Spec.Storage.SparkDependencies.Schedule,
 			JobTemplate: batchv1beta1.JobTemplateSpec{
 				Spec: batchv1.JobSpec{
-					Parallelism:             &one,
-					TTLSecondsAfterFinished: jaeger.Spec.Storage.SparkDependencies.TTLSecondsAfterFinished,
+					Parallelism: &one,
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
 							Containers: []corev1.Container{

--- a/pkg/cronjob/spark_dependencies_test.go
+++ b/pkg/cronjob/spark_dependencies_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 )
 
 func TestRemoveEmptyVars(t *testing.T) {
@@ -79,10 +79,7 @@ func TestCreate(t *testing.T) {
 
 func TestSparkDependencies(t *testing.T) {
 	j := &v1.Jaeger{Spec: v1.JaegerSpec{Storage: v1.JaegerStorageSpec{Type: "elasticsearch"}}}
-	ttlSecondsAfterFinished := int32(100)
-	j.Spec.Storage.SparkDependencies.TTLSecondsAfterFinished = &ttlSecondsAfterFinished
 
 	cjob := CreateSparkDependencies(j)
 	assert.Equal(t, j.Namespace, cjob.Namespace)
-	assert.Equal(t, ttlSecondsAfterFinished, *cjob.Spec.JobTemplate.Spec.TTLSecondsAfterFinished)
 }

--- a/pkg/storage/cassandra_dependencies.go
+++ b/pkg/storage/cassandra_dependencies.go
@@ -8,7 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 )
 
 func cassandraDeps(jaeger *v1.Jaeger) []batchv1.Job {
@@ -81,8 +81,7 @@ func cassandraDeps(jaeger *v1.Jaeger) []batchv1.Job {
 				},
 			},
 			Spec: batchv1.JobSpec{
-				ActiveDeadlineSeconds:   &deadline,
-				TTLSecondsAfterFinished: jaeger.Spec.Storage.CassandraCreateSchema.TTLSecondsAfterFinished,
+				ActiveDeadlineSeconds: &deadline,
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Annotations: annotations,

--- a/pkg/storage/cassandra_dependencies_test.go
+++ b/pkg/storage/cassandra_dependencies_test.go
@@ -33,14 +33,3 @@ func TestCassandraCreateSchemaEnabledNil(t *testing.T) {
 	assert.Nil(t, jaeger.Spec.Storage.CassandraCreateSchema.Enabled)
 	assert.Len(t, cassandraDeps(jaeger), 1)
 }
-
-func TestCassandraCreateSchemaTTLSecondsAfterFinished(t *testing.T) {
-	trueVar := true
-
-	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestCassandraCreateSchemaTTLSecondsAfterFinished"})
-	jaeger.Spec.Storage.CassandraCreateSchema.Enabled = &trueVar
-	ttlSecondsAfterFinished := int32(100)
-	jaeger.Spec.Storage.CassandraCreateSchema.TTLSecondsAfterFinished = &ttlSecondsAfterFinished
-	cjob := cassandraDeps(jaeger)
-	assert.Equal(t, ttlSecondsAfterFinished, *cjob[0].Spec.TTLSecondsAfterFinished)
-}

--- a/pkg/strategy/controller.go
+++ b/pkg/strategy/controller.go
@@ -9,18 +9,13 @@ import (
 	"github.com/spf13/viper"
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/cronjob"
 	"github.com/jaegertracing/jaeger-operator/pkg/storage"
 )
 
 const (
 	esCertGenerationScript = "./scripts/cert_generation.sh"
-)
-
-var (
-	// Default to 1 day
-	defTTLSecondsAfterFinished = int32(86400)
 )
 
 // For returns the appropriate Strategy for the given Jaeger instance
@@ -95,7 +90,6 @@ func normalize(jaeger *v1.Jaeger) {
 	normalizeIndexCleaner(&jaeger.Spec.Storage.EsIndexCleaner, jaeger.Spec.Storage.Type)
 	normalizeElasticsearch(&jaeger.Spec.Storage.Elasticsearch)
 	normalizeRollover(&jaeger.Spec.Storage.Rollover)
-	normalizeCassandraCreateSchema(&jaeger.Spec.Storage.CassandraCreateSchema)
 	normalizeUI(&jaeger.Spec)
 }
 
@@ -112,9 +106,6 @@ func normalizeSparkDependencies(spec *v1.JaegerStorageSpec) {
 	}
 	if spec.SparkDependencies.Schedule == "" {
 		spec.SparkDependencies.Schedule = "55 23 * * *"
-	}
-	if spec.SparkDependencies.TTLSecondsAfterFinished == nil {
-		spec.SparkDependencies.TTLSecondsAfterFinished = &defTTLSecondsAfterFinished
 	}
 }
 
@@ -134,9 +125,6 @@ func normalizeIndexCleaner(spec *v1.JaegerEsIndexCleanerSpec, storage string) {
 		defDays := 7
 		spec.NumberOfDays = &defDays
 	}
-	if spec.TTLSecondsAfterFinished == nil {
-		spec.TTLSecondsAfterFinished = &defTTLSecondsAfterFinished
-	}
 }
 
 func normalizeElasticsearch(spec *v1.ElasticsearchSpec) {
@@ -151,15 +139,6 @@ func normalizeRollover(spec *v1.JaegerEsRolloverSpec) {
 	}
 	if spec.Schedule == "" {
 		spec.Schedule = "*/30 * * * *"
-	}
-	if spec.TTLSecondsAfterFinished == nil {
-		spec.TTLSecondsAfterFinished = &defTTLSecondsAfterFinished
-	}
-}
-
-func normalizeCassandraCreateSchema(spec *v1.JaegerCassandraCreateSchemaSpec) {
-	if spec.TTLSecondsAfterFinished == nil {
-		spec.TTLSecondsAfterFinished = &defTTLSecondsAfterFinished
 	}
 }
 

--- a/pkg/strategy/controller_test.go
+++ b/pkg/strategy/controller_test.go
@@ -9,7 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 )
 
 func TestNewControllerForAllInOneAsDefault(t *testing.T) {
@@ -172,15 +172,14 @@ func TestNormalizeIndexCleaner(t *testing.T) {
 	falseVar := false
 	days7 := 7
 	days55 := 55
-	ttlSecondsAfterFinished100 := int32(100)
 	tests := []struct {
 		underTest v1.JaegerEsIndexCleanerSpec
 		expected  v1.JaegerEsIndexCleanerSpec
 	}{
 		{underTest: v1.JaegerEsIndexCleanerSpec{},
-			expected: v1.JaegerEsIndexCleanerSpec{Image: "foo", Schedule: "55 23 * * *", NumberOfDays: &days7, Enabled: &trueVar, TTLSecondsAfterFinished: &defTTLSecondsAfterFinished}},
-		{underTest: v1.JaegerEsIndexCleanerSpec{Image: "bla", Schedule: "lol", NumberOfDays: &days55, Enabled: &falseVar, TTLSecondsAfterFinished: &ttlSecondsAfterFinished100},
-			expected: v1.JaegerEsIndexCleanerSpec{Image: "bla", Schedule: "lol", NumberOfDays: &days55, Enabled: &falseVar, TTLSecondsAfterFinished: &ttlSecondsAfterFinished100}},
+			expected: v1.JaegerEsIndexCleanerSpec{Image: "foo", Schedule: "55 23 * * *", NumberOfDays: &days7, Enabled: &trueVar}},
+		{underTest: v1.JaegerEsIndexCleanerSpec{Image: "bla", Schedule: "lol", NumberOfDays: &days55, Enabled: &falseVar},
+			expected: v1.JaegerEsIndexCleanerSpec{Image: "bla", Schedule: "lol", NumberOfDays: &days55, Enabled: &falseVar}},
 	}
 	for _, test := range tests {
 		normalizeIndexCleaner(&test.underTest, "elasticsearch")
@@ -191,15 +190,14 @@ func TestNormalizeIndexCleaner(t *testing.T) {
 func TestNormalizeRollover(t *testing.T) {
 	viper.Set("jaeger-es-rollover-image", "hoo")
 	defer viper.Reset()
-	ttlSecondsAfterFinished100 := int32(100)
 	tests := []struct {
 		underTest v1.JaegerEsRolloverSpec
 		expected  v1.JaegerEsRolloverSpec
 	}{
 		{underTest: v1.JaegerEsRolloverSpec{},
-			expected: v1.JaegerEsRolloverSpec{Image: "hoo", Schedule: "*/30 * * * *", TTLSecondsAfterFinished: &defTTLSecondsAfterFinished}},
-		{underTest: v1.JaegerEsRolloverSpec{Image: "bla", Schedule: "lol", TTLSecondsAfterFinished: &ttlSecondsAfterFinished100},
-			expected: v1.JaegerEsRolloverSpec{Image: "bla", Schedule: "lol", TTLSecondsAfterFinished: &ttlSecondsAfterFinished100}},
+			expected: v1.JaegerEsRolloverSpec{Image: "hoo", Schedule: "*/30 * * * *"}},
+		{underTest: v1.JaegerEsRolloverSpec{Image: "bla", Schedule: "lol"},
+			expected: v1.JaegerEsRolloverSpec{Image: "bla", Schedule: "lol"}},
 	}
 	for _, test := range tests {
 		normalizeRollover(&test.underTest)
@@ -212,7 +210,6 @@ func TestNormalizeSparkDependencies(t *testing.T) {
 	defer viper.Reset()
 	trueVar := true
 	falseVar := false
-	ttlSecondsAfterFinished100 := int32(100)
 	tests := []struct {
 		underTest v1.JaegerStorageSpec
 		expected  v1.JaegerStorageSpec
@@ -220,15 +217,15 @@ func TestNormalizeSparkDependencies(t *testing.T) {
 		{
 			underTest: v1.JaegerStorageSpec{Type: "elasticsearch", Options: v1.NewOptions(map[string]interface{}{"es.server-urls": "foo"})},
 			expected: v1.JaegerStorageSpec{Type: "elasticsearch", Options: v1.NewOptions(map[string]interface{}{"es.server-urls": "foo"}),
-				SparkDependencies: v1.JaegerDependenciesSpec{Schedule: "55 23 * * *", Image: "foo", Enabled: &trueVar, TTLSecondsAfterFinished: &defTTLSecondsAfterFinished}},
+				SparkDependencies: v1.JaegerDependenciesSpec{Schedule: "55 23 * * *", Image: "foo", Enabled: &trueVar}},
 		},
 		{
 			underTest: v1.JaegerStorageSpec{Type: "elasticsearch"},
-			expected:  v1.JaegerStorageSpec{Type: "elasticsearch", SparkDependencies: v1.JaegerDependenciesSpec{Schedule: "55 23 * * *", Image: "foo", TTLSecondsAfterFinished: &defTTLSecondsAfterFinished}},
+			expected:  v1.JaegerStorageSpec{Type: "elasticsearch", SparkDependencies: v1.JaegerDependenciesSpec{Schedule: "55 23 * * *", Image: "foo"}},
 		},
 		{
-			underTest: v1.JaegerStorageSpec{Type: "elasticsearch", SparkDependencies: v1.JaegerDependenciesSpec{Schedule: "foo", Image: "bla", Enabled: &falseVar, TTLSecondsAfterFinished: &ttlSecondsAfterFinished100}},
-			expected:  v1.JaegerStorageSpec{Type: "elasticsearch", SparkDependencies: v1.JaegerDependenciesSpec{Schedule: "foo", Image: "bla", Enabled: &falseVar, TTLSecondsAfterFinished: &ttlSecondsAfterFinished100}},
+			underTest: v1.JaegerStorageSpec{Type: "elasticsearch", SparkDependencies: v1.JaegerDependenciesSpec{Schedule: "foo", Image: "bla", Enabled: &falseVar}},
+			expected:  v1.JaegerStorageSpec{Type: "elasticsearch", SparkDependencies: v1.JaegerDependenciesSpec{Schedule: "foo", Image: "bla", Enabled: &falseVar}},
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
Fixes #494 by making the property `ttlSecondsAfterFinished` noop. The property still exists in the CRD, as we can't remove due to backwards compatibility reasons, but we are effectively removing the actual feature until we can reliably check which feature gates are on.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>