### PR TITLE
Add Prometheus scrape annotations to agent

### DIFF
--- a/pkg/inject/sidecar.go
+++ b/pkg/inject/sidecar.go
@@ -24,6 +24,11 @@ var (
 	Label = "sidecar.jaegertracing.io/injected"
 	// AnnotationLegacy holds the annotation name we had in the past, which we keep for backwards compatibility
 	AnnotationLegacy = "inject-jaeger-agent"
+	// PrometheusDefaultAnnotations is a map containing annotations for prometheus to be inserted at sidecar in case it doesn't have any
+	PrometheusDefaultAnnotations = map[string]string{
+		"prometheus.io/scrape": "true",
+		"prometheus.io/port":   "5778",
+	}
 )
 
 const (
@@ -210,6 +215,13 @@ func decorate(dep *appsv1.Deployment) {
 			}
 		}
 	}
+	for key, value := range PrometheusDefaultAnnotations {
+		_, ok := dep.Annotations[key]
+		if !ok {
+			dep.Annotations[key] = value
+		}
+	}
+
 }
 
 func hasEnv(name string, vars []corev1.EnvVar) bool {

--- a/pkg/inject/sidecar_test.go
+++ b/pkg/inject/sidecar_test.go
@@ -386,6 +386,36 @@ func TestSidecarWithLabel(t *testing.T) {
 	assert.Equal(t, dep2.Labels[Label], jaeger.Name)
 }
 
+func TestSidecarWithoutPrometheusAnnotations(t *testing.T) {
+	// prepare
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestSidecarWithoutPrometheusAnnotations"})
+	dep := Sidecar(jaeger, dep(map[string]string{Annotation: jaeger.Name}, map[string]string{}))
+
+	// test
+	dep = Sidecar(jaeger, dep)
+
+	// verify
+	assert.Contains(t, dep.Annotations, "prometheus.io/scrape")
+	assert.Contains(t, dep.Annotations, "prometheus.io/port")
+}
+
+func TestSidecarWithPrometheusAnnotations(t *testing.T) {
+	// prepare
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestSidecarWithPrometheusAnnotations"})
+	dep := dep(map[string]string{
+		Annotation:             jaeger.Name,
+		"prometheus.io/scrape": "false",
+		"prometheus.io/port":   "9090",
+	}, map[string]string{})
+
+	// test
+	dep = Sidecar(jaeger, dep)
+
+	// verify
+	assert.Equal(t, dep.Annotations["prometheus.io/scrape"], "false")
+	assert.Equal(t, dep.Annotations["prometheus.io/port"], "9090")
+}
+
 func dep(annotations map[string]string, labels map[string]string) *appsv1.Deployment {
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
As discussed in #28, it was created a way to insert prometheus annotations at agents that are deployed as sidecars so it won't overwrite similar annotations provided by the service.

Closes #28