### PR TITLE
Use ES single redundancy by default

### DIFF
--- a/pkg/strategy/controller.go
+++ b/pkg/strategy/controller.go
@@ -133,7 +133,7 @@ func normalizeElasticsearch(spec *v1.ElasticsearchSpec) {
 		spec.NodeCount = 1
 	}
 	if spec.RedundancyPolicy == "" {
-		spec.RedundancyPolicy = esv1.ZeroRedundancy
+		spec.RedundancyPolicy = esv1.SingleRedundancy
 	}
 }
 

--- a/pkg/strategy/controller_test.go
+++ b/pkg/strategy/controller_test.go
@@ -240,7 +240,7 @@ func TestNormalizeElasticsearch(t *testing.T) {
 		expected  v1.ElasticsearchSpec
 	}{
 		{underTest: v1.ElasticsearchSpec{},
-			expected: v1.ElasticsearchSpec{NodeCount: 1, RedundancyPolicy: "ZeroRedundancy"}},
+			expected: v1.ElasticsearchSpec{NodeCount: 1, RedundancyPolicy: "SingleRedundancy"}},
 		{underTest: v1.ElasticsearchSpec{NodeCount: 3, RedundancyPolicy: "FullRedundancy"},
 			expected: v1.ElasticsearchSpec{NodeCount: 3, RedundancyPolicy: "FullRedundancy"}},
 		{underTest: v1.ElasticsearchSpec{Image: "bla", NodeCount: 150, RedundancyPolicy: "ZeroRedundancy"},


### PR DESCRIPTION
Related to https://github.com/jaegertracing/jaeger-operator/pull/501#discussion_r304001869



Signed-off-by: Pavol Loffay <ploffay@redhat.com>