### PR TITLE
Changed Operator to set ownership of the instances it manages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ e2e-tests-streaming: prepare-e2e-tests es kafka
 .PHONY: run
 run: crd
 	@rm -rf /tmp/_cert*
-	@bash -c 'trap "exit 0" INT; OPERATOR_NAME=${OPERATOR_NAME} KUBERNETES_CONFIG=${KUBERNETES_CONFIG} WATCH_NAMESPACE=${WATCH_NAMESPACE} go run -ldflags ${LD_FLAGS} main.go start ${CLI_FLAGS}'
+	@bash -c 'trap "exit 0" INT; POD_NAMESPACE=default OPERATOR_NAME=${OPERATOR_NAME} KUBERNETES_CONFIG=${KUBERNETES_CONFIG} WATCH_NAMESPACE=${WATCH_NAMESPACE} go run -ldflags ${LD_FLAGS} main.go start ${CLI_FLAGS}'
 
 .PHONY: run-debug
 run-debug: run

--- a/deploy/olm-catalog/jaeger.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/jaeger.clusterserviceversion.yaml
@@ -253,6 +253,10 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.name
+                - name: POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
                 - name: OPERATOR_NAME
                   value: jaeger-operator
                 image: jaegertracing/jaeger-operator:1.13.1

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -29,5 +29,9 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: OPERATOR_NAME
               value: "jaeger-operator"

--- a/pkg/apis/jaegertracing/v1/builder.go
+++ b/pkg/apis/jaegertracing/v1/builder.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"github.com/spf13/viper"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -11,6 +12,9 @@ func NewJaeger(nsn types.NamespacedName) *Jaeger {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      nsn.Name,
 			Namespace: nsn.Namespace,
+			Labels: map[string]string{
+				LabelManagedBy: viper.GetString(ConfigIdentity),
+			},
 		},
 	}
 }

--- a/pkg/apis/jaegertracing/v1/const.go
+++ b/pkg/apis/jaegertracing/v1/const.go
@@ -1,0 +1,9 @@
+package v1
+
+const (
+	// LabelManagedBy is used as the key to the label indicating that this instance is managed by an operator
+	LabelManagedBy string = "app.kubernetes.io/managed-by"
+
+	// ConfigIdentity is the key to the configuration map related to the operator's identity
+	ConfigIdentity string = "identity"
+)

--- a/test/operator.yaml
+++ b/test/operator.yaml
@@ -30,5 +30,9 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: OPERATOR_NAME
               value: "jaeger-operator"


### PR DESCRIPTION
Fixes #567 by setting a `managed-by` value with the `namespace.name` of the operator that manages the instance.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>