### PR TITLE
Streamline tests by simplifying calls to CreatePortForward

### DIFF
--- a/test/e2e/all_in_one_test.go
+++ b/test/e2e/all_in_one_test.go
@@ -157,11 +157,7 @@ func (suite *AllInOneTestSuite)  TestAllInOneWithUIConfig()  {
 	err = e2eutil.WaitForDeployment(t, fw.KubeClient, namespace, "all-in-one-with-ui-config", 1, retryInterval, timeout)
 	require.NoError(t, err, "Error waiting for jaeger deployment")
 
-	queryPod, err := GetPod(namespace, "all-in-one-with-ui-config", "jaegertracing/all-in-one", fw.KubeClient)
-	require.NoError(t, err, "Failed to find pod starting with all-in-one-with-ui-config with image jaegertracing/all-in-one")
-
-	portForward, closeChan, err := CreatePortForward(namespace, queryPod.Name, []string{"16686"}, fw.KubeConfig)
-	require.NoError(t, err, "Failed to create PortForward")
+	portForward, closeChan := CreatePortForward(namespace, "all-in-one-with-ui-config", "jaegertracing/all-in-one", []string{"16686"}, fw.KubeConfig)
 	defer portForward.Close()
 	defer close(closeChan)
 

--- a/test/e2e/cassandra_test.go
+++ b/test/e2e/cassandra_test.go
@@ -65,13 +65,10 @@ func (suite *CassandraTestSuite) TestCassandra()  {
 	err = e2eutil.WaitForDeployment(t, fw.KubeClient, namespace, "with-cassandra", 1, retryInterval, timeout)
 	require.NoError(t, err, "Error waiting for deployment")
 
-	jaegerPod, err := GetPod(namespace, "with-cassandra", "jaegertracing/all-in-one", fw.KubeClient)
-	require.NoError(t, err, "Failed to find pod starting with with-cassandra with image jaegertracing/all-in-one")
-	portForw, closeChan, err := CreatePortForward(namespace, jaegerPod.Name, []string{"16686", "14268"}, fw.KubeConfig)
-	require.NoError(t, err, "Failed to create PortForward")
-
+	portForw, closeChan := CreatePortForward(namespace, "with-cassandra", "jaegertracing/all-in-one", []string{"16686", "14268"}, fw.KubeConfig)
 	defer portForw.Close()
 	defer close(closeChan)
+
 	err = SmokeTest("http://localhost:16686/api/traces", "http://localhost:14268/api/traces", "foobar", retryInterval, timeout)
 	require.NoError(t, err, "SmokeTest Failed")
 }

--- a/test/e2e/daemonset_test.go
+++ b/test/e2e/daemonset_test.go
@@ -95,11 +95,7 @@ func (suite *DaemonSetTestSuite) TestDaemonSet()  {
 	err = e2eutil.WaitForDeployment(t, fw.KubeClient, namespace, "vertx-create-span", 1, retryInterval, timeout)
 	require.NoError(t, err, "Error waiting for VertX app to start")
 
-	queryPod, err := GetPod(namespace, "agent-as-daemonset", "jaegertracing/all-in-one", fw.KubeClient)
-	require.NoErrorf(t, err, "Error trying to find pod with prefix agent-as-daemonset and image jaegertracing/all-in-one in namespace [%s]: %s\n", namespace)
-
-	portForw, closeChan, err := CreatePortForward(namespace, queryPod.Name, []string{"16686"}, fw.KubeConfig)
-	require.NoError(t, err, "Error creating portforward")
+	portForw, closeChan := CreatePortForward(namespace, "agent-as-daemonset", "jaegertracing/all-in-one", []string{"16686"}, fw.KubeConfig)
 	defer portForw.Close()
 	defer close(closeChan)
 

--- a/test/e2e/self_provisioned_elasticsearch_test.go
+++ b/test/e2e/self_provisioned_elasticsearch_test.go
@@ -79,22 +79,14 @@ func (suite *SelfProvisionedTestSuite) TestSelfProvisionedESSmokeTest() {
 	err = e2eutil.WaitForDeployment(t, fw.KubeClient, namespace, "simple-prod-query", 1, retryInterval, timeout)
 	require.NoError(t, err, "Error waiting for query deployment")
 
-	queryPod, err := GetPod(namespace, "simple-prod-query", "jaegertracing/jaeger-query", fw.KubeClient)
-	require.NoError(t, err, "Error getting QueryPod")
-
-	collectorPod, err := GetPod(namespace, "simple-prod-collector", "jaegertracing/jaeger-collector", fw.KubeClient)
-	require.NoError(t, err, "Error getting CollectorPod")
-
-	portForw, closeChan, err := CreatePortForward(namespace, queryPod.Name, []string{"16686"}, fw.KubeConfig)
-	require.NoError(t, err, "Error creating port forward")
-
+	portForw, closeChan := CreatePortForward(namespace, "simple-prod-query", "jaegertracing/jaeger-query", []string{"16686"}, fw.KubeConfig)
 	defer portForw.Close()
 	defer close(closeChan)
-	portForwColl, closeChanColl, err := CreatePortForward(namespace, collectorPod.Name, []string{"14268"}, fw.KubeConfig)
-	require.NoError(t, err, "Error creating port forward")
 
+	portForwColl, closeChanColl := CreatePortForward(namespace, "simple-prod-collector", "jaegertracing/jaeger-collector", []string{"14268"}, fw.KubeConfig)
 	defer portForwColl.Close()
 	defer close(closeChanColl)
+
 	err = SmokeTest("http://localhost:16686/api/traces", "http://localhost:14268/api/traces", "foobar", retryInterval, timeout)
 	require.NoError(t, err, "Error running smoketest")
 }

--- a/test/e2e/sidecar_test.go
+++ b/test/e2e/sidecar_test.go
@@ -74,11 +74,7 @@ func (suite *SidecarTestSuite) TestSidecar() {
 	err = e2eutil.WaitForDeployment(t, fw.KubeClient, namespace, "vertx-create-span-sidecar", 1, retryInterval, timeout)
 	require.NoError(t, err, "Failed waiting for vertx-create-span-sidecar deployment")
 
-	queryPod, err := GetPod(namespace, "agent-as-sidecar", "jaegertracing/all-in-one", fw.KubeClient)
-	require.NoError(t, err, "Failed to find pod starting with agent-as-sidecar with image jaegertracing/all-in-one")
-
-	portForward, closeChan, err := CreatePortForward(namespace, queryPod.Name, []string{"16686"}, fw.KubeConfig)
-	require.NoError(t, err, "Failed to create PortForward")
+	portForward, closeChan := CreatePortForward(namespace, "agent-as-sidecar", "jaegertracing/all-in-one", []string{"16686"}, fw.KubeConfig)
 	defer portForward.Close()
 	defer close(closeChan)
 


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com>

In every test where we call CreatePortForward, we are also calling get Pod first.  To simplify this and help shorten tests I've made the following changes:

- Have CreatePortForward call GetPod so the test doesn't have to do it
- If there is a problem in CreatePortForward or GetPod fail the test there rather than returning an error.
