### PR TITLE
Add waitForDeployment on agent-as-daemonset to avoid test failures

### DIFF
--- a/test/e2e/examples1_test.go
+++ b/test/e2e/examples1_test.go
@@ -75,6 +75,9 @@ func (suite *ExamplesTestSuite) TestAgentAsDaemonSet() {
 	err := WaitForDaemonSet(t, fw.KubeClient, namespace, name+"-agent-daemonset", retryInterval, timeout)
 	require.NoError(t, err)
 
+	err = waitForDeployment(t, fw.KubeClient, namespace, "agent-as-daemonset", 1, retryInterval, timeout)
+	require.NoError(t, err)
+
 	AllInOneSmokeTest(name)
 }
 


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com>