### PR TITLE
Allow setting es-operator-image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,8 @@ OPERATOR_VERSION ?= "$(shell git describe --tags)"
 STORAGE_NAMESPACE ?= "${shell kubectl get sa default -o jsonpath='{.metadata.namespace}' || oc project -q}"
 KAFKA_NAMESPACE ?= "kafka"
 ES_OPERATOR_NAMESPACE = openshift-logging
-ES_OPERATOR_VERSION = 4.1
+ES_OPERATOR_VERSION ?= release-4.1
+ES_OPERATOR_IMAGE ?= quay.io/openshift/origin-elasticsearch-operator:4.1
 SDK_VERSION=v0.8.1
 
 LD_FLAGS ?= "-X $(VERSION_PKG).version=$(OPERATOR_VERSION) -X $(VERSION_PKG).buildDate=$(VERSION_DATE) -X $(VERSION_PKG).defaultJaeger=$(JAEGER_VERSION)"
@@ -136,20 +137,20 @@ deploy-es-operator: set-max-map-count
 	@kubectl create namespace ${ES_OPERATOR_NAMESPACE} 2>&1 | grep -v "already exists" || true
 	@kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/master/example/prometheus-operator-crd/prometheusrule.crd.yaml
 	@kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/master/example/prometheus-operator-crd/servicemonitor.crd.yaml
-	@kubectl apply -f https://raw.githubusercontent.com/openshift/elasticsearch-operator/release-${ES_OPERATOR_VERSION}/manifests/01-service-account.yaml -n ${ES_OPERATOR_NAMESPACE}
-	@kubectl apply -f https://raw.githubusercontent.com/openshift/elasticsearch-operator/release-${ES_OPERATOR_VERSION}/manifests/02-role.yaml
-	@kubectl apply -f https://raw.githubusercontent.com/openshift/elasticsearch-operator/release-${ES_OPERATOR_VERSION}/manifests/03-role-bindings.yaml
-	@kubectl apply -f https://raw.githubusercontent.com/openshift/elasticsearch-operator/release-${ES_OPERATOR_VERSION}/manifests/04-crd.yaml -n ${ES_OPERATOR_NAMESPACE}
-	@kubectl apply -f https://raw.githubusercontent.com/openshift/elasticsearch-operator/release-${ES_OPERATOR_VERSION}/manifests/05-deployment.yaml -n ${ES_OPERATOR_NAMESPACE}
-	@kubectl set image deployment/elasticsearch-operator elasticsearch-operator=quay.io/openshift/origin-elasticsearch-operator:${ES_OPERATOR_VERSION} -n ${ES_OPERATOR_NAMESPACE}
+	@kubectl apply -f https://raw.githubusercontent.com/openshift/elasticsearch-operator/${ES_OPERATOR_VERSION}/manifests/01-service-account.yaml -n ${ES_OPERATOR_NAMESPACE}
+	@kubectl apply -f https://raw.githubusercontent.com/openshift/elasticsearch-operator/${ES_OPERATOR_VERSION}/manifests/02-role.yaml
+	@kubectl apply -f https://raw.githubusercontent.com/openshift/elasticsearch-operator/${ES_OPERATOR_VERSION}/manifests/03-role-bindings.yaml
+	@kubectl apply -f https://raw.githubusercontent.com/openshift/elasticsearch-operator/${ES_OPERATOR_VERSION}/manifests/04-crd.yaml -n ${ES_OPERATOR_NAMESPACE}
+	kubectl apply -f https://raw.githubusercontent.com/openshift/elasticsearch-operator/${ES_OPERATOR_VERSION}/manifests/05-deployment.yaml -n ${ES_OPERATOR_NAMESPACE}
+	kubectl set image deployment/elasticsearch-operator elasticsearch-operator=${ES_OPERATOR_IMAGE} -n ${ES_OPERATOR_NAMESPACE}
 
 .PHONY: undeploy-es-operator
 undeploy-es-operator:
