### PR TITLE
When using OLM we still need to create and delete the cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,15 +199,15 @@ else
 	@echo Creating namespace $(KAFKA_NAMESPACE)
 	@kubectl create namespace $(KAFKA_NAMESPACE) 2>&1 | grep -v "already exists" || true
 	@sed 's/namespace: .*/namespace: kafka/' ./test/kafka-operator.yml | kubectl -n $(KAFKA_NAMESPACE) apply -f -  2>&1 | grep -v "already exists" || true
-	@kubectl apply -f ./test/kafka.yml -n $(KAFKA_NAMESPACE) 2>&1 | grep -v "already exists" || true
 endif
+	@kubectl apply -f ./test/kafka.yml -n $(KAFKA_NAMESPACE) 2>&1 | grep -v "already exists" || true
 
 .PHONY: undeploy-kafka
 undeploy-kafka:
+	@kubectl delete -f ./test/kafka.yml -n $(KAFKA_NAMESPACE) 2>&1 || true
 ifeq ($(OLM),true)
 	@echo Skipping kafka-operator undeployment, as it should have been installed via OperatorHub
 else
-	@kubectl delete -f ./test/kafka.yml -n $(KAFKA_NAMESPACE) 2>&1 || true
 	@kubectl delete namespace $(KAFKA_NAMESPACE) 2>&1 || true
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -193,11 +193,11 @@ storage:
 
 .PHONY: kafka
 kafka:
+	@echo Creating namespace $(KAFKA_NAMESPACE)
+	@kubectl create namespace $(KAFKA_NAMESPACE) 2>&1 | grep -v "already exists" || true
 ifeq ($(OLM),true)
 	@echo Skipping kafka-operator deployment, assuming it has been installed via OperatorHub
 else
-	@echo Creating namespace $(KAFKA_NAMESPACE)
-	@kubectl create namespace $(KAFKA_NAMESPACE) 2>&1 | grep -v "already exists" || true
 	@sed 's/namespace: .*/namespace: kafka/' ./test/kafka-operator.yml | kubectl -n $(KAFKA_NAMESPACE) apply -f -  2>&1 | grep -v "already exists" || true
 endif
 	@kubectl apply -f ./test/kafka.yml -n $(KAFKA_NAMESPACE) 2>&1 | grep -v "already exists" || true
@@ -205,11 +205,7 @@ endif
 .PHONY: undeploy-kafka
 undeploy-kafka:
 	@kubectl delete -f ./test/kafka.yml -n $(KAFKA_NAMESPACE) 2>&1 || true
-ifeq ($(OLM),true)
-	@echo Skipping kafka-operator undeployment, as it should have been installed via OperatorHub
-else
 	@kubectl delete namespace $(KAFKA_NAMESPACE) 2>&1 || true
-endif
 
 .PHONY: clean
 clean: undeploy-kafka undeploy-es-operator

--- a/Makefile
+++ b/Makefile
@@ -205,6 +205,11 @@ endif
 .PHONY: undeploy-kafka
 undeploy-kafka:
 	@kubectl delete -f ./test/kafka.yml -n $(KAFKA_NAMESPACE) 2>&1 || true
+ifeq ($(OLM),true)
+	@echo Skiping kafka-operator undeploy
+else
+	@kubectl delete -f ./test/kafka-operator.yml 2>&1 || true
+endif
 	@kubectl delete namespace $(KAFKA_NAMESPACE) 2>&1 || true
 
 .PHONY: clean


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com>

This is a follow-on to my previous PR.  I realized even if we've installed the kafka-operator via OLD we still need to create the test cluster.
