### PR TITLE
Load env variables in the given secretName in Spark dependencies

### DIFF
--- a/pkg/cronjob/spark_dependencies.go
+++ b/pkg/cronjob/spark_dependencies.go
@@ -32,6 +32,17 @@ func CreateSparkDependencies(jaeger *v1.Jaeger) *batchv1beta1.CronJob {
 	}
 	envVars = append(envVars, getStorageEnvs(jaeger.Spec.Storage)...)
 
+	var envFromSource []corev1.EnvFromSource
+	if len(jaeger.Spec.Storage.SecretName) > 0 {
+		envFromSource = append(envFromSource, corev1.EnvFromSource{
+			SecretRef: &corev1.SecretEnvSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: jaeger.Spec.Storage.SecretName,
+				},
+			},
+		})
+	}
+
 	trueVar := true
 	one := int32(1)
 	name := fmt.Sprintf("%s-spark-dependencies", jaeger.Name)
@@ -82,6 +93,7 @@ func CreateSparkDependencies(jaeger *v1.Jaeger) *batchv1beta1.CronJob {
 									Name:  name,
 									// let spark job use its default values
 									Env:       removeEmptyVars(envVars),
+									EnvFrom:   envFromSource,
 									Resources: commonSpec.Resources,
 								},
 							},

--- a/pkg/cronjob/spark_dependencies_test.go
+++ b/pkg/cronjob/spark_dependencies_test.go
@@ -79,8 +79,8 @@ func TestCreate(t *testing.T) {
 	assert.NotNil(t, CreateSparkDependencies(&v1.Jaeger{Spec: v1.JaegerSpec{Storage: v1.JaegerStorageSpec{Type: "elasticsearch"}}}))
 }
 
-func TestSparkDependenciesSecretSecrets(t *testing.T) {
-	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestSparkDependenciesSecretSecrets"})
+func TestSparkDependenciesSecrets(t *testing.T) {
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestSparkDependenciesSecrets"})
 	secret := "mysecret"
 	jaeger.Spec.Storage.SecretName = secret
 

--- a/pkg/cronjob/spark_dependencies_test.go
+++ b/pkg/cronjob/spark_dependencies_test.go
@@ -87,6 +87,8 @@ func TestSparkDependenciesSecrets(t *testing.T) {
 	days := 0
 	jaeger.Spec.Storage.EsIndexCleaner.NumberOfDays = &days
 	cronJob := CreateSparkDependencies(jaeger)
+	assert.Len(t, cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers, 1)
+	assert.Len(t, cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].EnvFrom, 1)
 	assert.Equal(t, secret, cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].EnvFrom[0].SecretRef.LocalObjectReference.Name)
 }
 

--- a/pkg/cronjob/spark_dependencies_test.go
+++ b/pkg/cronjob/spark_dependencies_test.go
@@ -79,6 +79,17 @@ func TestCreate(t *testing.T) {
 	assert.NotNil(t, CreateSparkDependencies(&v1.Jaeger{Spec: v1.JaegerSpec{Storage: v1.JaegerStorageSpec{Type: "elasticsearch"}}}))
 }
 
+func TestSparkDependenciesSecretSecrets(t *testing.T) {
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestSparkDependenciesSecretSecrets"})
+	secret := "mysecret"
+	jaeger.Spec.Storage.SecretName = secret
+
+	days := 0
+	jaeger.Spec.Storage.EsIndexCleaner.NumberOfDays = &days
+	cronJob := CreateSparkDependencies(jaeger)
+	assert.Equal(t, secret, cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].EnvFrom[0].SecretRef.LocalObjectReference.Name)
+}
+
 func TestSparkDependencies(t *testing.T) {
 	j := &v1.Jaeger{Spec: v1.JaegerSpec{Storage: v1.JaegerStorageSpec{Type: "elasticsearch"}}}
 


### PR DESCRIPTION
So, I store the Elasticsearch credentials in a secret which I then pass in the `storage.secretName` parameter. These credentials are then correctly loaded by the collector, the query and the Elasticsearch cleaner cronjob, but not by Spark dependencies.

I am noob Go programmer so feel free to edit this piece of code as you see fit.