### PR TITLE
Prepared the code base for openapi code generation

### DIFF
--- a/deploy/crds/jaegertracing_v1_jaeger_crd.yaml
+++ b/deploy/crds/jaegertracing_v1_jaeger_crd.yaml
@@ -11,3 +11,7 @@ spec:
     singular: jaeger
   scope: Namespaced
   version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/go-logr/zapr v0.1.0 // indirect
 	github.com/go-openapi/jsonpointer v0.17.2 // indirect
 	github.com/go-openapi/jsonreference v0.17.2 // indirect
-	github.com/go-openapi/spec v0.19.0 // indirect
+	github.com/go-openapi/spec v0.19.0
 	github.com/go-openapi/swag v0.17.2 // indirect
 	github.com/golang/groupcache v0.0.0-20181024230925-c65c006176ff // indirect
 	github.com/google/btree v1.0.0 // indirect

--- a/pkg/apis/jaegertracing/v1/freeform.go
+++ b/pkg/apis/jaegertracing/v1/freeform.go
@@ -4,12 +4,10 @@ import (
 	"encoding/json"
 )
 
-// FreeForm defines a common options parameter that maintains the hierarchical
-// structure of the data, unlike Options which flattens the hierarchy into a
-// key/value map where the hierarchy is converted to '.' separated items in the key.
+// FreeForm defines a common options parameter that maintains the hierarchical structure of the data, unlike Options which flattens the hierarchy into a key/value map where the hierarchy is converted to '.' separated items in the key.
 // +k8s:openapi-gen=true
 type FreeForm struct {
-	json []byte
+	json []byte `json:",inline"`
 }
 
 // NewFreeForm build a new FreeForm object based on the given map

