### PR TITLE
Add wait for ingester to fix streaming test failures

### DIFF
--- a/test/e2e/examples1_test.go
+++ b/test/e2e/examples1_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
-	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -96,7 +95,7 @@ func (suite *ExamplesTestSuite) TestBusinessApp() {
 	// First deploy a Jaeger instance
 	jaegerInstance := createJaegerInstanceFromFile("simplest", "../../deploy/examples/simplest.yaml")
 	defer undeployJaegerInstance(jaegerInstance)
-	err := e2eutil.WaitForDeployment(t, fw.KubeClient, namespace, "simplest", 1, retryInterval, timeout)
+	err := waitForDeployment(t, fw.KubeClient, namespace, "simplest", 1, retryInterval, timeout)
 	require.NoError(t, err)
 
 	// Now deploy deploy/examples/business-application-injected-sidecar.yaml
@@ -105,7 +104,7 @@ func (suite *ExamplesTestSuite) TestBusinessApp() {
 	if err != nil && !strings.Contains(string(output), "AlreadyExists") {
 		require.NoError(t, err, "Failed creating Jaeger instance with: [%s]\n", string(output))
 	}
-	err = e2eutil.WaitForDeployment(t, fw.KubeClient, namespace, "myapp", 1, retryInterval, timeout)
+	err = waitForDeployment(t, fw.KubeClient, namespace, "myapp", 1, retryInterval, timeout)
 	require.NoError(t, err, "Failed waiting for myapp deployment")
 
 	// Add a liveliness probe to create some traces

--- a/test/e2e/examples2_test.go
+++ b/test/e2e/examples2_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
-	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -81,7 +80,7 @@ func (suite *ExamplesTestSuite2) TestWithSampling() {
 	jaegerInstance := createJaegerInstanceFromFile(name, yamlFileName)
 	defer undeployJaegerInstance(jaegerInstance)
 
-	err := e2eutil.WaitForDeployment(t, fw.KubeClient, namespace, name, 1, retryInterval, timeout)
+	err := waitForDeployment(t, fw.KubeClient, namespace, name, 1, retryInterval, timeout)
 	require.NoErrorf(t, err, "Error waiting for %s to deploy", name)
 
 	// Check sampling options.  t would be nice to create some spans and check that they are being sampled at the correct rate

--- a/test/e2e/streaming_test.go
+++ b/test/e2e/streaming_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
-	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -63,10 +62,13 @@ func (suite *StreamingTestSuite) TestStreaming() {
 	require.NoError(t, err, "Error deploying jaeger")
 	defer undeployJaegerInstance(j)
 
-	err = e2eutil.WaitForDeployment(t, fw.KubeClient, namespace, "simple-streaming-collector", 1, retryInterval, timeout)
+	err = waitForDeployment(t, fw.KubeClient, namespace, "simple-streaming-ingester", 1, retryInterval, timeout)
+	require.NoError(t, err, "Error waiting for ingester deployment")
+
+	err = waitForDeployment(t, fw.KubeClient, namespace, "simple-streaming-collector", 1, retryInterval, timeout)
 	require.NoError(t, err, "Error waiting for collector deployment")
 
-	err = e2eutil.WaitForDeployment(t, fw.KubeClient, namespace, "simple-streaming-query", 1, retryInterval, timeout)
+	err = waitForDeployment(t, fw.KubeClient, namespace, "simple-streaming-query", 1, retryInterval, timeout)
 	require.NoError(t, err, "Error waiting for query deployment")
 
 	ProductionSmokeTest("simple-streaming")

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -293,7 +293,7 @@ func smokeTestProductionExample(name, yamlFileName string) {
 	queryDeploymentName := name + "-query"
 	collectorDeploymentName := name + "-collector"
 
-	if name == "simple-streaming" {
+	if jaegerInstance.Spec.Strategy == "streaming" {
 		ingesterDeploymentName := name + "-ingester"
 		err := waitForDeployment(t, fw.KubeClient, namespace, ingesterDeploymentName, 1, retryInterval, timeout)
 		require.NoErrorf(t, err, "Error waiting for %s to deploy", ingesterDeploymentName)

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -15,6 +15,7 @@ import (
 	osv1sec "github.com/openshift/api/security/v1"
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -279,7 +280,7 @@ func smokeTestAllInOneExample(name, yamlFileName string) {
 	jaegerInstance := createJaegerInstanceFromFile(name, yamlFileName)
 	defer undeployJaegerInstance(jaegerInstance)
 
-	err := e2eutil.WaitForDeployment(t, fw.KubeClient, namespace, name, 1, retryInterval, timeout)
+	err := waitForDeployment(t, fw.KubeClient, namespace, name, 1, retryInterval, timeout)
 	require.NoErrorf(t, err, "Error waiting for %s to deploy", name)
 
 	AllInOneSmokeTest(name)
@@ -292,10 +293,24 @@ func smokeTestProductionExample(name, yamlFileName string) {
 	queryDeploymentName := name + "-query"
 	collectorDeploymentName := name + "-collector"
 
-	err := e2eutil.WaitForDeployment(t, fw.KubeClient, namespace, queryDeploymentName, 1, retryInterval, timeout)
+	if name == "simple-streaming" {
+		ingesterDeploymentName := name + "-ingester"
+		err := waitForDeployment(t, fw.KubeClient, namespace, ingesterDeploymentName, 1, retryInterval, timeout)
+		require.NoErrorf(t, err, "Error waiting for %s to deploy", ingesterDeploymentName)
+	}
+
+	err := waitForDeployment(t, fw.KubeClient, namespace, queryDeploymentName, 1, retryInterval, timeout)
 	require.NoErrorf(t, err, "Error waiting for %s to deploy", queryDeploymentName)
-	err = e2eutil.WaitForDeployment(t, fw.KubeClient, namespace, collectorDeploymentName, 1, retryInterval, timeout)
+	err = waitForDeployment(t, fw.KubeClient, namespace, collectorDeploymentName, 1, retryInterval, timeout)
 	require.NoErrorf(t, err, "Error waiting for %s to deploy", collectorDeploymentName)
 
 	ProductionSmokeTest(name)
+}
+
+func waitForDeployment(t *testing.T, kubeclient kubernetes.Interface, namespace, name string, replicas int, retryInterval, timeout time.Duration) error {
+	start := time.Now()
+	err := e2eutil.WaitForDeployment(t, fw.KubeClient, namespace, name, 1, retryInterval, timeout)
+	elapsed := time.Since(start)
+	log.Infof("Deployment of %s in namespace %s took %s\n", name, namespace, elapsed)
+	return err
 }

--- a/test/e2e/wait_util.go
+++ b/test/e2e/wait_util.go
@@ -14,6 +14,7 @@ import (
 // WaitForStatefulset checks to see if a given statefulset has the desired number of replicas available after a specified amount of time
 // See #WaitForDeployment for the full semantics
 func WaitForStatefulset(t *testing.T, kubeclient kubernetes.Interface, namespace, name string, retryInterval, timeout time.Duration) error {
+	start := time.Now()
 	err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
 		statefulset, err := kubeclient.AppsV1().StatefulSets(namespace).Get(name, metav1.GetOptions{IncludeUninitialized: true})
 		if err != nil {
@@ -31,15 +32,17 @@ func WaitForStatefulset(t *testing.T, kubeclient kubernetes.Interface, namespace
 		return false, nil
 	})
 	if err != nil {
+		t.Logf("Failed waiting for statefulset after %s\n", time.Since(start))
 		return err
 	}
-	t.Logf("Statefulset available\n")
+	t.Logf("Statefulset available after %s\n", time.Since(start))
 	return nil
 }
 
 // WaitForDaemonSet checks to see if a given daemonset has the desired number of instances available after a specified amount of time
 // See #WaitForDeployment for the full semantics
 func WaitForDaemonSet(t *testing.T, kubeclient kubernetes.Interface, namespace, name string, retryInterval, timeout time.Duration) error {
+	start := time.Now()
 	err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
 		daemonset, err := kubeclient.AppsV1().DaemonSets(namespace).Get(name, metav1.GetOptions{IncludeUninitialized: true})
 		if err != nil {
@@ -57,15 +60,17 @@ func WaitForDaemonSet(t *testing.T, kubeclient kubernetes.Interface, namespace, 
 		return false, nil
 	})
 	if err != nil {
+		t.Logf("Failed waiting for daemonset after %s\n", time.Since(start))
 		return err
 	}
-	t.Logf("DaemonSet available\n")
+	t.Logf("DaemonSet available after %s\n", time.Since(start))
 	return nil
 }
 
 // WaitForIngress checks to see if a given ingress' load balancer is ready after a specified amount of time
 // See #WaitForDeployment for the full semantics
 func WaitForIngress(t *testing.T, kubeclient kubernetes.Interface, namespace, name string, retryInterval, timeout time.Duration) (*v1beta1.Ingress, error) {
+	start := time.Now()
 	var ingress *v1beta1.Ingress
 	err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
 		ingress, err = kubeclient.ExtensionsV1beta1().Ingresses(namespace).Get(name, metav1.GetOptions{IncludeUninitialized: true})
@@ -84,15 +89,17 @@ func WaitForIngress(t *testing.T, kubeclient kubernetes.Interface, namespace, na
 		return false, nil
 	})
 	if err != nil {
+		t.Logf("Failed waiting for ingress after %s\n", time.Since(start))
 		return ingress, err
 	}
-	t.Logf("Ingress available\n")
+	t.Logf("Ingress available after %s\n", time.Since(start))
 	return ingress, nil
 }
 
 // WaitForJob checks to see if a given job has completed successfuly
 // See #WaitForDeployment for the full semantics
 func WaitForJob(t *testing.T, kubeclient kubernetes.Interface, namespace, name string, retryInterval, timeout time.Duration) error {
+	start := time.Now()
 	err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
 		job, err := kubeclient.BatchV1().Jobs(namespace).Get(name, metav1.GetOptions{IncludeUninitialized: true})
 		if err != nil {
@@ -110,15 +117,18 @@ func WaitForJob(t *testing.T, kubeclient kubernetes.Interface, namespace, name s
 		return false, nil
 	})
 	if err != nil {
+		t.Logf("Failed waiting for job after %s\n", time.Since(start))
 		return err
 	}
-	t.Logf("Jobs succeeded\n")
+	t.Logf("Jobs succeeded after %s\n", time.Since(start))
 	return nil
 }
 
 // WaitForJobOfAnOwner checks to see if a given job has completed successfully
 // See #WaitForDeployment for the full semantics
 func WaitForJobOfAnOwner(t *testing.T, kubeclient kubernetes.Interface, namespace, ownerName string, retryInterval, timeout time.Duration) error {
+	start := time.Now()
+
 	err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
 		jobList, err := kubeclient.BatchV1().Jobs(namespace).List(metav1.ListOptions{IncludeUninitialized: true})
 		if err != nil {
@@ -139,6 +149,7 @@ func WaitForJobOfAnOwner(t *testing.T, kubeclient kubernetes.Interface, namespac
 		return false, nil
 	})
 	if err != nil {
+		t.Logf("Failed waiting for job of an owner after %s\n", time.Since(start))
 		return err
 	}
 	t.Logf("Jobs succeeded\n")
@@ -148,6 +159,7 @@ func WaitForJobOfAnOwner(t *testing.T, kubeclient kubernetes.Interface, namespac
 // WaitForCronJob checks to see if a given cron job scheduled a job
 // See #WaitForDeployment for the full semantics
 func WaitForCronJob(t *testing.T, kubeclient kubernetes.Interface, namespace, name string, retryInterval, timeout time.Duration) error {
+	start := time.Now()
 	err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
 		cronJob, err := kubeclient.BatchV1beta1().CronJobs(namespace).Get(name, metav1.GetOptions{IncludeUninitialized: true})
 		if err != nil {
@@ -164,8 +176,9 @@ func WaitForCronJob(t *testing.T, kubeclient kubernetes.Interface, namespace, na
 		return false, nil
 	})
 	if err != nil {
+		t.Logf("Failed waiting for cronjob after %s\n", time.Since(start))
 		return err
 	}
-	t.Logf("CronJob succeeded\n")
+	t.Logf("CronJob succeeded after %s\n", time.Since(start))
 	return nil
 }

--- a/test/e2e/wait_util.go
+++ b/test/e2e/wait_util.go
@@ -128,7 +128,6 @@ func WaitForJob(t *testing.T, kubeclient kubernetes.Interface, namespace, name s
 // See #WaitForDeployment for the full semantics
 func WaitForJobOfAnOwner(t *testing.T, kubeclient kubernetes.Interface, namespace, ownerName string, retryInterval, timeout time.Duration) error {
 	start := time.Now()
-
 	err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
 		jobList, err := kubeclient.BatchV1().Jobs(namespace).List(metav1.ListOptions{IncludeUninitialized: true})
 		if err != nil {
@@ -152,7 +151,7 @@ func WaitForJobOfAnOwner(t *testing.T, kubeclient kubernetes.Interface, namespac
 		t.Logf("Failed waiting for job of an owner after %s\n", time.Since(start))
 		return err
 	}
-	t.Logf("Jobs succeeded\n")
+	t.Logf("Jobs succeeded after %s\n", time.Since(start))
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com>

Adding a wait for deployment of the ingester in streaming tests in order to try to eliminate Github build failures.  Also adding some timing on wait steps to try to help with future errors.

