### PR TITLE
Update tests to permit running with operators installed via OperatorHub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,6 +165,9 @@ endif
 
 .PHONY: undeploy-es-operator
 undeploy-es-operator:
+ifeq ($(OLM),true)
+	@echo Skipping es-operator undeployment, as it should have been installed via OperatorHub
+else
 	@kubectl delete -f https://raw.githubusercontent.com/openshift/elasticsearch-operator/${ES_OPERATOR_BRANCH}/manifests/05-deployment.yaml -n ${ES_OPERATOR_NAMESPACE} || true
 	@kubectl delete -f https://raw.githubusercontent.com/openshift/elasticsearch-operator/${ES_OPERATOR_BRANCH}/manifests/04-crd.yaml -n ${ES_OPERATOR_NAMESPACE} || true
 	@kubectl delete -f https://raw.githubusercontent.com/openshift/elasticsearch-operator/${ES_OPERATOR_BRANCH}/manifests/03-role-bindings.yaml || true
@@ -173,6 +176,7 @@ undeploy-es-operator:
 	@kubectl delete -f https://raw.githubusercontent.com/coreos/prometheus-operator/master/example/prometheus-operator-crd/servicemonitor.crd.yaml || true
 	@kubectl delete -f https://raw.githubusercontent.com/coreos/prometheus-operator/master/example/prometheus-operator-crd/prometheusrule.crd.yaml || true
 	@kubectl delete namespace ${ES_OPERATOR_NAMESPACE} 2>&1 || true
+endif
 
 .PHONY: es
 es: storage
@@ -190,7 +194,7 @@ storage:
 .PHONY: kafka
 kafka:
 ifeq ($(OLM),true)
-	@echo Skipping Kafka deployment, assuming it has been installed via OperatorHub
+	@echo Skipping kafka-operator deployment, assuming it has been installed via OperatorHub
 else
 	@echo Creating namespace $(KAFKA_NAMESPACE)
 	@kubectl create namespace $(KAFKA_NAMESPACE) 2>&1 | grep -v "already exists" || true
@@ -200,8 +204,12 @@ endif
 
 .PHONY: undeploy-kafka
 undeploy-kafka:
+ifeq ($(OLM),true)
+	@echo Skipping kafka-operator undeployment, as it should have been installed via OperatorHub
+else
 	@kubectl delete -f ./test/kafka.yml -n $(KAFKA_NAMESPACE) 2>&1 || true
 	@kubectl delete namespace $(KAFKA_NAMESPACE) 2>&1 || true
+endif
 
 .PHONY: clean
 clean: undeploy-kafka undeploy-es-operator

--- a/test/e2e/all_in_one_test.go
+++ b/test/e2e/all_in_one_test.go
@@ -162,7 +162,7 @@ func (suite *AllInOneTestSuite) TestAllInOneWithUIConfig() {
 
 	queryPort := randomPortNumber()
 	ports := []string{queryPort + ":16686"}
-	portForward, closeChan := CreatePortForward(namespace, "all-in-one-with-ui-config", "jaegertracing/all-in-one", ports, fw.KubeConfig)
+	portForward, closeChan := CreatePortForward(namespace, "all-in-one-with-ui-config", "all-in-one", ports, fw.KubeConfig)
 	defer portForward.Close()
 	defer close(closeChan)
 

--- a/test/e2e/daemonset_test.go
+++ b/test/e2e/daemonset_test.go
@@ -113,7 +113,7 @@ func (suite *DaemonSetTestSuite) TestDaemonSet() {
 
 	queryPort := randomPortNumber()
 	ports := []string{queryPort + ":16686"}
-	portForw, closeChan := CreatePortForward(namespace, "agent-as-daemonset", "jaegertracing/all-in-one", ports, fw.KubeConfig)
+	portForw, closeChan := CreatePortForward(namespace, "agent-as-daemonset", "all-in-one", ports, fw.KubeConfig)
 	defer portForw.Close()
 	defer close(closeChan)
 

--- a/test/e2e/examples1_test.go
+++ b/test/e2e/examples1_test.go
@@ -132,7 +132,7 @@ func (suite *ExamplesTestSuite) TestBusinessApp() {
 	// Confirm that we've created some traces
 	queryPort := randomPortNumber()
 	ports := []string{queryPort + ":16686"}
-	portForward, closeChan := CreatePortForward(namespace, "simplest", "jaegertracing/all-in-one", ports, fw.KubeConfig)
+	portForward, closeChan := CreatePortForward(namespace, "simplest", "all-in-one", ports, fw.KubeConfig)
 	defer portForward.Close()
 	defer close(closeChan)
 

--- a/test/e2e/sidecar_test.go
+++ b/test/e2e/sidecar_test.go
@@ -77,7 +77,7 @@ func (suite *SidecarTestSuite) TestSidecar() {
 
 	queryPort := randomPortNumber()
 	ports := []string{queryPort + ":16686"}
-	portForward, closeChan := CreatePortForward(namespace, "agent-as-sidecar", "jaegertracing/all-in-one", ports, fw.KubeConfig)
+	portForward, closeChan := CreatePortForward(namespace, "agent-as-sidecar", "all-in-one", ports, fw.KubeConfig)
 	defer portForward.Close()
 	defer close(closeChan)
 

--- a/test/e2e/smoketest.go
+++ b/test/e2e/smoketest.go
@@ -15,7 +15,7 @@ import (
 
 // AllInOneSmokeTest is for the all-in-one image, where query and collector use the same pod
 func AllInOneSmokeTest(resourceName string) {
-	allInOneImageName := "jaegertracing/all-in-one"
+	allInOneImageName := "all-in-one"
 	queryPort := randomPortNumber()
 	collectorPort := randomPortNumber()
 	ports := []string{queryPort + ":16686", collectorPort + ":14268"}
@@ -30,8 +30,8 @@ func AllInOneSmokeTest(resourceName string) {
 
 // ProductionSmokeTest should be used if query and collector are in separate pods
 func ProductionSmokeTest(resourceName string) {
-	queryPodImageName := "jaegertracing/jaeger-query"
-	collectorPodImageName := "jaegertracing/jaeger-collector"
+	queryPodImageName := "jaeger-query"
+	collectorPodImageName := "jaeger-collector"
 	queryPodPrefix := resourceName + "-query"
 	collectorPodPrefix := resourceName + "-collector"
 


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com>

This updates the tests to not install the kafka or es-operators so we can test using operators installed via OperatorHub.  

It also fixes a bug with the use of ES_OPERATOR_NAMESPACE in the Makefile.