--- a/pkg/apis/jaegertracing/v1/jaeger_types.go
+++ b/pkg/apis/jaegertracing/v1/jaeger_types.go
@@ -52,17 +52,38 @@ const (
 // JaegerSpec defines the desired state of Jaeger
 // +k8s:openapi-gen=true
 type JaegerSpec struct {
-	Strategy  string              `json:"strategy"`
-	AllInOne  JaegerAllInOneSpec  `json:"allInOne"`
-	Query     JaegerQuerySpec     `json:"query"`
-	Collector JaegerCollectorSpec `json:"collector"`
-	Ingester  JaegerIngesterSpec  `json:"ingester"`
-	Agent     JaegerAgentSpec     `json:"agent"`
-	UI        JaegerUISpec        `json:"ui"`
-	Sampling  JaegerSamplingSpec  `json:"sampling"`
-	Storage   JaegerStorageSpec   `json:"storage"`
-	Ingress   JaegerIngressSpec   `json:"ingress"`
-	JaegerCommonSpec
+	// +optional
+	Strategy string `json:"strategy,omitempty"`
+
+	// +optional
+	AllInOne JaegerAllInOneSpec `json:"allInOne,omitempty"`
+
+	// +optional
+	Query JaegerQuerySpec `json:"query,omitempty"`
+
+	// +optional
+	Collector JaegerCollectorSpec `json:"collector,omitempty"`
+
+	// +optional
+	Ingester JaegerIngesterSpec `json:"ingester,omitempty"`
+
+	// +optional
+	Agent JaegerAgentSpec `json:"agent,omitempty"`
+
+	// +optional
+	UI JaegerUISpec `json:"ui,omitempty"`
+
+	// +optional
+	Sampling JaegerSamplingSpec `json:"sampling,omitempty"`
+
+	// +optional
+	Storage JaegerStorageSpec `json:"storage,omitempty"`
+
+	// +optional
+	Ingress JaegerIngressSpec `json:"ingress,omitempty"`
+
+	// +optional
+	JaegerCommonSpec `json:",inline,omitempty"`
 }
 
 // JaegerStatus defines the observed state of Jaeger
@@ -76,181 +97,320 @@ type JaegerStatus struct {
 // Jaeger is the Schema for the jaegers API
 // +k8s:openapi-gen=true
 type Jaeger struct {
-	metav1.TypeMeta   `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
+
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   JaegerSpec   `json:"spec,omitempty"`
+	// +optional
+	Spec JaegerSpec `json:"spec,omitempty"`
+
+	// +optional
 	Status JaegerStatus `json:"status,omitempty"`
 }
 
 // JaegerCommonSpec defines the common elements used in multiple other spec structs
-// +k8s:openapi-gen=true
+// +k8s:openapi-gen=false
 type JaegerCommonSpec struct {
-	Volumes         []v1.Volume             `json:"volumes"`
-	VolumeMounts    []v1.VolumeMount        `json:"volumeMounts"`
-	Annotations     map[string]string       `json:"annotations,omitempty"`
-	Labels          map[string]string       `json:"labels,omitempty"`
-	Resources       v1.ResourceRequirements `json:"resources,omitempty"`
-	Affinity        *v1.Affinity            `json:"affinity,omitempty"`
-	Tolerations     []v1.Toleration         `json:"tolerations,omitempty"`
-	SecurityContext *v1.PodSecurityContext  `json:"securityContext,omitempty"`
-	ServiceAccount  string                  `json:"serviceAccount,omitempty"`
+	// +optional
+	Volumes []v1.Volume `json:"volumes,omitempty"`
+
+	// +optional
+	VolumeMounts []v1.VolumeMount `json:"volumeMounts,omitempty"`
+
+	// +optional
+	Annotations map[string]string `json:"annotations,omitempty"`
+
+	// +optional
+	Labels map[string]string `json:"labels,omitempty"`
+
+	// +optional
+	Resources v1.ResourceRequirements `json:"resources,omitempty"`
+
+	// +optional
+	Affinity *v1.Affinity `json:"affinity,omitempty"`
+
+	// +optional
+	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
+
+	// +optional
+	SecurityContext *v1.PodSecurityContext `json:"securityContext,omitempty"`
+
+	// +optional
+	ServiceAccount string `json:"serviceAccount,omitempty"`
 }
 
 // JaegerQuerySpec defines the options to be used when deploying the query
 // +k8s:openapi-gen=true
 type JaegerQuerySpec struct {
 	// Size represents the number of replicas to create for this service. DEPRECATED, use `Replicas` instead.
-	Size int `json:"size"`
+	// +optional
+	Size int `json:"size,omitempty"`
 
 	// Replicas represents the number of replicas to create for this service.
-	Replicas *int32 `json:"replicas"`
+	// +optional
+	Replicas *int32 `json:"replicas,omitempty"`
 
-	Image   string  `json:"image"`
-	Options Options `json:"options"`
-	JaegerCommonSpec
+	// +optional
+	Image string `json:"image,omitempty"`
+
+	// +optional
+	Options Options `json:"options,omitempty"`
+
+	// +optional
+	JaegerCommonSpec `json:",inline,omitempty"`
 }
 
 // JaegerUISpec defines the options to be used to configure the UI
 // +k8s:openapi-gen=true
 type JaegerUISpec struct {
-	Options FreeForm `json:"options"`
+	// +optional
+	Options FreeForm `json:"options,omitempty"`
 }
 
 // JaegerSamplingSpec defines the options to be used to configure the UI
 // +k8s:openapi-gen=true
 type JaegerSamplingSpec struct {
-	Options FreeForm `json:"options"`
+	// +optional
+	Options FreeForm `json:"options,omitempty"`
 }
 
 // JaegerIngressSpec defines the options to be used when deploying the query ingress
 // +k8s:openapi-gen=true
 type JaegerIngressSpec struct {
-	Enabled   *bool                      `json:"enabled"`
-	Security  IngressSecurityType        `json:"security"`
+	// +optional
+	Enabled *bool `json:"enabled,omitempty"`
+
+	// +optional
+	Security IngressSecurityType `json:"security,omitempty"`
+
+	// +optional
 	OpenShift JaegerIngressOpenShiftSpec `json:"openshift,omitempty"`
-	JaegerCommonSpec
+
+	// +optional
+	JaegerCommonSpec `json:",inline,omitempty"`
 }
 
 // JaegerIngressOpenShiftSpec defines the OpenShift-specific options in the context of ingress connections,
 // such as options for the OAuth Proxy
 // +k8s:openapi-gen=true
 type JaegerIngressOpenShiftSpec struct {
-	SAR          string `json:"sar,omitempty"`
+	// +optional
+	SAR string `json:"sar,omitempty"`
+
+	// +optional
 	DelegateURLs string `json:"delegate-urls,omitempty"`
 }
 
 // JaegerAllInOneSpec defines the options to be used when deploying the query
 // +k8s:openapi-gen=true
 type JaegerAllInOneSpec struct {
-	Image   string  `json:"image"`
-	Options Options `json:"options"`
-	JaegerCommonSpec
+	// +optional
+	Image string `json:"image,omitempty"`
+
+	// +optional
+	Options Options `json:"options,omitempty"`
+
+	// +optional
+	JaegerCommonSpec `json:",inline,omitempty"`
 }
 
 // JaegerCollectorSpec defines the options to be used when deploying the collector
 // +k8s:openapi-gen=true
 type JaegerCollectorSpec struct {
 	// Size represents the number of replicas to create for this service. DEPRECATED, use `Replicas` instead.
-	Size int `json:"size"`
+	// +optional
+	Size int `json:"size,omitempty"`
 
 	// Replicas represents the number of replicas to create for this service.
-	Replicas *int32 `json:"replicas"`
+	// +optional
+	Replicas *int32 `json:"replicas,omitempty"`
 
-	Image   string  `json:"image"`
-	Options Options `json:"options"`
-	JaegerCommonSpec
+	// +optional
+	Image string `json:"image,omitempty"`
+
+	// +optional
+	Options Options `json:"options,omitempty"`
+
+	// +optional
+	JaegerCommonSpec `json:",inline,omitempty"`
 }
 
 // JaegerIngesterSpec defines the options to be used when deploying the ingester
 // +k8s:openapi-gen=true
 type JaegerIngesterSpec struct {
 	// Size represents the number of replicas to create for this service. DEPRECATED, use `Replicas` instead.
-	Size int `json:"size"`
+	// +optional
+	Size int `json:"size,omitempty"`
 
 	// Replicas represents the number of replicas to create for this service.
-	Replicas *int32 `json:"replicas"`
+	// +optional
+	Replicas *int32 `json:"replicas,omitempty"`
 
-	Image   string  `json:"image"`
-	Options Options `json:"options"`
-	JaegerCommonSpec
+	// +optional
+	Image string `json:"image,omitempty"`
+
+	// +optional
+	Options Options `json:"options,omitempty"`
+
+	// +optional
+	JaegerCommonSpec `json:",inline,omitempty"`
 }
 
 // JaegerAgentSpec defines the options to be used when deploying the agent
 // +k8s:openapi-gen=true
 type JaegerAgentSpec struct {
-	Strategy string  `json:"strategy"` // can be either 'DaemonSet' or 'Sidecar' (default)
-	Image    string  `json:"image"`
-	Options  Options `json:"options"`
-	JaegerCommonSpec
+	// Strategy can be either 'DaemonSet' or 'Sidecar' (default)
+	// +optional
+	Strategy string `json:"strategy,omitempty"`
+
+	// +optional
+	Image string `json:"image,omitempty"`
+
+	// +optional
+	Options Options `json:"options,omitempty"`
+
+	// +optional
+	JaegerCommonSpec `json:",inline,omitempty"`
 }
 
 // JaegerStorageSpec defines the common storage options to be used for the query and collector
 // +k8s:openapi-gen=true
 type JaegerStorageSpec struct {
-	Type                  string                          `json:"type"` // can be `memory` (default), `cassandra`, `elasticsearch`, `kafka` or `managed`
-	SecretName            string                          `json:"secretName"`
-	Options               Options                         `json:"options"`
-	CassandraCreateSchema JaegerCassandraCreateSchemaSpec `json:"cassandraCreateSchema"`
-	SparkDependencies     JaegerDependenciesSpec          `json:"dependencies"`
-	EsIndexCleaner        JaegerEsIndexCleanerSpec        `json:"esIndexCleaner"`
-	Rollover              JaegerEsRolloverSpec            `json:"esRollover"`
-	Elasticsearch         ElasticsearchSpec               `json:"elasticsearch"`
+	// Type can be `memory` (default), `cassandra`, `elasticsearch`, `kafka` or `managed`
+	// +optional
+	Type string `json:"type,omitempty"`
+
+	// +optional
+	SecretName string `json:"secretName,omitempty"`
+
+	// +optional
+	Options Options `json:"options,omitempty"`
+
+	// +optional
+	CassandraCreateSchema JaegerCassandraCreateSchemaSpec `json:"cassandraCreateSchema,omitempty"`
+
+	// +optional
+	Dependencies JaegerDependenciesSpec `json:"dependencies,omitempty"`
+
+	// +optional
+	EsIndexCleaner JaegerEsIndexCleanerSpec `json:"esIndexCleaner,omitempty"`
+
+	// +optional
+	EsRollover JaegerEsRolloverSpec `json:"esRollover,omitempty"`
+
+	// +optional
+	Elasticsearch ElasticsearchSpec `json:"elasticsearch,omitempty"`
 }
 
 // ElasticsearchSpec represents the ES configuration options that we pass down to the Elasticsearch operator
 // +k8s:openapi-gen=true
 type ElasticsearchSpec struct {
-	Image            string                        `json:"image"`
-	Resources        v1.ResourceRequirements       `json:"resources"`
-	NodeCount        int32                         `json:"nodeCount"`
-	NodeSelector     map[string]string             `json:"nodeSelector,omitempty"`
-	Storage          esv1.ElasticsearchStorageSpec `json:"storage"`
-	RedundancyPolicy esv1.RedundancyPolicyType     `json:"redundancyPolicy"`
+	// +optional
+	Image string `json:"image,omitempty"`
+
+	// +optional
+	Resources v1.ResourceRequirements `json:"resources,omitempty"`
+
+	// +optional
+	NodeCount int32 `json:"nodeCount,omitempty"`
+
+	// +optional
+	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+
+	// +optional
+	Storage esv1.ElasticsearchStorageSpec `json:"storage,omitempty"`
+
+	// +optional
+	RedundancyPolicy esv1.RedundancyPolicyType `json:"redundancyPolicy,omitempty"`
 }
 
 // JaegerCassandraCreateSchemaSpec holds the options related to the create-schema batch job
 // +k8s:openapi-gen=true
 type JaegerCassandraCreateSchemaSpec struct {
-	Enabled                 *bool  `json:"enabled"`
-	Image                   string `json:"image"`
-	Datacenter              string `json:"datacenter"`
-	Mode                    string `json:"mode"`
+	// +optional
+	Enabled *bool `json:"enabled,omitempty"`
+
+	// +optional
+	Image string `json:"image,omitempty"`
+
+	// +optional
+	Datacenter string `json:"datacenter,omitempty"`
+
+	// +optional
+	Mode string `json:"mode,omitempty"`
+
+	// +optional
 	TTLSecondsAfterFinished *int32 `json:"ttlSecondsAfterFinished,omitempty"`
 }
 
 // JaegerDependenciesSpec defined options for running spark-dependencies.
 // +k8s:openapi-gen=true
 type JaegerDependenciesSpec struct {
-	Enabled                     *bool  `json:"enabled"`
-	SparkMaster                 string `json:"sparkMaster"`
-	Schedule                    string `json:"schedule"`
-	Image                       string `json:"image"`
-	JavaOpts                    string `json:"javaOpts"`
-	CassandraClientAuthEnabled  bool   `json:"cassandraClientAuthEnabled"`
-	ElasticsearchClientNodeOnly bool   `json:"elasticsearchClientNodeOnly"`
-	ElasticsearchNodesWanOnly   bool   `json:"elasticsearchNodesWanOnly"`
-	TTLSecondsAfterFinished     *int32 `json:"ttlSecondsAfterFinished,omitempty"`
+	// +optional
+	Enabled *bool `json:"enabled,omitempty"`
+
+	// +optional
+	SparkMaster string `json:"sparkMaster,omitempty"`
+
+	// +optional
+	Schedule string `json:"schedule,omitempty"`
+
+	// +optional
+	Image string `json:"image,omitempty"`
+
+	// +optional
+	JavaOpts string `json:"javaOpts,omitempty"`
+
+	// +optional
+	CassandraClientAuthEnabled bool `json:"cassandraClientAuthEnabled,omitempty"`
+
+	// +optional
+	ElasticsearchClientNodeOnly bool `json:"elasticsearchClientNodeOnly,omitempty"`
+
+	// +optional
+	ElasticsearchNodesWanOnly bool `json:"elasticsearchNodesWanOnly,omitempty"`
+
+	// +optional
+	TTLSecondsAfterFinished *int32 `json:"ttlSecondsAfterFinished,omitempty"`
 }
 
 // JaegerEsIndexCleanerSpec holds the options related to es-index-cleaner
 // +k8s:openapi-gen=true
 type JaegerEsIndexCleanerSpec struct {
-	Enabled                 *bool  `json:"enabled"`
-	NumberOfDays            *int   `json:"numberOfDays"`
-	Schedule                string `json:"schedule"`
-	Image                   string `json:"image"`
+	// +optional
+	Enabled *bool `json:"enabled,omitempty"`
+
+	// +optional
+	NumberOfDays *int `json:"numberOfDays,omitempty"`
+
+	// +optional
+	Schedule string `json:"schedule,omitempty"`
+
+	// +optional
+	Image string `json:"image,omitempty"`
+
+	// +optional
 	TTLSecondsAfterFinished *int32 `json:"ttlSecondsAfterFinished,omitempty"`
 }
 
 // JaegerEsRolloverSpec holds the options related to es-rollover
 type JaegerEsRolloverSpec struct {
-	Image                   string `json:"image"`
-	Schedule                string `json:"schedule"`
-	Conditions              string `json:"conditions"`
+	// +optional
+	Image string `json:"image,omitempty"`
+
+	// +optional
+	Schedule string `json:"schedule,omitempty"`
+
+	// +optional
+	Conditions string `json:"conditions,omitempty"`
+
+	// +optional
 	TTLSecondsAfterFinished *int32 `json:"ttlSecondsAfterFinished,omitempty"`
+
 	// we parse it with time.ParseDuration
-	ReadTTL string `json:"readTTL"`
+	// +optional
+	ReadTTL string `json:"readTTL,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/jaegertracing/v1/jaeger_types.go
+++ b/pkg/apis/jaegertracing/v1/jaeger_types.go
@@ -110,7 +110,7 @@ type Jaeger struct {
 }
 
 // JaegerCommonSpec defines the common elements used in multiple other spec structs
-// +k8s:openapi-gen=false
+// +k8s:openapi-gen=true
 type JaegerCommonSpec struct {
 	// +optional
 	Volumes []v1.Volume `json:"volumes,omitempty"`

--- a/pkg/apis/jaegertracing/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/jaegertracing/v1/zz_generated.deepcopy.go
@@ -490,9 +490,9 @@ func (in *JaegerStorageSpec) DeepCopyInto(out *JaegerStorageSpec) {
 	*out = *in
 	in.Options.DeepCopyInto(&out.Options)
 	in.CassandraCreateSchema.DeepCopyInto(&out.CassandraCreateSchema)
-	in.SparkDependencies.DeepCopyInto(&out.SparkDependencies)
+	in.Dependencies.DeepCopyInto(&out.Dependencies)
 	in.EsIndexCleaner.DeepCopyInto(&out.EsIndexCleaner)
-	in.Rollover.DeepCopyInto(&out.Rollover)
+	in.EsRollover.DeepCopyInto(&out.EsRollover)
 	in.Elasticsearch.DeepCopyInto(&out.Elasticsearch)
 	return
 }

--- a/pkg/controller/jaeger/jaeger_controller.go
+++ b/pkg/controller/jaeger/jaeger_controller.go
@@ -147,8 +147,8 @@ func (r *ReconcileJaeger) Reconcile(request reconcile.Request) (reconcile.Result
 
 // validate validates CR before processing it
 func validate(jaeger *v1.Jaeger) error {
-	if jaeger.Spec.Storage.Rollover.ReadTTL != "" {
-		if _, err := time.ParseDuration(jaeger.Spec.Storage.Rollover.ReadTTL); err != nil {
+	if jaeger.Spec.Storage.EsRollover.ReadTTL != "" {
+		if _, err := time.ParseDuration(jaeger.Spec.Storage.EsRollover.ReadTTL); err != nil {
 			return errors.Wrap(err, "failed to parse esRollover.readTTL to time.Duration")
 		}
 	}

--- a/pkg/cronjob/es_rollover.go
+++ b/pkg/cronjob/es_rollover.go
@@ -31,8 +31,8 @@ func CreateRollover(jaeger *v1.Jaeger) []batchv1beta1.CronJob {
 func rollover(jaeger *v1.Jaeger) batchv1beta1.CronJob {
 	name := fmt.Sprintf("%s-es-rollover", jaeger.Name)
 	envs := esScriptEnvVars(jaeger.Spec.Storage.Options)
-	if jaeger.Spec.Storage.Rollover.Conditions != "" {
-		envs = append(envs, corev1.EnvVar{Name: "CONDITIONS", Value: jaeger.Spec.Storage.Rollover.Conditions})
+	if jaeger.Spec.Storage.EsRollover.Conditions != "" {
+		envs = append(envs, corev1.EnvVar{Name: "CONDITIONS", Value: jaeger.Spec.Storage.EsRollover.Conditions})
 	}
 	one := int32(1)
 	return batchv1beta1.CronJob{
@@ -44,7 +44,7 @@ func rollover(jaeger *v1.Jaeger) batchv1beta1.CronJob {
 		},
 		Spec: batchv1beta1.CronJobSpec{
 			ConcurrencyPolicy: batchv1beta1.ForbidConcurrent,
-			Schedule:          jaeger.Spec.Storage.Rollover.Schedule,
+			Schedule:          jaeger.Spec.Storage.EsRollover.Schedule,
 			JobTemplate: batchv1beta1.JobTemplateSpec{
 				Spec: batchv1.JobSpec{
 					Parallelism: &one,
@@ -61,7 +61,7 @@ func rollover(jaeger *v1.Jaeger) batchv1beta1.CronJob {
 							Containers: []corev1.Container{
 								{
 									Name:  name,
-									Image: jaeger.Spec.Storage.Rollover.Image,
+									Image: jaeger.Spec.Storage.EsRollover.Image,
 									Args:  []string{"rollover", util.GetEsHostname(jaeger.Spec.Storage.Options.Map())},
 									Env:   envs,
 								},
@@ -77,8 +77,8 @@ func rollover(jaeger *v1.Jaeger) batchv1beta1.CronJob {
 func lookback(jaeger *v1.Jaeger) batchv1beta1.CronJob {
 	name := fmt.Sprintf("%s-es-lookback", jaeger.Name)
 	envs := esScriptEnvVars(jaeger.Spec.Storage.Options)
-	if jaeger.Spec.Storage.Rollover.ReadTTL != "" {
-		dur, err := time.ParseDuration(jaeger.Spec.Storage.Rollover.ReadTTL)
+	if jaeger.Spec.Storage.EsRollover.ReadTTL != "" {
+		dur, err := time.ParseDuration(jaeger.Spec.Storage.EsRollover.ReadTTL)
 		if err == nil {
 			d := parseToUnits(dur)
 			envs = append(envs, corev1.EnvVar{Name: "UNIT", Value: string(d.units)})
@@ -86,7 +86,7 @@ func lookback(jaeger *v1.Jaeger) batchv1beta1.CronJob {
 		} else {
 			jaeger.Logger().
 				WithError(err).
-				WithField("readTTL", jaeger.Spec.Storage.Rollover.ReadTTL).
+				WithField("readTTL", jaeger.Spec.Storage.EsRollover.ReadTTL).
 				Error("Failed to parse esRollover.readTTL to time.duration")
 		}
 	}
@@ -99,10 +99,10 @@ func lookback(jaeger *v1.Jaeger) batchv1beta1.CronJob {
 		},
 		Spec: batchv1beta1.CronJobSpec{
 			ConcurrencyPolicy: batchv1beta1.ForbidConcurrent,
-			Schedule:          jaeger.Spec.Storage.Rollover.Schedule,
+			Schedule:          jaeger.Spec.Storage.EsRollover.Schedule,
 			JobTemplate: batchv1beta1.JobTemplateSpec{
 				Spec: batchv1.JobSpec{
-					TTLSecondsAfterFinished: jaeger.Spec.Storage.Rollover.TTLSecondsAfterFinished,
+					TTLSecondsAfterFinished: jaeger.Spec.Storage.EsRollover.TTLSecondsAfterFinished,
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Annotations: map[string]string{
@@ -116,7 +116,7 @@ func lookback(jaeger *v1.Jaeger) batchv1beta1.CronJob {
 							Containers: []corev1.Container{
 								{
 									Name:  name,
-									Image: jaeger.Spec.Storage.Rollover.Image,
+									Image: jaeger.Spec.Storage.EsRollover.Image,
 									Args:  []string{"lookback", util.GetEsHostname(jaeger.Spec.Storage.Options.Map())},
 									Env:   envs,
 								},

--- a/pkg/cronjob/es_rollover_test.go
+++ b/pkg/cronjob/es_rollover_test.go
@@ -21,8 +21,8 @@ func TestCreateRollover(t *testing.T) {
 func TestRollover(t *testing.T) {
 	j := v1.NewJaeger(types.NamespacedName{Name: "eevee"})
 	j.Namespace = "kitchen"
-	j.Spec.Storage.Rollover.Image = "wohooo"
-	j.Spec.Storage.Rollover.Conditions = "weheee"
+	j.Spec.Storage.EsRollover.Image = "wohooo"
+	j.Spec.Storage.EsRollover.Conditions = "weheee"
 	j.Spec.Storage.Options = v1.NewOptions(map[string]interface{}{"es.server-urls": "foo,bar", "es.index-prefix": "shortone"})
 
 	cjob := rollover(j)
@@ -30,7 +30,7 @@ func TestRollover(t *testing.T) {
 	assert.Equal(t, []metav1.OwnerReference{util.AsOwner(j)}, cjob.OwnerReferences)
 	assert.Equal(t, util.Labels("eevee-es-rollover", "cronjob-es-rollover", *j), cjob.Labels)
 	assert.Equal(t, 1, len(cjob.Spec.JobTemplate.Spec.Template.Spec.Containers))
-	assert.Equal(t, j.Spec.Storage.Rollover.Image, cjob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Image)
+	assert.Equal(t, j.Spec.Storage.EsRollover.Image, cjob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Image)
 	assert.Equal(t, []string{"rollover", "foo"}, cjob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Args)
 	assert.Equal(t, []corev1.EnvVar{{Name: "INDEX_PREFIX", Value: "shortone"}, {Name: "CONDITIONS", Value: "weheee"}}, cjob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Env)
 }
@@ -38,8 +38,8 @@ func TestRollover(t *testing.T) {
 func TestLookback(t *testing.T) {
 	j := v1.NewJaeger(types.NamespacedName{Name: "squirtle"})
 	j.Namespace = "kitchen"
-	j.Spec.Storage.Rollover.Image = "wohooo"
-	j.Spec.Storage.Rollover.ReadTTL = "2h"
+	j.Spec.Storage.EsRollover.Image = "wohooo"
+	j.Spec.Storage.EsRollover.ReadTTL = "2h"
 	j.Spec.Storage.Options = v1.NewOptions(map[string]interface{}{"es.server-urls": "foo,bar", "es.index-prefix": "shortone"})
 
 	cjob := lookback(j)
@@ -47,7 +47,7 @@ func TestLookback(t *testing.T) {
 	assert.Equal(t, []metav1.OwnerReference{util.AsOwner(j)}, cjob.OwnerReferences)
 	assert.Equal(t, util.Labels("squirtle-es-lookback", "cronjob-es-lookback", *j), cjob.Labels)
 	assert.Equal(t, 1, len(cjob.Spec.JobTemplate.Spec.Template.Spec.Containers))
-	assert.Equal(t, j.Spec.Storage.Rollover.Image, cjob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Image)
+	assert.Equal(t, j.Spec.Storage.EsRollover.Image, cjob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Image)
 	assert.Equal(t, []string{"lookback", "foo"}, cjob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Args)
 	assert.Equal(t, []corev1.EnvVar{{Name: "INDEX_PREFIX", Value: "shortone"}, {Name: "UNIT", Value: "hours"}, {Name: "UNIT_COUNT", Value: "2"}}, cjob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Env)
 }

--- a/pkg/cronjob/spark_dependencies.go
+++ b/pkg/cronjob/spark_dependencies.go
@@ -25,8 +25,8 @@ func SupportedStorage(storage string) bool {
 func CreateSparkDependencies(jaeger *v1.Jaeger) *batchv1beta1.CronJob {
 	envVars := []corev1.EnvVar{
 		{Name: "STORAGE", Value: jaeger.Spec.Storage.Type},
-		{Name: "SPARK_MASTER", Value: jaeger.Spec.Storage.SparkDependencies.SparkMaster},
-		{Name: "JAVA_OPTS", Value: jaeger.Spec.Storage.SparkDependencies.JavaOpts},
+		{Name: "SPARK_MASTER", Value: jaeger.Spec.Storage.Dependencies.SparkMaster},
+		{Name: "JAVA_OPTS", Value: jaeger.Spec.Storage.Dependencies.JavaOpts},
 	}
 	envVars = append(envVars, getStorageEnvs(jaeger.Spec.Storage)...)
 
@@ -57,7 +57,7 @@ func CreateSparkDependencies(jaeger *v1.Jaeger) *batchv1beta1.CronJob {
 		},
 		Spec: batchv1beta1.CronJobSpec{
 			ConcurrencyPolicy: batchv1beta1.ForbidConcurrent,
-			Schedule:          jaeger.Spec.Storage.SparkDependencies.Schedule,
+			Schedule:          jaeger.Spec.Storage.Dependencies.Schedule,
 			JobTemplate: batchv1beta1.JobTemplateSpec{
 				Spec: batchv1.JobSpec{
 					Parallelism: &one,
@@ -65,7 +65,7 @@ func CreateSparkDependencies(jaeger *v1.Jaeger) *batchv1beta1.CronJob {
 						Spec: corev1.PodSpec{
 							Containers: []corev1.Container{
 								{
-									Image: jaeger.Spec.Storage.SparkDependencies.Image,
+									Image: jaeger.Spec.Storage.Dependencies.Image,
 									Name:  name,
 									// let spark job use its default values
 									Env: removeEmptyVars(envVars),
@@ -103,7 +103,7 @@ func getStorageEnvs(s v1.JaegerStorageSpec) []corev1.EnvVar {
 			{Name: "CASSANDRA_PASSWORD", Value: sFlagsMap["cassandra.password"]},
 			{Name: "CASSANDRA_USE_SSL", Value: sFlagsMap["cassandra.tls"]},
 			{Name: "CASSANDRA_LOCAL_DC", Value: sFlagsMap["cassandra.local-dc"]},
-			{Name: "CASSANDRA_CLIENT_AUTH_ENABLED", Value: strconv.FormatBool(s.SparkDependencies.CassandraClientAuthEnabled)},
+			{Name: "CASSANDRA_CLIENT_AUTH_ENABLED", Value: strconv.FormatBool(s.Dependencies.CassandraClientAuthEnabled)},
 		}
 	case "elasticsearch":
 		return []corev1.EnvVar{
@@ -111,8 +111,8 @@ func getStorageEnvs(s v1.JaegerStorageSpec) []corev1.EnvVar {
 			{Name: "ES_INDEX_PREFIX", Value: sFlagsMap["es.index-prefix"]},
 			{Name: "ES_USERNAME", Value: sFlagsMap["es.username"]},
 			{Name: "ES_PASSWORD", Value: sFlagsMap["es.password"]},
-			{Name: "ES_CLIENT_NODE_ONLY", Value: strconv.FormatBool(s.SparkDependencies.ElasticsearchClientNodeOnly)},
-			{Name: "ES_NODES_WAN_ONLY", Value: strconv.FormatBool(s.SparkDependencies.ElasticsearchNodesWanOnly)},
+			{Name: "ES_CLIENT_NODE_ONLY", Value: strconv.FormatBool(s.Dependencies.ElasticsearchClientNodeOnly)},
+			{Name: "ES_NODES_WAN_ONLY", Value: strconv.FormatBool(s.Dependencies.ElasticsearchNodesWanOnly)},
 		}
 	default:
 		return nil

--- a/pkg/storage/elasticsearch_dependencies.go
+++ b/pkg/storage/elasticsearch_dependencies.go
@@ -8,7 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/util"
 )
 
@@ -41,7 +41,7 @@ func elasticsearchDependencies(jaeger *v1.Jaeger) []batchv1.Job {
 					Containers: []corev1.Container{
 						{
 							Name:  name,
-							Image: jaeger.Spec.Storage.Rollover.Image,
+							Image: jaeger.Spec.Storage.EsRollover.Image,
 							Args:  []string{"init", util.GetEsHostname(jaeger.Spec.Storage.Options.Map())},
 							Env:   envVars(jaeger.Spec.Storage.Options),
 						},

--- a/pkg/storage/elasticsearch_dependencies_test.go
+++ b/pkg/storage/elasticsearch_dependencies_test.go
@@ -51,7 +51,7 @@ func TestEnableRollover(t *testing.T) {
 func TestElasticsearchDependencies(t *testing.T) {
 	j := v1.NewJaeger(types.NamespacedName{Name: "eevee"})
 	j.Namespace = "kitchen"
-	j.Spec.Storage.Rollover.Image = "wohooo"
+	j.Spec.Storage.EsRollover.Image = "wohooo"
 	j.Spec.Storage.Options = v1.NewOptions(map[string]interface{}{"es.server-urls": "foo,bar", "es.index-prefix": "shortone"})
 
 	deps := elasticsearchDependencies(j)
@@ -62,7 +62,7 @@ func TestElasticsearchDependencies(t *testing.T) {
 	assert.Equal(t, []metav1.OwnerReference{util.AsOwner(j)}, job.OwnerReferences)
 	assert.Equal(t, util.Labels("eevee-es-rollover-create-mapping", "job-es-rollover-create-mapping", *j), job.Labels)
 	assert.Equal(t, 1, len(job.Spec.Template.Spec.Containers))
-	assert.Equal(t, j.Spec.Storage.Rollover.Image, job.Spec.Template.Spec.Containers[0].Image)
+	assert.Equal(t, j.Spec.Storage.EsRollover.Image, job.Spec.Template.Spec.Containers[0].Image)
 	assert.Equal(t, []string{"init", "foo"}, job.Spec.Template.Spec.Containers[0].Args)
 	assert.Equal(t, []corev1.EnvVar{{Name: "INDEX_PREFIX", Value: "shortone"}}, job.Spec.Template.Spec.Containers[0].Env)
 }

--- a/pkg/strategy/all-in-one.go
+++ b/pkg/strategy/all-in-one.go
@@ -67,7 +67,7 @@ func newAllInOneStrategy(jaeger *v1.Jaeger) S {
 		}
 	}
 
-	if isBoolTrue(jaeger.Spec.Storage.SparkDependencies.Enabled) {
+	if isBoolTrue(jaeger.Spec.Storage.Dependencies.Enabled) {
 		if cronjob.SupportedStorage(jaeger.Spec.Storage.Type) {
 			c.cronJobs = append(c.cronJobs, *cronjob.CreateSparkDependencies(jaeger))
 		} else {

--- a/pkg/strategy/all-in-one_test.go
+++ b/pkg/strategy/all-in-one_test.go
@@ -135,15 +135,15 @@ func testSparkDependencies(t *testing.T, fce func(jaeger *v1.Jaeger) S) {
 	}{
 		{jaeger: &v1.Jaeger{Spec: v1.JaegerSpec{
 			Storage: v1.JaegerStorageSpec{Type: "elasticsearch",
-				SparkDependencies: v1.JaegerDependenciesSpec{Enabled: &trueVar}},
+				Dependencies: v1.JaegerDependenciesSpec{Enabled: &trueVar}},
 		}}, sparkCronJobEnabled: true},
 		{jaeger: &v1.Jaeger{Spec: v1.JaegerSpec{
 			Storage: v1.JaegerStorageSpec{Type: "cassandra",
-				SparkDependencies: v1.JaegerDependenciesSpec{Enabled: &trueVar}},
+				Dependencies: v1.JaegerDependenciesSpec{Enabled: &trueVar}},
 		}}, sparkCronJobEnabled: true},
 		{jaeger: &v1.Jaeger{Spec: v1.JaegerSpec{
 			Storage: v1.JaegerStorageSpec{Type: "kafka",
-				SparkDependencies: v1.JaegerDependenciesSpec{Enabled: &trueVar}},
+				Dependencies: v1.JaegerDependenciesSpec{Enabled: &trueVar}},
 		}}, sparkCronJobEnabled: false},
 		{jaeger: &v1.Jaeger{Spec: v1.JaegerSpec{
 			Storage: v1.JaegerStorageSpec{Type: "elasticsearch"},

--- a/pkg/strategy/controller.go
+++ b/pkg/strategy/controller.go
@@ -90,23 +90,23 @@ func normalize(jaeger *v1.Jaeger) {
 	normalizeSparkDependencies(&jaeger.Spec.Storage)
 	normalizeIndexCleaner(&jaeger.Spec.Storage.EsIndexCleaner, jaeger.Spec.Storage.Type)
 	normalizeElasticsearch(&jaeger.Spec.Storage.Elasticsearch)
-	normalizeRollover(&jaeger.Spec.Storage.Rollover)
+	normalizeRollover(&jaeger.Spec.Storage.EsRollover)
 	normalizeUI(&jaeger.Spec)
 }
 
 func normalizeSparkDependencies(spec *v1.JaegerStorageSpec) {
 	// auto enable only for supported storages
 	if cronjob.SupportedStorage(spec.Type) &&
-		spec.SparkDependencies.Enabled == nil &&
+		spec.Dependencies.Enabled == nil &&
 		!storage.ShouldDeployElasticsearch(*spec) {
 		trueVar := true
-		spec.SparkDependencies.Enabled = &trueVar
+		spec.Dependencies.Enabled = &trueVar
 	}
-	if spec.SparkDependencies.Image == "" {
-		spec.SparkDependencies.Image = viper.GetString("jaeger-spark-dependencies-image")
+	if spec.Dependencies.Image == "" {
+		spec.Dependencies.Image = viper.GetString("jaeger-spark-dependencies-image")
 	}
-	if spec.SparkDependencies.Schedule == "" {
-		spec.SparkDependencies.Schedule = "55 23 * * *"
+	if spec.Dependencies.Schedule == "" {
+		spec.Dependencies.Schedule = "55 23 * * *"
 	}
 }
 
@@ -154,7 +154,7 @@ func normalizeUI(spec *v1.JaegerSpec) {
 		}
 	}
 	enableArchiveButton(uiOpts, spec.Storage.Options.Map())
-	disableDependenciesTab(uiOpts, spec.Storage.Type, spec.Storage.SparkDependencies.Enabled)
+	disableDependenciesTab(uiOpts, spec.Storage.Type, spec.Storage.Dependencies.Enabled)
 	enableLogOut(uiOpts, spec)
 	if len(uiOpts) > 0 {
 		spec.UI.Options = v1.NewFreeForm(uiOpts)

--- a/pkg/strategy/controller_test.go
+++ b/pkg/strategy/controller_test.go
@@ -217,15 +217,15 @@ func TestNormalizeSparkDependencies(t *testing.T) {
 		{
 			underTest: v1.JaegerStorageSpec{Type: "elasticsearch", Options: v1.NewOptions(map[string]interface{}{"es.server-urls": "foo"})},
 			expected: v1.JaegerStorageSpec{Type: "elasticsearch", Options: v1.NewOptions(map[string]interface{}{"es.server-urls": "foo"}),
-				SparkDependencies: v1.JaegerDependenciesSpec{Schedule: "55 23 * * *", Image: "foo", Enabled: &trueVar}},
+				Dependencies: v1.JaegerDependenciesSpec{Schedule: "55 23 * * *", Image: "foo", Enabled: &trueVar}},
 		},
 		{
 			underTest: v1.JaegerStorageSpec{Type: "elasticsearch"},
-			expected:  v1.JaegerStorageSpec{Type: "elasticsearch", SparkDependencies: v1.JaegerDependenciesSpec{Schedule: "55 23 * * *", Image: "foo"}},
+			expected:  v1.JaegerStorageSpec{Type: "elasticsearch", Dependencies: v1.JaegerDependenciesSpec{Schedule: "55 23 * * *", Image: "foo"}},
 		},
 		{
-			underTest: v1.JaegerStorageSpec{Type: "elasticsearch", SparkDependencies: v1.JaegerDependenciesSpec{Schedule: "foo", Image: "bla", Enabled: &falseVar}},
-			expected:  v1.JaegerStorageSpec{Type: "elasticsearch", SparkDependencies: v1.JaegerDependenciesSpec{Schedule: "foo", Image: "bla", Enabled: &falseVar}},
+			underTest: v1.JaegerStorageSpec{Type: "elasticsearch", Dependencies: v1.JaegerDependenciesSpec{Schedule: "foo", Image: "bla", Enabled: &falseVar}},
+			expected:  v1.JaegerStorageSpec{Type: "elasticsearch", Dependencies: v1.JaegerDependenciesSpec{Schedule: "foo", Image: "bla", Enabled: &falseVar}},
 		},
 	}
 	for _, test := range tests {

--- a/pkg/strategy/production.go
+++ b/pkg/strategy/production.go
@@ -69,7 +69,7 @@ func newProductionStrategy(jaeger *v1.Jaeger, es *storage.ElasticsearchDeploymen
 		}
 	}
 
-	if isBoolTrue(jaeger.Spec.Storage.SparkDependencies.Enabled) {
+	if isBoolTrue(jaeger.Spec.Storage.Dependencies.Enabled) {
 		if cronjob.SupportedStorage(jaeger.Spec.Storage.Type) {
 			c.cronJobs = append(c.cronJobs, *cronjob.CreateSparkDependencies(jaeger))
 		} else {

--- a/pkg/strategy/streaming.go
+++ b/pkg/strategy/streaming.go
@@ -76,7 +76,7 @@ func newStreamingStrategy(jaeger *v1.Jaeger) S {
 		}
 	}
 
-	if isBoolTrue(jaeger.Spec.Storage.SparkDependencies.Enabled) {
+	if isBoolTrue(jaeger.Spec.Storage.Dependencies.Enabled) {
 		if cronjob.SupportedStorage(jaeger.Spec.Storage.Type) {
 			c.cronJobs = append(c.cronJobs, *cronjob.CreateSparkDependencies(jaeger))
 		} else {

--- a/test/e2e/spark_dependencies_test.go
+++ b/test/e2e/spark_dependencies_test.go
@@ -5,16 +5,16 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/pkg/errors"
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
+	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 )
 
 func sparkTest(t *testing.T, f *framework.Framework, testCtx *framework.TestCtx, storage v1.JaegerStorageSpec) error {
-	storage.SparkDependencies = v1.JaegerDependenciesSpec{
+	storage.Dependencies = v1.JaegerDependenciesSpec{
 		// run immediately
 		Schedule: "*/1 * * * *",
 	}
@@ -52,7 +52,7 @@ func sparkTest(t *testing.T, f *framework.Framework, testCtx *framework.TestCtx,
 		return errors.WithMessage(err, "Failed waiting for Job Of An Owner")
 	}
 
-	err =  e2eutil.WaitForDeployment(t, f.KubeClient, namespace, name, 1, retryInterval, timeout)
+	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, name, 1, retryInterval, timeout)
 	if err != nil {
 		return errors.WithMessage(err, "Failed waiting for deployment ")
 	} else {


### PR DESCRIPTION
* Added `omitempty` to most properties, as well as the `+optional` tag.
* Renamed a couple of properties, to match their json names. This mismatch is marked as a violation by the openapi code generation (!!).

The code that is generated via `openapi` is not added as part of this PR, because of problems we found during the development of this PR. Once we can get the `openapi` command to generate an acceptable outcome for us, we can run it a first time and add a check to the CI, similar to what we do with `operator-sdk generate k8s`.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>