-	@kubectl delete -f https://raw.githubusercontent.com/openshift/elasticsearch-operator/release-${ES_OPERATOR_VERSION}/manifests/05-deployment.yaml -n ${ES_OPERATOR_NAMESPACE} || true
-	@kubectl delete -f https://raw.githubusercontent.com/openshift/elasticsearch-operator/release-${ES_OPERATOR_VERSION}/manifests/04-crd.yaml -n ${ES_OPERATOR_NAMESPACE} || true
-	@kubectl delete -f https://raw.githubusercontent.com/openshift/elasticsearch-operator/release-${ES_OPERATOR_VERSION}/manifests/03-role-bindings.yaml || true
-	@kubectl delete -f https://raw.githubusercontent.com/openshift/elasticsearch-operator/release-${ES_OPERATOR_VERSION}/manifests/02-role.yaml || true
-	@kubectl delete -f https://raw.githubusercontent.com/openshift/elasticsearch-operator/release-${ES_OPERATOR_VERSION}/manifests/01-service-account.yaml -n ${ES_OPERATOR_NAMESPACE} || true
+	@kubectl delete -f https://raw.githubusercontent.com/openshift/elasticsearch-operator/${ES_OPERATOR_VERSION}/manifests/05-deployment.yaml -n ${ES_OPERATOR_NAMESPACE} || true
+	@kubectl delete -f https://raw.githubusercontent.com/openshift/elasticsearch-operator/${ES_OPERATOR_VERSION}/manifests/04-crd.yaml -n ${ES_OPERATOR_NAMESPACE} || true
+	@kubectl delete -f https://raw.githubusercontent.com/openshift/elasticsearch-operator/${ES_OPERATOR_VERSION}/manifests/03-role-bindings.yaml || true
+	@kubectl delete -f https://raw.githubusercontent.com/openshift/elasticsearch-operator/${ES_OPERATOR_VERSION}/manifests/02-role.yaml || true
+	@kubectl delete -f https://raw.githubusercontent.com/openshift/elasticsearch-operator/${ES_OPERATOR_VERSION}/manifests/01-service-account.yaml -n ${ES_OPERATOR_NAMESPACE} || true
 	@kubectl delete -f https://raw.githubusercontent.com/coreos/prometheus-operator/master/example/prometheus-operator-crd/servicemonitor.crd.yaml || true
 	@kubectl delete -f https://raw.githubusercontent.com/coreos/prometheus-operator/master/example/prometheus-operator-crd/prometheusrule.crd.yaml || true
 	@kubectl delete namespace ${ES_OPERATOR_NAMESPACE} 2>&1 || true

--- a/Makefile
+++ b/Makefile
@@ -141,8 +141,8 @@ deploy-es-operator: set-max-map-count
 	@kubectl apply -f https://raw.githubusercontent.com/openshift/elasticsearch-operator/${ES_OPERATOR_BRANCH}/manifests/02-role.yaml
 	@kubectl apply -f https://raw.githubusercontent.com/openshift/elasticsearch-operator/${ES_OPERATOR_BRANCH}/manifests/03-role-bindings.yaml
 	@kubectl apply -f https://raw.githubusercontent.com/openshift/elasticsearch-operator/${ES_OPERATOR_BRANCH}/manifests/04-crd.yaml -n ${ES_OPERATOR_NAMESPACE}
-	kubectl apply -f https://raw.githubusercontent.com/openshift/elasticsearch-operator/${ES_OPERATOR_BRANCH}/manifests/05-deployment.yaml -n ${ES_OPERATOR_NAMESPACE}
-	kubectl set image deployment/elasticsearch-operator elasticsearch-operator=${ES_OPERATOR_IMAGE} -n ${ES_OPERATOR_NAMESPACE}
+	@kubectl apply -f https://raw.githubusercontent.com/openshift/elasticsearch-operator/${ES_OPERATOR_BRANCH}/manifests/05-deployment.yaml -n ${ES_OPERATOR_NAMESPACE}
+	@kubectl set image deployment/elasticsearch-operator elasticsearch-operator=${ES_OPERATOR_IMAGE} -n ${ES_OPERATOR_NAMESPACE}
 
 .PHONY: undeploy-es-operator
 undeploy-es-operator:

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ OPERATOR_VERSION ?= "$(shell git describe --tags)"
 STORAGE_NAMESPACE ?= "${shell kubectl get sa default -o jsonpath='{.metadata.namespace}' || oc project -q}"
 KAFKA_NAMESPACE ?= "kafka"
 ES_OPERATOR_NAMESPACE = openshift-logging
-ES_OPERATOR_VERSION ?= release-4.1
+ES_OPERATOR_BRANCH ?= release-4.1
 ES_OPERATOR_IMAGE ?= quay.io/openshift/origin-elasticsearch-operator:4.1
 SDK_VERSION=v0.8.1
 
@@ -137,20 +137,20 @@ deploy-es-operator: set-max-map-count
 	@kubectl create namespace ${ES_OPERATOR_NAMESPACE} 2>&1 | grep -v "already exists" || true
 	@kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/master/example/prometheus-operator-crd/prometheusrule.crd.yaml
 	@kubectl apply -f https://raw.githubusercontent.com/coreos/prometheus-operator/master/example/prometheus-operator-crd/servicemonitor.crd.yaml
