### PR TITLE
Further simplify smoke test

### DIFF
--- a/test/e2e/cassandra_test.go
+++ b/test/e2e/cassandra_test.go
@@ -66,7 +66,7 @@ func (suite *CassandraTestSuite) TestCassandra()  {
 	err = e2eutil.WaitForDeployment(t, fw.KubeClient, namespace, "with-cassandra", 1, retryInterval, timeout)
 	require.NoError(t, err, "Error waiting for deployment")
 
-	AllInOneSmokeTest("with-cassandra", "jaegertracing/all-in-one", "foobar", retryInterval, timeout)
+	AllInOneSmokeTest("with-cassandra")
 }
 
 func (suite *CassandraTestSuite) TestCassandraSparkDependencies()  {

--- a/test/e2e/elasticsearch_test.go
+++ b/test/e2e/elasticsearch_test.go
@@ -90,8 +90,7 @@ func (suite *ElasticSearchTestSuite) TestSimpleProd() {
 	err = e2eutil.WaitForDeployment(t, fw.KubeClient, namespace, "simple-prod-query", 1, retryInterval, timeout)
 	require.NoError(t, err, "Error waiting for query deployment")
 
-	ProductionSmokeTest("simple-prod-query", "jaegertracing/jaeger-query", "simple-prod-collector",
-		"jaegertracing/jaeger-collector", "foobar", retryInterval, timeout)
+	ProductionSmokeTest("simple-prod")
 }
 
 func (suite *ElasticSearchTestSuite) TestEsIndexCleaner() {
@@ -106,7 +105,7 @@ func (suite *ElasticSearchTestSuite) TestEsIndexCleaner() {
 	require.NoError(t, err, "Error waiting for deployment")
 
 	// create span, otherwise index cleaner fails - there would not be indices
-	AllInOneSmokeTest(name, "jaegertracing/all-in-one", "foo-bar", retryInterval, timeout)
+	AllInOneSmokeTest(name)
 
 	// Once we've created a span with the smoke test, enable the index cleaer
 	key := types.NamespacedName{Name:name, Namespace:namespace}

--- a/test/e2e/self_provisioned_elasticsearch_test.go
+++ b/test/e2e/self_provisioned_elasticsearch_test.go
@@ -81,7 +81,7 @@ func (suite *SelfProvisionedTestSuite) TestSelfProvisionedESSmokeTest() {
 	err = e2eutil.WaitForDeployment(t, fw.KubeClient, namespace, "simple-prod-query", 1, retryInterval, timeout)
 	require.NoError(t, err, "Error waiting for query deployment")
 
-	ProductionSmokeTest("simple-prod-query", "jaegertracing/jaeger-query", "simple-prod-collector", "jaegertracing/jaeger-collector", "foobar", retryInterval, timeout)
+	ProductionSmokeTest("simple-prod")
 }
 
 func (suite *SelfProvisionedTestSuite) TestValidateEsOperatorImage() {

--- a/test/e2e/streaming_test.go
+++ b/test/e2e/streaming_test.go
@@ -69,7 +69,7 @@ func (suite *StreamingTestSuite) TestStreaming() {
 	err = e2eutil.WaitForDeployment(t, fw.KubeClient, namespace, "simple-streaming-query", 1, retryInterval, timeout)
 	require.NoError(t, err, "Error waiting for query deployment")
 
-	ProductionSmokeTest("simple-streaming-query", "jaegertracing/jaeger-query", "simple-streaming-collector", "jaegertracing/jaeger-collector", "foobar", retryInterval, timeout)
+	ProductionSmokeTest("simple-streaming-query")
 }
 
 func jaegerStreamingDefinition(namespace string, name string) *v1.Jaeger {

--- a/test/e2e/streaming_test.go
+++ b/test/e2e/streaming_test.go
@@ -69,7 +69,7 @@ func (suite *StreamingTestSuite) TestStreaming() {
 	err = e2eutil.WaitForDeployment(t, fw.KubeClient, namespace, "simple-streaming-query", 1, retryInterval, timeout)
 	require.NoError(t, err, "Error waiting for query deployment")
 
-	ProductionSmokeTest("simple-streaming-query")
+	ProductionSmokeTest("simple-streaming")
 }
 
 func jaegerStreamingDefinition(namespace string, name string) *v1.Jaeger {


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com>

This is a follow-up to PR 561.  Once I picked that up and started working on #144 I discovered I could simplify function calls even further, as we were always passing around the same values.
