### PR TITLE
Simplify usage of smoke test by having it do port forwarding

### DIFF
--- a/test/e2e/cassandra_test.go
+++ b/test/e2e/cassandra_test.go
@@ -66,12 +66,7 @@ func (suite *CassandraTestSuite) TestCassandra()  {
 	err = e2eutil.WaitForDeployment(t, fw.KubeClient, namespace, "with-cassandra", 1, retryInterval, timeout)
 	require.NoError(t, err, "Error waiting for deployment")
 
-	portForw, closeChan := CreatePortForward(namespace, "with-cassandra", "jaegertracing/all-in-one", []string{"16686", "14268"}, fw.KubeConfig)
-	defer portForw.Close()
-	defer close(closeChan)
-
-	err = SmokeTest("http://localhost:16686/api/traces", "http://localhost:14268/api/traces", "foobar", retryInterval, timeout)
-	require.NoError(t, err, "SmokeTest Failed")
+	SmokeTest("with-cassandra", "jaegertracing/all-in-one",  "foobar", retryInterval, timeout)
 }
 
 func (suite *CassandraTestSuite) TestCassandraSparkDependencies()  {

--- a/test/e2e/self_provisioned_elasticsearch_test.go
+++ b/test/e2e/self_provisioned_elasticsearch_test.go
@@ -79,16 +79,7 @@ func (suite *SelfProvisionedTestSuite) TestSelfProvisionedESSmokeTest() {
 	err = e2eutil.WaitForDeployment(t, fw.KubeClient, namespace, "simple-prod-query", 1, retryInterval, timeout)
 	require.NoError(t, err, "Error waiting for query deployment")
 
-	portForw, closeChan := CreatePortForward(namespace, "simple-prod-query", "jaegertracing/jaeger-query", []string{"16686"}, fw.KubeConfig)
-	defer portForw.Close()
-	defer close(closeChan)
-
-	portForwColl, closeChanColl := CreatePortForward(namespace, "simple-prod-collector", "jaegertracing/jaeger-collector", []string{"14268"}, fw.KubeConfig)
-	defer portForwColl.Close()
-	defer close(closeChanColl)
-
-	err = SmokeTest("http://localhost:16686/api/traces", "http://localhost:14268/api/traces", "foobar", retryInterval, timeout)
-	require.NoError(t, err, "Error running smoketest")
+	SmokeTestWithCollector("simple-prod-query", "jaegertracing/jaeger-query", "simple-prod-collector", "jaegertracing/jaeger-collector", "foobar", retryInterval, timeout)
 }
 
 func getJaegerSimpleProd() *v1.Jaeger {

--- a/test/e2e/smoketest.go
+++ b/test/e2e/smoketest.go
@@ -7,30 +7,52 @@ import (
 	"strings"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"github.com/uber/jaeger-client-go/config"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-func SmokeTest(apiTracesEndpoint, collectorEndpoint, serviceName string, interval, timeout time.Duration) error {
+// This version is for the all-in-one image, where query and collector use the same pod
+func SmokeTest(queryPodPrefix, queryPodImageName, serviceName string, interval, timeout time.Duration) {
+	portForw, closeChan := CreatePortForward(namespace, queryPodPrefix, queryPodImageName, []string{"16686", "14268"}, fw.KubeConfig)
+	defer portForw.Close()
+	defer close(closeChan)
+	executeSmokeTest(serviceName, interval, timeout)
+}
+
+// Call this version if query and collector are in separate pods
+func SmokeTestWithCollector(queryPodPrefix, queryPodImageName, collectorPodPrefix, collectorPodImageName, serviceName string, interval, timeout time.Duration) {
+	portForw, closeChan := CreatePortForward(namespace, queryPodPrefix, queryPodImageName, []string{"16686"}, fw.KubeConfig)
+	defer portForw.Close()
+	defer close(closeChan)
+
+	portForwColl, closeChanColl := CreatePortForward(namespace, collectorPodPrefix, collectorPodImageName, []string{"14268"}, fw.KubeConfig)
+	defer portForwColl.Close()
+	defer close(closeChanColl)
+
+	executeSmokeTest(serviceName, interval, timeout)
+}
+
+func executeSmokeTest(serviceName string, interval time.Duration, duration time.Duration) {
+	apiTracesEndpoint := "http://localhost:16686/api/traces"
+	collectorEndpoint := "http://localhost:14268/api/traces"
 	cfg := config.Configuration{
-		Reporter: &config.ReporterConfig{CollectorEndpoint: collectorEndpoint},
-		Sampler: &config.SamplerConfig{Type:"const", Param:1},
+		Reporter:    &config.ReporterConfig{CollectorEndpoint: collectorEndpoint},
+		Sampler:     &config.SamplerConfig{Type: "const", Param: 1},
 		ServiceName: serviceName,
 	}
 	tracer, closer, err := cfg.NewTracer()
 	if err != nil {
-		return err
+		require.NoError(t, err, "Failed to create tracer in SmokeTest")
 	}
-
 	tStr := time.Now().Format(time.RFC3339Nano)
 	tracer.StartSpan("SmokeTest").
 		SetTag("time-RFC3339Nano", tStr).
 		Finish()
 	closer.Close()
-
-	return wait.Poll(interval, timeout, func() (done bool, err error) {
+	err = wait.Poll(interval, timeout, func() (done bool, err error) {
 		c := http.Client{Timeout: time.Second}
-		req, err := http.NewRequest(http.MethodGet, apiTracesEndpoint+ "?service=" + serviceName, nil)
+		req, err := http.NewRequest(http.MethodGet, apiTracesEndpoint+"?service="+serviceName, nil)
 		if err != nil {
 			return false, err
 		}
@@ -43,10 +65,10 @@ func SmokeTest(apiTracesEndpoint, collectorEndpoint, serviceName string, interva
 		bodyBytes, err := ioutil.ReadAll(resp.Body)
 		bodyString := string(bodyBytes)
 
-
 		if !strings.Contains(bodyString, "errors\":null") {
 			return false, errors.New("query service returns errors: " + bodyString)
 		}
 		return strings.Contains(bodyString, tStr), nil
 	})
+	require.NoError(t, err, "SmokeTest failed")
 }

--- a/test/e2e/streaming_test.go
+++ b/test/e2e/streaming_test.go
@@ -69,16 +69,7 @@ func (suite *StreamingTestSuite) TestStreaming() {
 	err = e2eutil.WaitForDeployment(t, fw.KubeClient, namespace, "simple-streaming-query", 1, retryInterval, timeout)
 	require.NoError(t, err, "Error waiting for query deployment")
 
-	portForw, closeChan := CreatePortForward(namespace, "simple-streaming-query", "jaegertracing/jaeger-query", []string{"16686"}, fw.KubeConfig)
-	defer portForw.Close()
-	defer close(closeChan)
-
-	portForwColl, closeChanColl := CreatePortForward(namespace, "simple-streaming-collector", "jaegertracing/jaeger-collector", []string{"14268"}, fw.KubeConfig)
-	defer portForwColl.Close()
-	defer close(closeChanColl)
-
-	err = SmokeTest("http://localhost:16686/api/traces", "http://localhost:14268/api/traces", "foobar", retryInterval, timeout)
-	require.NoError(t, err, "Error running smoketest")
+	SmokeTestWithCollector("simple-streaming-query", "jaegertracing/jaeger-query", "simple-streaming-collector", "jaegertracing/jaeger-collector", "foobar", retryInterval, timeout)
 }
 
 func jaegerStreamingDefinition(namespace string, name string) *v1.Jaeger {


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com> 

This simplifies usage of the smoke test by having the smoketest itself handle the port forwarding.  This shortens our existing tests, but will also be useful for new tests like ones I will be adding for #144 where I anticipate running the smoke test to validate most of the examplees
