### PR TITLE
Use elasticsearch operator 4.2, add workflow for 4.1

### DIFF
--- a/.github/workflows/e2e-openshift-4.1.yaml
+++ b/.github/workflows/e2e-openshift-4.1.yaml
@@ -8,26 +8,25 @@ jobs:
       matrix:
         TEST_GROUP: [es-self-provisioned]
     steps:
-      - uses: jpkrohling/setup-kubectl@v1-release
-      - uses: jpkrohling/setup-operator-sdk@v1-release
-      - uses: actions/checkout@v1
-        with:
-          path: src/github.com/jaegertracing/jaeger-operator # remove when using operator >= 0.9.0
+    - uses: jpkrohling/setup-kubectl@v1-release
+    - uses: jpkrohling/setup-operator-sdk@v1-release
+      with:
+        operator-sdk-version: v0.10.0
+    - uses: actions/checkout@v1
 
-      - name: "setup docker"
-        run: ./.ci/setup-docker.sh
+    - name: "setup docker"
+      run: ./.ci/setup-docker.sh
 
-      - name: "set max_map_count"
-        run: sudo sysctl -w vm.max_map_count=262144
+    - name: "set max_map_count"
+      run: sudo sysctl -w vm.max_map_count=262144
 
-      - name: "start openshift"
-        run: ./.ci/start-openshift.sh
+    - name: "start openshift"
+      run: ./.ci/start-openshift.sh
 
-      - name: "running end to end test"
-        env:
-          GOPATH: /home/runner/work/jaeger-operator #remove when using operator >= 0.9.0
-          CI: true
-          TEST_GROUP: ${{ matrix.TEST_GROUP }}
-          ES_OPERATOR_BRANCH: release-4.1
-          ES_OPERATOR_IMAGE: quay.io/openshift/origin-elasticsearch-operator:4.1
-        run: ./.ci/run-e2e-tests.sh
+    - name: "running end to end test"
+      env:
+        CI: true
+        TEST_GROUP: ${{ matrix.TEST_GROUP }}
+        ES_OPERATOR_BRANCH: release-4.1
+        ES_OPERATOR_IMAGE: quay.io/openshift/origin-elasticsearch-operator:4.1
+      run: ./.ci/run-e2e-tests.sh

--- a/.github/workflows/e2e-openshift-4.1.yaml
+++ b/.github/workflows/e2e-openshift-4.1.yaml
@@ -1,0 +1,33 @@
+name: "OpenShift end-to-end tests, ES operator 4.1"
+on: [push, pull_request]
+
+jobs:
+  end-to-end:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        TEST_GROUP: [es-self-provisioned]
+    steps:
+      - uses: jpkrohling/setup-kubectl@v1-release
+      - uses: jpkrohling/setup-operator-sdk@v1-release
+      - uses: actions/checkout@v1
+        with:
+          path: src/github.com/jaegertracing/jaeger-operator # remove when using operator >= 0.9.0
+
+      - name: "setup docker"
+        run: ./.ci/setup-docker.sh
+
+      - name: "set max_map_count"
+        run: sudo sysctl -w vm.max_map_count=262144
+
+      - name: "start openshift"
+        run: ./.ci/start-openshift.sh
+
+      - name: "running end to end test"
+        env:
+          GOPATH: /home/runner/work/jaeger-operator #remove when using operator >= 0.9.0
+          CI: true
+          TEST_GROUP: ${{ matrix.TEST_GROUP }}
+          ES_OPERATOR_BRANCH: release-4.1
+          ES_OPERATOR_IMAGE: quay.io/openshift/origin-elasticsearch-operator:4.1
+        run: ./.ci/run-e2e-tests.sh

--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,9 @@ OPERATOR_VERSION ?= "$(shell git describe --tags)"
 STORAGE_NAMESPACE ?= "${shell kubectl get sa default -o jsonpath='{.metadata.namespace}' || oc project -q}"
 KAFKA_NAMESPACE ?= "kafka"
 ES_OPERATOR_NAMESPACE ?= openshift-logging
