### PR TITLE
Prevented the Operator from overriding Secrets/ImagePullSecrets on ServiceAccounts

### DIFF
--- a/pkg/inventory/account.go
+++ b/pkg/inventory/account.go
@@ -27,9 +27,6 @@ func ForAccounts(existing []v1.ServiceAccount, desired []v1.ServiceAccount) Acco
 			util.InitObjectMeta(tp)
 
 			// we can't blindly DeepCopyInto, so, we select what we bring from the new to the old object
-			tp.Secrets = v.Secrets
-			tp.ImagePullSecrets = v.ImagePullSecrets
-			tp.AutomountServiceAccountToken = v.AutomountServiceAccountToken
 			tp.ObjectMeta.OwnerReferences = v.ObjectMeta.OwnerReferences
 
 			for k, v := range v.ObjectMeta.Annotations {

--- a/pkg/inventory/account_test.go
+++ b/pkg/inventory/account_test.go
@@ -29,6 +29,8 @@ func TestAccountInventory(t *testing.T) {
 			Labels:      map[string]string{"gopher": "jaeger"},
 		},
 		AutomountServiceAccountToken: &falseVar,
+		Secrets:                      []v1.ObjectReference{{Kind: "Secret"}},
+		ImagePullSecrets:             []v1.LocalObjectReference{{Name: "ImagePullSecret"}},
 	}
 	toDelete := v1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
@@ -45,7 +47,13 @@ func TestAccountInventory(t *testing.T) {
 
 	assert.Len(t, inv.Update, 1)
 	assert.Equal(t, "to-update", inv.Update[0].Name)
-	assert.Equal(t, &falseVar, inv.Update[0].AutomountServiceAccountToken)
+
+	// we do *not* set this in any of our current service accounts,
+	// but this might be set by the cluster -- in this case,
+	// we keep whatever is there, not touching the fields at all
+	assert.Equal(t, &trueVar, inv.Update[0].AutomountServiceAccountToken)
+	assert.Len(t, inv.Update[0].Secrets, 0)
+	assert.Len(t, inv.Update[0].ImagePullSecrets, 0)
 
 	assert.Len(t, inv.Delete, 1)
 	assert.Equal(t, "to-delete", inv.Delete[0].Name)


### PR DESCRIPTION
Fixes #521 by not overriding the `Secrets`, `ImagePullSecrets` nor `AutomountServiceAccountToken` fields from service accounts.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>