### PR TITLE
Use zero redundancy when number of ES nodes is 1

### DIFF
--- a/pkg/strategy/controller.go
+++ b/pkg/strategy/controller.go
@@ -133,7 +133,11 @@ func normalizeElasticsearch(spec *v1.ElasticsearchSpec) {
 		spec.NodeCount = 1
 	}
 	if spec.RedundancyPolicy == "" {
-		spec.RedundancyPolicy = esv1.SingleRedundancy
+		if spec.NodeCount == 1 {
+			spec.RedundancyPolicy = esv1.ZeroRedundancy
+		} else {
+			spec.RedundancyPolicy = esv1.SingleRedundancy
+		}
 	}
 }
 

--- a/pkg/strategy/controller_test.go
+++ b/pkg/strategy/controller_test.go
@@ -240,7 +240,9 @@ func TestNormalizeElasticsearch(t *testing.T) {
 		expected  v1.ElasticsearchSpec
 	}{
 		{underTest: v1.ElasticsearchSpec{},
-			expected: v1.ElasticsearchSpec{NodeCount: 1, RedundancyPolicy: "SingleRedundancy"}},
+			expected: v1.ElasticsearchSpec{NodeCount: 1, RedundancyPolicy: "ZeroRedundancy"}},
+		{underTest: v1.ElasticsearchSpec{NodeCount: 3},
+			expected: v1.ElasticsearchSpec{NodeCount: 3, RedundancyPolicy: "SingleRedundancy"}},
 		{underTest: v1.ElasticsearchSpec{NodeCount: 3, RedundancyPolicy: "FullRedundancy"},
 			expected: v1.ElasticsearchSpec{NodeCount: 3, RedundancyPolicy: "FullRedundancy"}},
 		{underTest: v1.ElasticsearchSpec{Image: "bla", NodeCount: 150, RedundancyPolicy: "ZeroRedundancy"},


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <ploffay@redhat.com>

ES operator does not allow single redundancy with single ES node.
```
oc logs elasticsearch-operator-5c76fb5664-4wtch -n openshift-logging        10:55 
time="2019-07-18T08:51:44Z" level=info msg="Go Version: go1.10.8"
time="2019-07-18T08:51:44Z" level=info msg="Go OS/Arch: linux/amd64"
time="2019-07-18T08:51:44Z" level=info msg="operator-sdk Version: 0.0.7"
time="2019-07-18T08:51:44Z" level=info msg="Watching logging.openshift.io/v1, Elasticsearch, , 5000000000"
time="2019-07-18T08:52:07Z" level=error msg="error syncing key (myproject/elasticsearch): Failed to reconcile Elasticsearch deployment spec: Wrong RedundancyPolicy selected 'SingleRedundancy'. Choose different RedundancyPolicy or add more nodes with data roles
```