-ES_OPERATOR_BRANCH ?= release-4.1
-ES_OPERATOR_IMAGE ?= quay.io/openshift/origin-elasticsearch-operator:4.1
-SDK_VERSION=v0.10.0
+ES_OPERATOR_BRANCH ?= release-4.2
+ES_OPERATOR_IMAGE ?= quay.io/openshift/origin-elasticsearch-operator:4.2
+SDK_VERSION=v0.8.1
 GOPATH ?= "$(HOME)/go"
 
 LD_FLAGS ?= "-X $(VERSION_PKG).version=$(OPERATOR_VERSION) -X $(VERSION_PKG).buildDate=$(VERSION_DATE) -X $(VERSION_PKG).defaultJaeger=$(JAEGER_VERSION)"
@@ -146,10 +146,18 @@ run-debug: CLI_FLAGS = "--log-level=debug"
 
 .PHONY: set-max-map-count
 set-max-map-count:
+#	This is not required in OCP 4.1. The node tuning operator configures the property automatically
+#	when label tuned.openshift.io/elasticsearch=true label is present on the ES pod. The label
+# is configured by ES operator.
 	@minishift ssh -- 'sudo sysctl -w vm.max_map_count=262144' > /dev/null 2>&1 || true
 
+.PHONY: set-node-os-linux
+set-node-os-linux:
+#	Elasticsearch requires labeled nodes. These labels are by default present in OCP 4.2
+	@oc label nodes --all kubernetes.io/os=linux --overwrite
+
 .PHONY: deploy-es-operator
-deploy-es-operator: set-max-map-count
+deploy-es-operator: set-node-os-linux set-max-map-count
 ifeq ($(OLM),true)
 	@echo Skipping es-operator deployment, assuming it has been installed via OperatorHub
 else

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ KAFKA_NAMESPACE ?= "kafka"
 ES_OPERATOR_NAMESPACE ?= openshift-logging
 ES_OPERATOR_BRANCH ?= release-4.2
 ES_OPERATOR_IMAGE ?= quay.io/openshift/origin-elasticsearch-operator:4.2
-SDK_VERSION=v0.8.1
+SDK_VERSION=v0.10.0
 GOPATH ?= "$(HOME)/go"
 
 LD_FLAGS ?= "-X $(VERSION_PKG).version=$(OPERATOR_VERSION) -X $(VERSION_PKG).buildDate=$(VERSION_DATE) -X $(VERSION_PKG).defaultJaeger=$(JAEGER_VERSION)"
@@ -146,14 +146,14 @@ run-debug: CLI_FLAGS = "--log-level=debug"
 
 .PHONY: set-max-map-count
 set-max-map-count:
-#	This is not required in OCP 4.1. The node tuning operator configures the property automatically
-#	when label tuned.openshift.io/elasticsearch=true label is present on the ES pod. The label
-# is configured by ES operator.
+	# This is not required in OCP 4.1. The node tuning operator configures the property automatically
+	# when label tuned.openshift.io/elasticsearch=true label is present on the ES pod. The label
+	# is configured by ES operator.
 	@minishift ssh -- 'sudo sysctl -w vm.max_map_count=262144' > /dev/null 2>&1 || true
 
 .PHONY: set-node-os-linux
 set-node-os-linux:
-#	Elasticsearch requires labeled nodes. These labels are by default present in OCP 4.2
+	# Elasticsearch requires labeled nodes. These labels are by default present in OCP 4.2
 	@kubectl label nodes --all kubernetes.io/os=linux --overwrite
 
 .PHONY: deploy-es-operator

--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ set-max-map-count:
 .PHONY: set-node-os-linux
 set-node-os-linux:
 #	Elasticsearch requires labeled nodes. These labels are by default present in OCP 4.2
-	@oc label nodes --all kubernetes.io/os=linux --overwrite
+	@kubectl label nodes --all kubernetes.io/os=linux --overwrite
 
 .PHONY: deploy-es-operator
 deploy-es-operator: set-node-os-linux set-max-map-count


### PR DESCRIPTION
* Deploy ES 4.2 by default
* Add workflow to test ES operator 4.1

Es operator 4.2 uses operator SDK `v0.7.0`. I think we should keep copied ES CR model files to allows us to update SDK to newer versions e.g. #609 

Signed-off-by: Pavol Loffay <ploffay@redhat.com>