### PR TITLE
Add hostnetworking & dnspolicy to agent daemonset

### DIFF
--- a/pkg/deployment/agent.go
+++ b/pkg/deployment/agent.go
@@ -151,6 +151,8 @@ func (a *Agent) Get() *appsv1.DaemonSet {
 						},
 						Resources: commonSpec.Resources,
 					}},
+					HostNetwork:        true,
+					DNSPolicy:          corev1.DNSClusterFirstWithHostNet,
 					Affinity:           commonSpec.Affinity,
 					Tolerations:        commonSpec.Tolerations,
 					SecurityContext:    commonSpec.SecurityContext,

--- a/pkg/deployment/agent_test.go
+++ b/pkg/deployment/agent_test.go
@@ -147,6 +147,24 @@ func TestDaemonSetAgentResources(t *testing.T) {
 	assert.Equal(t, *resource.NewQuantity(512, resource.DecimalSI), dep.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceRequestsEphemeralStorage])
 }
 
+func TestDaemonSetAgentHostNetwork(t *testing.T) {
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestDaemonSetAgentHostNetwork"})
+	jaeger.Spec.Agent.Strategy = "daemonset"
+	agent := NewAgent(jaeger)
+	dep := agent.Get()
+
+	assert.Equal(t, true, dep.Spec.Template.Spec.HostNetwork)
+}
+
+func TestDaemonSetAgentDnsPolicy(t *testing.T) {
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestDaemonSetAgentDnsPolicy"})
+	jaeger.Spec.Agent.Strategy = "daemonset"
+	agent := NewAgent(jaeger)
+	dep := agent.Get()
+
+	assert.Equal(t, corev1.DNSClusterFirstWithHostNet, dep.Spec.Template.Spec.DNSPolicy)
+}
+
 func TestAgentLabels(t *testing.T) {
 	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestAgentLabels"})
 	jaeger.Spec.Agent.Strategy = "daemonset"


### PR DESCRIPTION
These 2 properties are available in the jaeger production template,
but missing when the daemonset is created via the operator

Fixes #676