### PR TITLE
Avoid touching the original structure of the options

### DIFF
--- a/pkg/apis/jaegertracing/v1/options.go
+++ b/pkg/apis/jaegertracing/v1/options.go
@@ -10,6 +10,7 @@ import (
 // Options defines a common options parameter to the different structs
 type Options struct {
 	opts map[string]string
+	json []byte
 }
 
 // NewOptions build a new Options object based on the given map
@@ -46,13 +47,18 @@ func (o *Options) UnmarshalJSON(b []byte) error {
 	}
 
 	o.parse(entries)
+	o.json = b
 	return nil
 }
 
 // MarshalJSON specifies how to convert this object into JSON
 func (o Options) MarshalJSON() ([]byte, error) {
-	b, err := json.Marshal(o.opts)
-	return b, err
+	if len(o.json) == 0 && len(o.opts) == 0 {
+		return []byte("{}"), nil
+	} else if len(o.json) == 0 && len(o.opts) > 0 {
+		return json.Marshal(o.opts)
+	}
+	return o.json, nil
 }
 
 func (o *Options) parse(entries map[string]interface{}) {

--- a/pkg/apis/jaegertracing/v1/options_test.go
+++ b/pkg/apis/jaegertracing/v1/options_test.go
@@ -118,3 +118,20 @@ func TestExposedMap(t *testing.T) {
 	o.UnmarshalJSON([]byte(`{"cassandra": {"servers": "cassandra:9042"}}`))
 	assert.Equal(t, "cassandra:9042", o.Map()["cassandra.servers"])
 }
+
+func TestMarshallRaw(t *testing.T) {
+	json := []byte(`{"cassandra": {"servers": "cassandra:9042"}}`)
+	o := NewOptions(nil)
+	o.json = json
+	bytes, err := o.MarshalJSON()
+	assert.NoError(t, err)
+	assert.Equal(t, bytes, json)
+}
+
+func TestMarshallEmpty(t *testing.T) {
+	o := NewOptions(nil)
+	json := []byte(`{}`)
+	bytes, err := o.MarshalJSON()
+	assert.NoError(t, err)
+	assert.Equal(t, bytes, json)
+}

--- a/pkg/apis/jaegertracing/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/jaegertracing/v1/zz_generated.deepcopy.go
@@ -517,6 +517,11 @@ func (in *Options) DeepCopyInto(out *Options) {
 			(*out)[key] = val
 		}
 	}
+	if in.json != nil {
+		in, out := &in.json, &out.json
+		*out = make([]byte, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 


### PR DESCRIPTION
Signed-off-by: Ruben Vargas <ruben.vp8510@gmail.com>

Fixes Issue #304 

Changed the way that the options is serialized/deserialized, now options does not touch the yaml structure on an update.

This is similar to Freeform type, but it has internally a method for "flat" options, so this support both types of properties, condensed form and normal structure, but not a mix of them.

may be we can/should merge this type with Freeform ?