### PR TITLE
Get rid of finalizer, clean sidecars when no jaeger instance found

### DIFF
--- a/pkg/controller/jaeger/jaeger_controller.go
+++ b/pkg/controller/jaeger/jaeger_controller.go
@@ -10,7 +10,6 @@ import (
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -21,13 +20,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/autodetect"
-	"github.com/jaegertracing/jaeger-operator/pkg/inject"
 	"github.com/jaegertracing/jaeger-operator/pkg/strategy"
 )
-
-const finalizer = "finalizer.jaegertracing.io"
 
 // Add creates a new Jaeger Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
@@ -136,12 +132,6 @@ func (r *ReconcileJaeger) Reconcile(request reconcile.Request) (reconcile.Result
 
 		logFields.WithField("operator-identity", identity).Debug("configured this operator as the owner of the CR")
 		return reconcile.Result{}, nil
-	}
-
-	if err = r.handleFinalizer(instance.GetDeletionTimestamp() != nil, instance); err != nil || instance.GetDeletionTimestamp() != nil {
-		// if it's marked for deletion or was an error executing finalizer, we need to return a reconcilie result.
-		// otherwise we can continue.
-		return reconcile.Result{}, err
 	}
 
 	// workaround for https://github.com/jaegertracing/jaeger-operator/pull/558
@@ -276,57 +266,4 @@ func (r *ReconcileJaeger) apply(jaeger v1.Jaeger, str strategy.S) (v1.Jaeger, er
 	}
 
 	return jaeger, nil
-}
-
-func containsFinalizer(jaeger *v1.Jaeger, finalizerID string) bool {
-	finalizers := jaeger.GetFinalizers()
-	for _, finalizer := range finalizers {
-		if finalizer == finalizerID {
-			return true
-		}
-	}
-	return false
-}
-
-func (r *ReconcileJaeger) handleFinalizer(deleted bool, jaeger *v1.Jaeger) error {
-	// Is marked for deletion?
-	var err error
-	if deleted {
-		jaeger.Logger().Debug("marked as deleted, executing finalizer")
-		// Execute clean logic
-		opts := client.MatchingLabels(map[string]string{
-			inject.Annotation: jaeger.Name,
-		})
-		depList := &appsv1.DeploymentList{}
-		if err := r.client.List(context.Background(), opts, depList); err != nil {
-			return err
-		}
-		jaeger.Logger().Debug("cleaning sidecars")
-		// Clean deployments.
-		inject.CleanSidecars(depList.Items)
-		for _, d := range depList.Items {
-			jaeger.Logger().WithFields(log.Fields{
-				"deploymentName":      d.Name,
-				"deploymentNamespace": d.Namespace,
-			}).Debug("clean sidecar")
-			if err := r.client.Update(context.Background(), &d); err != nil {
-				jaeger.Logger().WithFields(log.Fields{
-					"deploymentName":      d.Name,
-					"deploymentNamespace": d.Namespace,
-				}).Error(err)
-				continue
-			}
-		}
-		jaeger.Logger().Debug("Removing finalizer")
-		// Set finalizer and update the CR
-		jaeger.SetFinalizers(nil)
-		return r.client.Update(context.Background(), jaeger)
-	}
-	if !containsFinalizer(jaeger, finalizer) {
-		// no marked for deletion and dont' contain finalizer, so we need to add the finalizer to the CR.
-		jaeger.Logger().Debug("Adding finalizer")
-		jaeger.SetFinalizers([]string{finalizer})
-		err = r.client.Update(context.Background(), jaeger)
-	}
-	return err
 }

--- a/pkg/inject/sidecar_test.go
+++ b/pkg/inject/sidecar_test.go
@@ -319,15 +319,9 @@ func TestCleanSidecars(t *testing.T) {
 	}
 	jaeger := v1.NewJaeger(nsn)
 	dep1 := Sidecar(jaeger, dep(map[string]string{Annotation: jaeger.Name}, map[string]string{}))
-	dep2 := Sidecar(jaeger, dep(map[string]string{Annotation: jaeger.Name}, map[string]string{}))
-	dep3 := Sidecar(jaeger, dep(map[string]string{Annotation: jaeger.Name}, map[string]string{}))
-	deployments := []appsv1.Deployment{*dep1, *dep2, *dep3}
-	CleanSidecars(deployments)
-	assert.Equal(t, len(deployments[0].Spec.Template.Spec.Containers), 1)
-	assert.Equal(t, len(deployments[0].Spec.Template.Spec.Containers), 1)
-	assert.Equal(t, len(deployments[0].Spec.Template.Spec.Containers), 1)
-	assert.NotContains(t, deployments[0].Labels, Annotation)
-	assert.NotContains(t, deployments[0].Annotations, Annotation)
+	CleanSidecar(dep1)
+	assert.Equal(t, len(dep1.Spec.Template.Spec.Containers), 1)
+
 }
 
 func TestSidecarWithLabel(t *testing.T) {
@@ -338,13 +332,13 @@ func TestSidecarWithLabel(t *testing.T) {
 	jaeger := v1.NewJaeger(nsn)
 	dep1 := dep(map[string]string{Annotation: jaeger.Name}, map[string]string{})
 	dep1 = Sidecar(jaeger, dep1)
-	assert.Equal(t, dep1.Labels[Annotation], "TestSidecarWithLabel")
+	assert.Equal(t, dep1.Labels[Label], "TestSidecarWithLabel")
 	dep2 := dep(map[string]string{Annotation: jaeger.Name}, map[string]string{})
 	dep2.Labels = map[string]string{"anotherLabel": "anotherValue"}
 	dep2 = Sidecar(jaeger, dep2)
 	assert.Equal(t, len(dep2.Labels), 2)
 	assert.Equal(t, dep2.Labels["anotherLabel"], "anotherValue")
-	assert.Equal(t, dep2.Labels[Annotation], jaeger.Name)
+	assert.Equal(t, dep2.Labels[Label], jaeger.Name)
 }
 
 func dep(annotations map[string]string, labels map[string]string) *appsv1.Deployment {


### PR DESCRIPTION
@jpkrohling 

After thinking about it, it seems like we don't need the finalizer, the thing with the finalizer is that the finalizer give you access to the jaeger instance before k8 deletes it. here I only need the name at the reconciliation request to do the clean of the sidecars.

Fixes #568 
