### PR TITLE
Simplify usage of smoke test by having it do port forwarding

### DIFF
--- a/test/e2e/cassandra_test.go
+++ b/test/e2e/cassandra_test.go
@@ -66,15 +66,7 @@ func (suite *CassandraTestSuite) TestCassandra()  {
 	err = e2eutil.WaitForDeployment(t, fw.KubeClient, namespace, "with-cassandra", 1, retryInterval, timeout)
 	require.NoError(t, err, "Error waiting for deployment")
 
-	queryPort := randomPortNumber()
-	collectorPort := randomPortNumber()
-	ports := []string{queryPort + ":16686", collectorPort + ":14268"}
-	portForw, closeChan := CreatePortForward(namespace, "with-cassandra", "jaegertracing/all-in-one", ports, fw.KubeConfig)
-	defer portForw.Close()
-	defer close(closeChan)
-
-	err = SmokeTest("http://localhost:" + queryPort + "/api/traces", "http://localhost:" + collectorPort + "/api/traces", "foobar", retryInterval, timeout)
-	require.NoError(t, err, "SmokeTest Failed")
+	SmokeTest("with-cassandra", "jaegertracing/all-in-one", "foobar", retryInterval, timeout)
 }
 
 func (suite *CassandraTestSuite) TestCassandraSparkDependencies()  {

--- a/test/e2e/cassandra_test.go
+++ b/test/e2e/cassandra_test.go
@@ -66,7 +66,7 @@ func (suite *CassandraTestSuite) TestCassandra()  {
 	err = e2eutil.WaitForDeployment(t, fw.KubeClient, namespace, "with-cassandra", 1, retryInterval, timeout)
 	require.NoError(t, err, "Error waiting for deployment")
 
-	SmokeTest("with-cassandra", "jaegertracing/all-in-one", "foobar", retryInterval, timeout)
+	AllInOneSmokeTest("with-cassandra", "jaegertracing/all-in-one", "foobar", retryInterval, timeout)
 }
 
 func (suite *CassandraTestSuite) TestCassandraSparkDependencies()  {

--- a/test/e2e/elasticsearch_test.go
+++ b/test/e2e/elasticsearch_test.go
@@ -90,7 +90,7 @@ func (suite *ElasticSearchTestSuite) TestSimpleProd() {
 	err = e2eutil.WaitForDeployment(t, fw.KubeClient, namespace, "simple-prod-query", 1, retryInterval, timeout)
 	require.NoError(t, err, "Error waiting for query deployment")
 
-	SmokeTestWithCollector("simple-prod-query", "jaegertracing/jaeger-query", "simple-prod-collector",
+	ProductionSmokeTest("simple-prod-query", "jaegertracing/jaeger-query", "simple-prod-collector",
 		"jaegertracing/jaeger-collector", "foobar", retryInterval, timeout)
 }
 
@@ -106,7 +106,7 @@ func (suite *ElasticSearchTestSuite) TestEsIndexCleaner() {
 	require.NoError(t, err, "Error waiting for deployment")
 
 	// create span, otherwise index cleaner fails - there would not be indices
-	SmokeTest(name, "jaegertracing/all-in-one", "foo-bar", retryInterval, timeout)
+	AllInOneSmokeTest(name, "jaegertracing/all-in-one", "foo-bar", retryInterval, timeout)
 
 	// Once we've created a span with the smoke test, enable the index cleaer
 	key := types.NamespacedName{Name:name, Namespace:namespace}

--- a/test/e2e/elasticsearch_test.go
+++ b/test/e2e/elasticsearch_test.go
@@ -90,21 +90,8 @@ func (suite *ElasticSearchTestSuite) TestSimpleProd() {
 	err = e2eutil.WaitForDeployment(t, fw.KubeClient, namespace, "simple-prod-query", 1, retryInterval, timeout)
 	require.NoError(t, err, "Error waiting for query deployment")
 
-	queryPort := randomPortNumber()
-	queryPorts := []string{queryPort + ":16686"}
-	portForw, closeChan := CreatePortForward(namespace, "simple-prod-query", "jaegertracing/jaeger-query", queryPorts, fw.KubeConfig)
-	defer portForw.Close()
-	defer close(closeChan)
-
-	collectorPort := randomPortNumber()
-	collectorPorts := []string{collectorPort + ":14268"}
-	portForwColl, closeChanColl := CreatePortForward(namespace, "simple-prod-collector", "jaegertracing/jaeger-collector", collectorPorts, fw.KubeConfig)
-	require.NoError(t, err, "Error creating port forward")
-
-	defer portForwColl.Close()
-	defer close(closeChanColl)
-	err = SmokeTest("http://localhost:" + queryPort + "/api/traces", "http://localhost:" + collectorPort + "/api/traces", "foobar", retryInterval, timeout)
-	require.NoError(t, err, "Error running smoketest")
+	SmokeTestWithCollector("simple-prod-query", "jaegertracing/jaeger-query", "simple-prod-collector",
+		"jaegertracing/jaeger-collector", "foobar", retryInterval, timeout)
 }
 
 func (suite *ElasticSearchTestSuite) TestEsIndexCleaner() {
@@ -119,15 +106,7 @@ func (suite *ElasticSearchTestSuite) TestEsIndexCleaner() {
 	require.NoError(t, err, "Error waiting for deployment")
 
 	// create span, otherwise index cleaner fails - there would not be indices
-	queryPort := randomPortNumber()
-	collectorPort := randomPortNumber()
-	ports := []string{queryPort + ":16686", collectorPort + ":14268"}
-	portForw, closeChan := CreatePortForward(namespace, name, "jaegertracing/all-in-one", ports, fw.KubeConfig)
-	defer portForw.Close()
-	defer close(closeChan)
-
-	err = SmokeTest("http://localhost:" + queryPort + "/api/traces", "http://localhost:" + collectorPort + "/api/traces", "foo-bar", retryInterval, timeout)
-	require.NoError(t, err, "Error running smoketest")
+	SmokeTest(name, "jaegertracing/all-in-one", "foo-bar", retryInterval, timeout)
 
 	// Once we've created a span with the smoke test, enable the index cleaer
 	key := types.NamespacedName{Name:name, Namespace:namespace}

--- a/test/e2e/self_provisioned_elasticsearch_test.go
+++ b/test/e2e/self_provisioned_elasticsearch_test.go
@@ -81,20 +81,7 @@ func (suite *SelfProvisionedTestSuite) TestSelfProvisionedESSmokeTest() {
 	err = e2eutil.WaitForDeployment(t, fw.KubeClient, namespace, "simple-prod-query", 1, retryInterval, timeout)
 	require.NoError(t, err, "Error waiting for query deployment")
 
-	queryPort := randomPortNumber()
-	queryPorts := []string{queryPort + ":16686"}
-	portForw, closeChan := CreatePortForward(namespace, "simple-prod-query", "jaegertracing/jaeger-query", queryPorts, fw.KubeConfig)
-	defer portForw.Close()
-	defer close(closeChan)
-
-	collectorPort := randomPortNumber()
-	collectorPorts := []string{collectorPort + ":14268"}
-	portForwColl, closeChanColl := CreatePortForward(namespace, "simple-prod-collector", "jaegertracing/jaeger-collector", collectorPorts, fw.KubeConfig)
-	defer portForwColl.Close()
-	defer close(closeChanColl)
-
-	err = SmokeTest("http://localhost:" + queryPort + "/api/traces", "http://localhost:" + collectorPort + "/api/traces", "foobar", retryInterval, timeout)
-	require.NoError(t, err, "Error running smoketest")
+	SmokeTestWithCollector("simple-prod-query", "jaegertracing/jaeger-query", "simple-prod-collector", "jaegertracing/jaeger-collector", "foobar", retryInterval, timeout)
 }
 
 func (suite *SelfProvisionedTestSuite) TestValidateEsOperatorImage() {

--- a/test/e2e/self_provisioned_elasticsearch_test.go
+++ b/test/e2e/self_provisioned_elasticsearch_test.go
@@ -81,7 +81,7 @@ func (suite *SelfProvisionedTestSuite) TestSelfProvisionedESSmokeTest() {
 	err = e2eutil.WaitForDeployment(t, fw.KubeClient, namespace, "simple-prod-query", 1, retryInterval, timeout)
 	require.NoError(t, err, "Error waiting for query deployment")
 
-	SmokeTestWithCollector("simple-prod-query", "jaegertracing/jaeger-query", "simple-prod-collector", "jaegertracing/jaeger-collector", "foobar", retryInterval, timeout)
+	ProductionSmokeTest("simple-prod-query", "jaegertracing/jaeger-query", "simple-prod-collector", "jaegertracing/jaeger-collector", "foobar", retryInterval, timeout)
 }
 
 func (suite *SelfProvisionedTestSuite) TestValidateEsOperatorImage() {

--- a/test/e2e/smoketest.go
+++ b/test/e2e/smoketest.go
@@ -14,11 +14,11 @@ import (
 )
 
 // This version is for the all-in-one image, where query and collector use the same pod
-func SmokeTest(queryPodPrefix, queryPodImageName, serviceName string, interval, timeout time.Duration) {
+func AllInOneSmokeTest(allInOnePodPrefix, allInOnePodImageName, serviceName string, interval, timeout time.Duration) {
 	queryPort := randomPortNumber()
 	collectorPort := randomPortNumber()
 	ports := []string{queryPort + ":16686", collectorPort + ":14268"}
-	portForw, closeChan := CreatePortForward(namespace, queryPodPrefix, queryPodImageName, ports, fw.KubeConfig)
+	portForw, closeChan := CreatePortForward(namespace, allInOnePodPrefix, allInOnePodImageName, ports, fw.KubeConfig)
 	defer portForw.Close()
 	defer close(closeChan)
 
@@ -28,7 +28,7 @@ func SmokeTest(queryPodPrefix, queryPodImageName, serviceName string, interval, 
 }
 
 // Call this version if query and collector are in separate pods
-func SmokeTestWithCollector(queryPodPrefix, queryPodImageName, collectorPodPrefix, collectorPodImageName, serviceName string, interval, timeout time.Duration) {
+func ProductionSmokeTest(queryPodPrefix, queryPodImageName, collectorPodPrefix, collectorPodImageName, serviceName string, interval, timeout time.Duration) {
 	queryPort := randomPortNumber()
 	queryPorts := []string{queryPort + ":16686"}
 	portForw, closeChan := CreatePortForward(namespace, queryPodPrefix, queryPodImageName, queryPorts, fw.KubeConfig)

--- a/test/e2e/smoketest.go
+++ b/test/e2e/smoketest.go
@@ -24,7 +24,7 @@ func AllInOneSmokeTest(allInOnePodPrefix, allInOnePodImageName, serviceName stri
 
 	apiTracesEndpoint := fmt.Sprintf("http://localhost:%s/api/traces", queryPort)
 	collectorEndpoint := fmt.Sprintf("http://localhost:%s/api/traces", collectorPort)
-	ExecuteSmokeTest(apiTracesEndpoint, collectorEndpoint, serviceName, interval, timeout)
+	executeSmokeTest(apiTracesEndpoint, collectorEndpoint, serviceName, interval, timeout)
 }
 
 // Call this version if query and collector are in separate pods
@@ -43,10 +43,10 @@ func ProductionSmokeTest(queryPodPrefix, queryPodImageName, collectorPodPrefix, 
 
 	apiTracesEndpoint := fmt.Sprintf("http://localhost:%s/api/traces", queryPort)
 	collectorEndpoint := fmt.Sprintf("http://localhost:%s/api/traces", collectorPort)
-	ExecuteSmokeTest(apiTracesEndpoint, collectorEndpoint, serviceName, interval, timeout)
+	executeSmokeTest(apiTracesEndpoint, collectorEndpoint, serviceName, interval, timeout)
 }
 
-func ExecuteSmokeTest(apiTracesEndpoint, collectorEndpoint, serviceName string, interval time.Duration, duration time.Duration) {
+func executeSmokeTest(apiTracesEndpoint, collectorEndpoint, serviceName string, interval time.Duration, duration time.Duration) {
 	cfg := config.Configuration{
 		Reporter: &config.ReporterConfig{CollectorEndpoint: collectorEndpoint},
 		Sampler: &config.SamplerConfig{Type: "const", Param: 1},

--- a/test/e2e/smoketest.go
+++ b/test/e2e/smoketest.go
@@ -2,25 +2,58 @@ package e2e
 
 import (
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"github.com/uber/jaeger-client-go/config"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-func SmokeTest(apiTracesEndpoint, collectorEndpoint, serviceName string, interval, timeout time.Duration) error {
+// This version is for the all-in-one image, where query and collector use the same pod
+func SmokeTest(queryPodPrefix, queryPodImageName, serviceName string, interval, timeout time.Duration) {
+	queryPort := randomPortNumber()
+	collectorPort := randomPortNumber()
+	ports := []string{queryPort + ":16686", collectorPort + ":14268"}
+	portForw, closeChan := CreatePortForward(namespace, queryPodPrefix, queryPodImageName, ports, fw.KubeConfig)
+	defer portForw.Close()
+	defer close(closeChan)
+
+	apiTracesEndpoint := fmt.Sprintf("http://localhost:%s/api/traces", queryPort)
+	collectorEndpoint := fmt.Sprintf("http://localhost:%s/api/traces", collectorPort)
+	ExecuteSmokeTest(apiTracesEndpoint, collectorEndpoint, serviceName, interval, timeout)
+}
+
+// Call this version if query and collector are in separate pods
+func SmokeTestWithCollector(queryPodPrefix, queryPodImageName, collectorPodPrefix, collectorPodImageName, serviceName string, interval, timeout time.Duration) {
+	queryPort := randomPortNumber()
+	queryPorts := []string{queryPort + ":16686"}
+	portForw, closeChan := CreatePortForward(namespace, queryPodPrefix, queryPodImageName, queryPorts, fw.KubeConfig)
+	defer portForw.Close()
+	defer close(closeChan)
+
+	collectorPort := randomPortNumber()
+	collectorPorts := []string{collectorPort + ":14268"}
+	portForwColl, closeChanColl := CreatePortForward(namespace, collectorPodPrefix, collectorPodImageName, collectorPorts, fw.KubeConfig)
+	defer portForwColl.Close()
+	defer close(closeChanColl)
+
+	apiTracesEndpoint := fmt.Sprintf("http://localhost:%s/api/traces", queryPort)
+	collectorEndpoint := fmt.Sprintf("http://localhost:%s/api/traces", collectorPort)
+	ExecuteSmokeTest(apiTracesEndpoint, collectorEndpoint, serviceName, interval, timeout)
+}
+
+func ExecuteSmokeTest(apiTracesEndpoint, collectorEndpoint, serviceName string, interval time.Duration, duration time.Duration) {
 	cfg := config.Configuration{
 		Reporter: &config.ReporterConfig{CollectorEndpoint: collectorEndpoint},
-		Sampler: &config.SamplerConfig{Type:"const", Param:1},
+		Sampler: &config.SamplerConfig{Type: "const", Param: 1},
 		ServiceName: serviceName,
 	}
 	tracer, closer, err := cfg.NewTracer()
-	if err != nil {
-		return err
-	}
+	require.NoError(t, err, "Failed to create tracer in SmokeTest")
 
 	tStr := time.Now().Format(time.RFC3339Nano)
 	tracer.StartSpan("SmokeTest").
@@ -28,9 +61,9 @@ func SmokeTest(apiTracesEndpoint, collectorEndpoint, serviceName string, interva
 		Finish()
 	closer.Close()
 
-	return wait.Poll(interval, timeout, func() (done bool, err error) {
+	err = wait.Poll(interval, timeout, func() (done bool, err error) {
 		c := http.Client{Timeout: time.Second}
-		req, err := http.NewRequest(http.MethodGet, apiTracesEndpoint+ "?service=" + serviceName, nil)
+		req, err := http.NewRequest(http.MethodGet, apiTracesEndpoint+"?service="+serviceName, nil)
 		if err != nil {
 			return false, err
 		}
@@ -43,10 +76,10 @@ func SmokeTest(apiTracesEndpoint, collectorEndpoint, serviceName string, interva
 		bodyBytes, err := ioutil.ReadAll(resp.Body)
 		bodyString := string(bodyBytes)
 
-
 		if !strings.Contains(bodyString, "errors\":null") {
 			return false, errors.New("query service returns errors: " + bodyString)
 		}
 		return strings.Contains(bodyString, tStr), nil
 	})
+	require.NoError(t, err, "SmokeTest failed")
 }

--- a/test/e2e/streaming_test.go
+++ b/test/e2e/streaming_test.go
@@ -69,7 +69,7 @@ func (suite *StreamingTestSuite) TestStreaming() {
 	err = e2eutil.WaitForDeployment(t, fw.KubeClient, namespace, "simple-streaming-query", 1, retryInterval, timeout)
 	require.NoError(t, err, "Error waiting for query deployment")
 
-	SmokeTestWithCollector("simple-streaming-query", "jaegertracing/jaeger-query", "simple-streaming-collector", "jaegertracing/jaeger-collector", "foobar", retryInterval, timeout)
+	ProductionSmokeTest("simple-streaming-query", "jaegertracing/jaeger-query", "simple-streaming-collector", "jaegertracing/jaeger-collector", "foobar", retryInterval, timeout)
 }
 
 func jaegerStreamingDefinition(namespace string, name string) *v1.Jaeger {

--- a/test/e2e/streaming_test.go
+++ b/test/e2e/streaming_test.go
@@ -69,20 +69,7 @@ func (suite *StreamingTestSuite) TestStreaming() {
 	err = e2eutil.WaitForDeployment(t, fw.KubeClient, namespace, "simple-streaming-query", 1, retryInterval, timeout)
 	require.NoError(t, err, "Error waiting for query deployment")
 
-	queryPort := randomPortNumber()
-	queryPorts := []string{queryPort + ":16686"}
-	portForw, closeChan := CreatePortForward(namespace, "simple-streaming-query", "jaegertracing/jaeger-query", queryPorts, fw.KubeConfig)
-	defer portForw.Close()
-	defer close(closeChan)
-
-	collectorPort := randomPortNumber()
-	collectorPorts := []string{collectorPort + ":14268"}
-	portForwColl, closeChanColl := CreatePortForward(namespace, "simple-streaming-collector", "jaegertracing/jaeger-collector", collectorPorts, fw.KubeConfig)
-	defer portForwColl.Close()
-	defer close(closeChanColl)
-
-	err = SmokeTest("http://localhost:" + queryPort + "/api/traces", "http://localhost:" + collectorPort + "/api/traces", "foobar", retryInterval, timeout)
-	require.NoError(t, err, "Error running smoketest")
+	SmokeTestWithCollector("simple-streaming-query", "jaegertracing/jaeger-query", "simple-streaming-collector", "jaegertracing/jaeger-collector", "foobar", retryInterval, timeout)
 }
 
 func jaegerStreamingDefinition(namespace string, name string) *v1.Jaeger {


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com>

This simplifies usage of the smoke test by having the smoketest itself handle the port forwarding. This shortens our existing tests, but will also be useful for new tests like ones I will be adding for #144 where I anticipate running the smoke test to validate most of the examplees