### PR TITLE
fix #644, included Log Out menu option in the default CR file

### DIFF
--- a/deploy/olm-catalog/jaeger.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/jaeger.clusterserviceversion.yaml
@@ -41,13 +41,18 @@ metadata:
                 },
                 "menu": [
                   {
-                    "label": "About Jaeger",
+                    "label": "About",
                     "items": [
                       {
                         "label": "Documentation",
                         "url": "https://www.jaegertracing.io/docs/latest"
                       }
                     ]
+                  },
+                  {
+                    "label":"Log Out",
+                    "url":"/oauth/sign_in",
+                    "anchorTarget":"_self"
                   }
                 ]
               }


### PR DESCRIPTION
* Included `Log Out` option
* Changed `About Jaeger` to `Jaeger`. [source for this change](https://github.com/jaegertracing/jaeger-operator/blob/220fe8426113dc98a6cfbb41157276ff15e29c27/pkg/strategy/controller.go#L235~L248)