### PR TITLE
Allowed usage of custom SA for OAuth Proxy

### DIFF
--- a/deploy/examples/custom-serviceaccount.yaml
+++ b/deploy/examples/custom-serviceaccount.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: customsa
+---
+apiVersion: jaegertracing.io/v1
+kind: Jaeger
+metadata:
+  name: custom-serviceaccount
+spec:
+  serviceAccount: customsa # this is created and managed externally to the operator

--- a/pkg/account/main.go
+++ b/pkg/account/main.go
@@ -4,7 +4,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/util"
 )
 
@@ -12,7 +12,12 @@ import (
 func Get(jaeger *v1.Jaeger) []*corev1.ServiceAccount {
 	accounts := []*corev1.ServiceAccount{}
 	if jaeger.Spec.Ingress.Security == v1.IngressSecurityOAuthProxy {
-		accounts = append(accounts, OAuthProxy(jaeger))
+		sa := util.Merge([]v1.JaegerCommonSpec{jaeger.Spec.Query.JaegerCommonSpec, jaeger.Spec.JaegerCommonSpec}).ServiceAccount
+		if len(sa) == 0 {
+			// if there's a service account specified for the query component, that's the one we use
+			// otherwise, we use a custom SA for the OAuth Proxy
+			accounts = append(accounts, OAuthProxy(jaeger))
+		}
 	}
 	return append(accounts, getMain(jaeger))
 }

--- a/pkg/account/oauth-proxy.go
+++ b/pkg/account/oauth-proxy.go
@@ -3,10 +3,11 @@ package account
 import (
 	"fmt"
 
-	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
-	"github.com/jaegertracing/jaeger-operator/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	"github.com/jaegertracing/jaeger-operator/pkg/util"
 )
 
 // OAuthProxy returns a service account representing a client in the context of the OAuth Proxy

--- a/pkg/account/oauth-proxy.go
+++ b/pkg/account/oauth-proxy.go
@@ -3,10 +3,10 @@ package account
 import (
 	"fmt"
 
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	"github.com/jaegertracing/jaeger-operator/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 )
 
 // OAuthProxy returns a service account representing a client in the context of the OAuth Proxy
@@ -46,6 +46,12 @@ func OAuthProxy(jaeger *v1.Jaeger) *corev1.ServiceAccount {
 
 // OAuthProxyAccountNameFor returns the service account name for this Jaeger instance in the context of the OAuth Proxy
 func OAuthProxyAccountNameFor(jaeger *v1.Jaeger) string {
+	sa := util.Merge([]v1.JaegerCommonSpec{jaeger.Spec.Query.JaegerCommonSpec, jaeger.Spec.JaegerCommonSpec}).ServiceAccount
+	if len(sa) > 0 {
+		// if we have a custom service account for the query object, that's the service name we return
+		return sa
+	}
+
 	return fmt.Sprintf("%s-ui-proxy", jaeger.Name)
 }
 

--- a/pkg/account/oauth_proxy_test.go
+++ b/pkg/account/oauth_proxy_test.go
@@ -21,5 +21,21 @@ func TestOAuthProxy(t *testing.T) {
 	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestOAuthProxy"})
 	jaeger.Spec.Ingress.Security = v1.IngressSecurityOAuthProxy
 
-	assert.Equal(t, OAuthProxy(jaeger).Name, fmt.Sprintf("%s-ui-proxy", jaeger.Name))
+	assert.Equal(t, fmt.Sprintf("%s-ui-proxy", jaeger.Name), OAuthProxy(jaeger).Name)
+}
+
+func TestOAuthOverrideServiceAccountForQuery(t *testing.T) {
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestOAuthOverrideServiceAccountForQuery"})
+	jaeger.Spec.Ingress.Security = v1.IngressSecurityOAuthProxy
+	jaeger.Spec.Query.ServiceAccount = "my-own-sa"
+
+	assert.Equal(t, "my-own-sa", OAuthProxy(jaeger).Name)
+}
+
+func TestOAuthOverrideServiceAccountForAllComponents(t *testing.T) {
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestOAuthOverrideServiceAccountForAllComponents"})
+	jaeger.Spec.Ingress.Security = v1.IngressSecurityOAuthProxy
+	jaeger.Spec.ServiceAccount = "my-own-sa"
+
+	assert.Equal(t, "my-own-sa", OAuthProxy(jaeger).Name)
 }


### PR DESCRIPTION
Fixes #519 by checking the service account from the JaegerSpec and from JaegerQuerySpec and using it when a value is present.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>