-	@kubectl apply -f https://raw.githubusercontent.com/openshift/elasticsearch-operator/${ES_OPERATOR_VERSION}/manifests/01-service-account.yaml -n ${ES_OPERATOR_NAMESPACE}
-	@kubectl apply -f https://raw.githubusercontent.com/openshift/elasticsearch-operator/${ES_OPERATOR_VERSION}/manifests/02-role.yaml
-	@kubectl apply -f https://raw.githubusercontent.com/openshift/elasticsearch-operator/${ES_OPERATOR_VERSION}/manifests/03-role-bindings.yaml
-	@kubectl apply -f https://raw.githubusercontent.com/openshift/elasticsearch-operator/${ES_OPERATOR_VERSION}/manifests/04-crd.yaml -n ${ES_OPERATOR_NAMESPACE}
-	kubectl apply -f https://raw.githubusercontent.com/openshift/elasticsearch-operator/${ES_OPERATOR_VERSION}/manifests/05-deployment.yaml -n ${ES_OPERATOR_NAMESPACE}
+	@kubectl apply -f https://raw.githubusercontent.com/openshift/elasticsearch-operator/${ES_OPERATOR_BRANCH}/manifests/01-service-account.yaml -n ${ES_OPERATOR_NAMESPACE}
+	@kubectl apply -f https://raw.githubusercontent.com/openshift/elasticsearch-operator/${ES_OPERATOR_BRANCH}/manifests/02-role.yaml
+	@kubectl apply -f https://raw.githubusercontent.com/openshift/elasticsearch-operator/${ES_OPERATOR_BRANCH}/manifests/03-role-bindings.yaml
+	@kubectl apply -f https://raw.githubusercontent.com/openshift/elasticsearch-operator/${ES_OPERATOR_BRANCH}/manifests/04-crd.yaml -n ${ES_OPERATOR_NAMESPACE}
+	kubectl apply -f https://raw.githubusercontent.com/openshift/elasticsearch-operator/${ES_OPERATOR_BRANCH}/manifests/05-deployment.yaml -n ${ES_OPERATOR_NAMESPACE}
 	kubectl set image deployment/elasticsearch-operator elasticsearch-operator=${ES_OPERATOR_IMAGE} -n ${ES_OPERATOR_NAMESPACE}
 
 .PHONY: undeploy-es-operator
 undeploy-es-operator:
-	@kubectl delete -f https://raw.githubusercontent.com/openshift/elasticsearch-operator/${ES_OPERATOR_VERSION}/manifests/05-deployment.yaml -n ${ES_OPERATOR_NAMESPACE} || true
-	@kubectl delete -f https://raw.githubusercontent.com/openshift/elasticsearch-operator/${ES_OPERATOR_VERSION}/manifests/04-crd.yaml -n ${ES_OPERATOR_NAMESPACE} || true
-	@kubectl delete -f https://raw.githubusercontent.com/openshift/elasticsearch-operator/${ES_OPERATOR_VERSION}/manifests/03-role-bindings.yaml || true
-	@kubectl delete -f https://raw.githubusercontent.com/openshift/elasticsearch-operator/${ES_OPERATOR_VERSION}/manifests/02-role.yaml || true
-	@kubectl delete -f https://raw.githubusercontent.com/openshift/elasticsearch-operator/${ES_OPERATOR_VERSION}/manifests/01-service-account.yaml -n ${ES_OPERATOR_NAMESPACE} || true
+	@kubectl delete -f https://raw.githubusercontent.com/openshift/elasticsearch-operator/${ES_OPERATOR_BRANCH}/manifests/05-deployment.yaml -n ${ES_OPERATOR_NAMESPACE} || true
+	@kubectl delete -f https://raw.githubusercontent.com/openshift/elasticsearch-operator/${ES_OPERATOR_BRANCH}/manifests/04-crd.yaml -n ${ES_OPERATOR_NAMESPACE} || true
+	@kubectl delete -f https://raw.githubusercontent.com/openshift/elasticsearch-operator/${ES_OPERATOR_BRANCH}/manifests/03-role-bindings.yaml || true
+	@kubectl delete -f https://raw.githubusercontent.com/openshift/elasticsearch-operator/${ES_OPERATOR_BRANCH}/manifests/02-role.yaml || true
+	@kubectl delete -f https://raw.githubusercontent.com/openshift/elasticsearch-operator/${ES_OPERATOR_BRANCH}/manifests/01-service-account.yaml -n ${ES_OPERATOR_NAMESPACE} || true
 	@kubectl delete -f https://raw.githubusercontent.com/coreos/prometheus-operator/master/example/prometheus-operator-crd/servicemonitor.crd.yaml || true
 	@kubectl delete -f https://raw.githubusercontent.com/coreos/prometheus-operator/master/example/prometheus-operator-crd/prometheusrule.crd.yaml || true
 	@kubectl delete namespace ${ES_OPERATOR_NAMESPACE} 2>&1 || true


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com>

Allow setting the elasticsearch operator image via an environment variable.  This is needed for CI for compatibility testing.
