### PR TITLE
Renamed the ManagedBy label to OperatedBy

### DIFF
--- a/pkg/apis/jaegertracing/v1/builder.go
+++ b/pkg/apis/jaegertracing/v1/builder.go
@@ -13,7 +13,7 @@ func NewJaeger(nsn types.NamespacedName) *Jaeger {
 			Name:      nsn.Name,
 			Namespace: nsn.Namespace,
 			Labels: map[string]string{
-				LabelManagedBy: viper.GetString(ConfigIdentity),
+				LabelOperatedBy: viper.GetString(ConfigIdentity),
 			},
 		},
 	}

--- a/pkg/apis/jaegertracing/v1/const.go
+++ b/pkg/apis/jaegertracing/v1/const.go
@@ -1,8 +1,8 @@
 package v1
 
 const (
-	// LabelManagedBy is used as the key to the label indicating that this instance is managed by an operator
-	LabelManagedBy string = "app.kubernetes.io/managed-by"
+	// LabelOperatedBy is used as the key to the label indicating which operator is managing the instance
+	LabelOperatedBy string = "jaegertracing.io/operated-by"
 
 	// ConfigIdentity is the key to the configuration map related to the operator's identity
 	ConfigIdentity string = "identity"

--- a/pkg/controller/jaeger/jaeger_controller.go
+++ b/pkg/controller/jaeger/jaeger_controller.go
@@ -112,7 +112,7 @@ func (r *ReconcileJaeger) Reconcile(request reconcile.Request) (reconcile.Result
 	// note: we need a namespace-scoped owner identity, which makes the `OwnerReference`
 	// not suitable for this purpose
 	identity := viper.GetString(v1.ConfigIdentity)
-	if val, found := instance.Labels[v1.LabelManagedBy]; found {
+	if val, found := instance.Labels[v1.LabelOperatedBy]; found {
 		if val != identity {
 			// if we are not the ones managing this instance, skip the reconciliation
 			log.WithFields(log.Fields{
@@ -126,7 +126,7 @@ func (r *ReconcileJaeger) Reconcile(request reconcile.Request) (reconcile.Result
 			instance.Labels = map[string]string{}
 		}
 
-		instance.Labels[v1.LabelManagedBy] = identity
+		instance.Labels[v1.LabelOperatedBy] = identity
 		if err := r.client.Update(context.Background(), instance); err != nil {
 			logFields.WithField(
 				"operator-identity", identity,

--- a/pkg/controller/jaeger/jaeger_controller_test.go
+++ b/pkg/controller/jaeger/jaeger_controller_test.go
@@ -191,7 +191,7 @@ func TestSetOwnerOnNewInstance(t *testing.T) {
 	persisted := &v1.Jaeger{}
 	cl.Get(context.Background(), req.NamespacedName, persisted)
 	assert.NotNil(t, persisted.Labels)
-	assert.Equal(t, "my-identity", persisted.Labels["app.kubernetes.io/managed-by"])
+	assert.Equal(t, "my-identity", persisted.Labels[v1.LabelOperatedBy])
 }
 
 func TestSkipOnNonOwnedCR(t *testing.T) {
@@ -202,7 +202,7 @@ func TestSkipOnNonOwnedCR(t *testing.T) {
 	nsn := types.NamespacedName{Name: "my-instance"}
 	jaeger := v1.NewJaeger(nsn)
 	jaeger.Labels = map[string]string{
-		"app.kubernetes.io/managed-by": "another-identity",
+		v1.LabelOperatedBy: "another-identity",
 	}
 
 	s := scheme.Scheme
@@ -221,7 +221,7 @@ func TestSkipOnNonOwnedCR(t *testing.T) {
 	assert.NotNil(t, persisted.Labels)
 
 	// the only way to reliably test this is to verify that the operator didn't attempt to set the ownership field
-	assert.Equal(t, "another-identity", persisted.Labels["app.kubernetes.io/managed-by"])
+	assert.Equal(t, "another-identity", persisted.Labels[v1.LabelOperatedBy])
 }
 
 func getReconciler(objs []runtime.Object) (*ReconcileJaeger, client.Client) {

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -16,7 +16,7 @@ func ManagedInstances(c client.Client) error {
 	list := &v1.JaegerList{}
 	identity := viper.GetString(v1.ConfigIdentity)
 	opts := client.MatchingLabels(map[string]string{
-		v1.LabelManagedBy: identity,
+		v1.LabelOperatedBy: identity,
 	})
 	if err := c.List(context.Background(), opts, list); err != nil {
 		return err
@@ -26,7 +26,7 @@ func ManagedInstances(c client.Client) error {
 		// this check shouldn't have been necessary, as I'd expect the list of items to come filtered out already
 		// but apparently, at least the fake client used in the unit tests doesn't filter it out... so, let's double-check
 		// that we indeed own the item
-		owner := j.Labels[v1.LabelManagedBy]
+		owner := j.Labels[v1.LabelOperatedBy]
 		if owner != identity {
 			log.WithFields(log.Fields{
 				"our-identity":   identity,

--- a/pkg/upgrade/upgrade_test.go
+++ b/pkg/upgrade/upgrade_test.go
@@ -45,7 +45,7 @@ func TestVersionUpgradeToLatestOwnedResource(t *testing.T) {
 
 	existing := v1.NewJaeger(nsn)
 	existing.Labels = map[string]string{
-		v1.LabelManagedBy: viper.GetString(v1.ConfigIdentity),
+		v1.LabelOperatedBy: viper.GetString(v1.ConfigIdentity),
 	}
 	existing.Status.Version = "1.11.0" // this is the first version we have an upgrade function
 	objs := []runtime.Object{existing}
@@ -95,7 +95,7 @@ func TestSkipForNonOwnedInstances(t *testing.T) {
 
 	existing := v1.NewJaeger(nsn)
 	existing.Labels = map[string]string{
-		v1.LabelManagedBy: "some-other-identity",
+		v1.LabelOperatedBy: "some-other-identity",
 	}
 	existing.Status.Version = "1.11.0"
 	objs := []runtime.Object{existing}


### PR DESCRIPTION
Based on the [discussion](https://github.com/jaegertracing/jaeger-operator/pull/571#discussion_r309112130) from #571 and feedback from other sources, I think it's worth having a dedicated label key to indicate which operator is managing the instance, instead of using Kubernetes' `app.kubernetes.io/managed-by`

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>