### PR TITLE
Updated the business-application example

### DIFF
--- a/deploy/examples/business-application-injected-sidecar.yaml
+++ b/deploy/examples/business-application-injected-sidecar.yaml
@@ -12,7 +12,12 @@ spec:
     metadata:
       labels:
         app: myapp
+      annotations:
+        sidecar.istio.io/inject: "true"
     spec:
       containers:
       - name: myapp
         image: jaegertracing/vertx-create-span:operator-e2e-tests
+        ports:
+        - containerPort: 8080
+          protocol: TCP


### PR DESCRIPTION
1. Added the container ports + names, so that 'kubectl expose deployment myapp' creates the appropriate ports
2. Added annotation instructing Istio to inject its sidecar proxy

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>