### PR TITLE
Bump Jaeger to 1.13

### DIFF
--- a/RELEASE.adoc
+++ b/RELEASE.adoc
@@ -1,5 +1,7 @@
 = Releasing the Jaeger Operator for Kubernetes
 
+1. Make sure the `jaeger.version` file is up to date
+
 1. Prepare a changelog and get it merged. A list of commits since the last release (`v1.8.0` in the following example) can be obtained via:
 
   $ git log --format="format:* %s" v1.8.0...HEAD

--- a/deploy/examples/all-in-one-with-options.yaml
+++ b/deploy/examples/all-in-one-with-options.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   strategy: allInOne
   allInOne:
-    image: jaegertracing/all-in-one:1.11
+    image: jaegertracing/all-in-one:1.13
     options:
       log-level: debug
       query:

--- a/jaeger.version
+++ b/jaeger.version
@@ -2,4 +2,4 @@
 # by default with the Jaeger Operator. This would usually be the latest 
 # stable Jaeger version. When you update this file, make sure to update the
 # the docs as well.
-1.12
+1.13


### PR DESCRIPTION
I apparently released the Operator 1.13 while we were still pointing the default underlying image to 1.12. This PR fixes that, making 1.13 the default version for the Operator 1.13.1.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>