### PR TITLE
Add support for TLS on ingress

### DIFF
--- a/pkg/apis/jaegertracing/v1/jaeger_types.go
+++ b/pkg/apis/jaegertracing/v1/jaeger_types.go
@@ -188,6 +188,9 @@ type JaegerIngressSpec struct {
 	OpenShift JaegerIngressOpenShiftSpec `json:"openshift,omitempty"`
 
 	// +optional
+	SecretName string `json:"secretName,omitempty"`
+
+	// +optional
 	JaegerCommonSpec `json:",inline,omitempty"`
 }
 

--- a/pkg/ingress/query.go
+++ b/pkg/ingress/query.go
@@ -57,12 +57,7 @@ func (i *QueryIngress) Get() *extv1beta1.Ingress {
 		spec.Backend = &backend
 	}
 
-	secretName := i.jaeger.Spec.Ingress.SecretName
-	if secretName != "" {
-		spec.TLS = append(spec.TLS, extv1beta1.IngressTLS{
-			SecretName: secretName,
-		})
-	}
+	i.addTLSSpec(spec)
 
 	return &extv1beta1.Ingress{
 		TypeMeta: metav1.TypeMeta{
@@ -85,6 +80,15 @@ func (i *QueryIngress) Get() *extv1beta1.Ingress {
 			Annotations: commonSpec.Annotations,
 		},
 		Spec: spec,
+	}
+}
+
+func (i *QueryIngress) addTLSSpec(spec extv1beta1.IngressSpec) {
+	secretName := i.jaeger.Spec.Ingress.SecretName
+	if secretName != "" {
+		spec.TLS = append(spec.TLS, extv1beta1.IngressTLS{
+			SecretName: secretName,
+		})
 	}
 }
 

--- a/pkg/ingress/query.go
+++ b/pkg/ingress/query.go
@@ -57,6 +57,13 @@ func (i *QueryIngress) Get() *extv1beta1.Ingress {
 		spec.Backend = &backend
 	}
 
+	secretName := i.jaeger.Spec.Ingress.SecretName
+	if secretName != "" {
+		spec.TLS = append(spec.TLS, extv1beta1.IngressTLS{
+			SecretName: secretName,
+		})
+	}
+
 	return &extv1beta1.Ingress{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Ingress",

--- a/pkg/ingress/query.go
+++ b/pkg/ingress/query.go
@@ -57,7 +57,7 @@ func (i *QueryIngress) Get() *extv1beta1.Ingress {
 		spec.Backend = &backend
 	}
 
-	i.addTLSSpec(spec)
+	i.addTLSSpec(&spec)
 
 	return &extv1beta1.Ingress{
 		TypeMeta: metav1.TypeMeta{
@@ -83,7 +83,7 @@ func (i *QueryIngress) Get() *extv1beta1.Ingress {
 	}
 }
 
-func (i *QueryIngress) addTLSSpec(spec extv1beta1.IngressSpec) {
+func (i *QueryIngress) addTLSSpec(spec *extv1beta1.IngressSpec) {
 	secretName := i.jaeger.Spec.Ingress.SecretName
 	if secretName != "" {
 		spec.TLS = append(spec.TLS, extv1beta1.IngressTLS{

--- a/pkg/ingress/query_test.go
+++ b/pkg/ingress/query_test.go
@@ -119,3 +119,13 @@ func TestQueryIngressLabels(t *testing.T) {
 	assert.Equal(t, "world", dep.Labels["hello"])
 	assert.Equal(t, "false", dep.Labels["another"])
 }
+
+func TestQueryIngressTLSSecret(t *testing.T) {
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestQueryIngressTLSSecret"})
+	jaeger.Spec.Ingress.SecretName = "test-secret"
+
+	ingress := NewQueryIngress(jaeger)
+	dep := ingress.Get()
+
+	assert.Equal(t, "test-secret", dep.Spec.TLS[0].SecretName)
+}


### PR DESCRIPTION
Fixes #85.

I didn't add the auto lookup of an existing secret like `<instance-name>-tls-secret`. This would require the client to be accessible in `ingress/query.go`.