### PR TITLE
New DeploymentStrategy type for JaegerSpec.Strategy 

### DIFF
--- a/pkg/apis/jaegertracing/v1/deployment_strategy.go
+++ b/pkg/apis/jaegertracing/v1/deployment_strategy.go
@@ -1,0 +1,49 @@
+package v1
+
+import (
+	"errors"
+	"strings"
+)
+
+// DeploymentStrategy represents the possible values for deployment strategies
+// +k8s:openapi-gen=true
+type DeploymentStrategy string
+
+const (
+	// DeploymentStrategyDeprecatedAllInOne represents the (deprecated) 'all-in-one' deployment strategy
+	// +k8s:openapi-gen=true
+	DeploymentStrategyDeprecatedAllInOne DeploymentStrategy = "all-in-one"
+
+	// DeploymentStrategyAllInOne represents the 'allInOne' deployment strategy (default)
+	// +k8s:openapi-gen=true
+	DeploymentStrategyAllInOne DeploymentStrategy = "allinone"
+
+	// DeploymentStrategyStreaming represents the 'streaming' deployment strategy
+	// +k8s:openapi-gen=true
+	DeploymentStrategyStreaming DeploymentStrategy = "streaming"
+
+	// DeploymentStrategyProduction represents the 'production' deployment strategy
+	// +k8s:openapi-gen=true
+	DeploymentStrategyProduction DeploymentStrategy = "production"
+)
+
+// UnmarshalText implements encoding.TextUnmarshaler to ensure that JSON values in the
+// strategy field of JSON jaeger specs are interpreted in a case-insensitive manner
+func (ds *DeploymentStrategy) UnmarshalText(text []byte) error {
+	if ds == nil {
+		return errors.New("DeploymentStrategy: UnmarshalText on nil pointer")
+	}
+
+	switch strings.ToLower(string(text)) {
+	default:
+		*ds = DeploymentStrategyAllInOne
+	case string(DeploymentStrategyDeprecatedAllInOne):
+		*ds = DeploymentStrategyDeprecatedAllInOne
+	case string(DeploymentStrategyStreaming):
+		*ds = DeploymentStrategyStreaming
+	case string(DeploymentStrategyProduction):
+		*ds = DeploymentStrategyProduction
+	}
+
+	return nil
+}

--- a/pkg/apis/jaegertracing/v1/deployment_strategy_test.go
+++ b/pkg/apis/jaegertracing/v1/deployment_strategy_test.go
@@ -1,0 +1,55 @@
+package v1
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnmarshalJSON(t *testing.T) {
+	tcs := map[string]struct {
+		json     string
+		expected DeploymentStrategy
+	}{
+		"allInOne":     {json: `"allInOne"`, expected: DeploymentStrategyAllInOne},
+		"streaming":    {json: `"streaming"`, expected: DeploymentStrategyStreaming},
+		"production":   {json: `"production"`, expected: DeploymentStrategyProduction},
+		"all-in-one":   {json: `"all-in-one"`, expected: DeploymentStrategyDeprecatedAllInOne},
+		"ALLinONE":     {json: `"ALLinONE"`, expected: DeploymentStrategyAllInOne},
+		"StReAmInG":    {json: `"StReAmInG"`, expected: DeploymentStrategyStreaming},
+		"Production":   {json: `"Production"`, expected: DeploymentStrategyProduction},
+		"All-IN-One":   {json: `"All-IN-One"`, expected: DeploymentStrategyDeprecatedAllInOne},
+		"random value": {json: `"random value"`, expected: DeploymentStrategyAllInOne},
+		"empty string": {json: `""`, expected: DeploymentStrategyAllInOne},
+	}
+
+	for name, tc := range tcs {
+		t.Run(name, func(t *testing.T) {
+			ds := DeploymentStrategy("")
+			err := json.Unmarshal([]byte(tc.json), &ds)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected, ds)
+		})
+	}
+}
+
+func TestMarshalJSON(t *testing.T) {
+	tcs := map[string]struct {
+		strategy DeploymentStrategy
+		expected string
+	}{
+		"allinone":   {strategy: DeploymentStrategyAllInOne, expected: `"allinone"`},
+		"streaming":  {strategy: DeploymentStrategyStreaming, expected: `"streaming"`},
+		"production": {strategy: DeploymentStrategyProduction, expected: `"production"`},
+		"all-in-one": {strategy: DeploymentStrategyDeprecatedAllInOne, expected: `"all-in-one"`},
+	}
+
+	for name, tc := range tcs {
+		t.Run(name, func(t *testing.T) {
+			data, err := json.Marshal(tc.strategy)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected, string(data))
+		})
+	}
+}

--- a/pkg/apis/jaegertracing/v1/jaeger_types.go
+++ b/pkg/apis/jaegertracing/v1/jaeger_types.go
@@ -53,6 +53,24 @@ const (
 // +k8s:openapi-gen=true
 type DeploymentStrategy string
 
+const (
+	// DeploymentStrategyDeprecatedAllInOne
+	// +k8s:openapi-gen=true
+	DeploymentStrategyDeprecatedAllInOne DeploymentStrategy = "all-in-one"
+
+	// DeploymentStrategyAllInOne
+	// +k8s:openapi-gen=true
+	DeploymentStrategyAllInOne DeploymentStrategy = "allinone"
+
+	// DeploymentStrategyStreaming
+	// +k8s:openapi-gen=true
+	DeploymentStrategyStreaming DeploymentStrategy = "streaming"
+
+	// DeploymentStrategyProduction
+	// +k8s:openapi-gen=true
+	DeploymentStrategyProduction DeploymentStrategy = "production"
+)
+
 // JaegerSpec defines the desired state of Jaeger
 // +k8s:openapi-gen=true
 type JaegerSpec struct {

--- a/pkg/apis/jaegertracing/v1/jaeger_types.go
+++ b/pkg/apis/jaegertracing/v1/jaeger_types.go
@@ -49,11 +49,15 @@ const (
 	IngressSecurityOAuthProxy IngressSecurityType = "oauth-proxy"
 )
 
+// DeploymentStrategy represents the possible values for deployment strategies
+// +k8s:openapi-gen=true
+type DeploymentStrategy string
+
 // JaegerSpec defines the desired state of Jaeger
 // +k8s:openapi-gen=true
 type JaegerSpec struct {
 	// +optional
-	Strategy string `json:"strategy,omitempty"`
+	Strategy DeploymentStrategy `json:"strategy,omitempty"`
 
 	// +optional
 	AllInOne JaegerAllInOneSpec `json:"allInOne,omitempty"`

--- a/pkg/apis/jaegertracing/v1/jaeger_types.go
+++ b/pkg/apis/jaegertracing/v1/jaeger_types.go
@@ -54,19 +54,19 @@ const (
 type DeploymentStrategy string
 
 const (
-	// DeploymentStrategyDeprecatedAllInOne
+	// DeploymentStrategyDeprecatedAllInOne represents the (deprecated) 'all-in-one' deployment strategy
 	// +k8s:openapi-gen=true
 	DeploymentStrategyDeprecatedAllInOne DeploymentStrategy = "all-in-one"
 
-	// DeploymentStrategyAllInOne
+	// DeploymentStrategyAllInOne represents the 'allInOne' deployment strategy (default)
 	// +k8s:openapi-gen=true
 	DeploymentStrategyAllInOne DeploymentStrategy = "allinone"
 
-	// DeploymentStrategyStreaming
+	// DeploymentStrategyStreaming represents the 'streaming' deployment strategy
 	// +k8s:openapi-gen=true
 	DeploymentStrategyStreaming DeploymentStrategy = "streaming"
 
-	// DeploymentStrategyProduction
+	// DeploymentStrategyProduction represents the 'production' deployment strategy
 	// +k8s:openapi-gen=true
 	DeploymentStrategyProduction DeploymentStrategy = "production"
 )

--- a/pkg/apis/jaegertracing/v1/jaeger_types.go
+++ b/pkg/apis/jaegertracing/v1/jaeger_types.go
@@ -49,28 +49,6 @@ const (
 	IngressSecurityOAuthProxy IngressSecurityType = "oauth-proxy"
 )
 
-// DeploymentStrategy represents the possible values for deployment strategies
-// +k8s:openapi-gen=true
-type DeploymentStrategy string
-
-const (
-	// DeploymentStrategyDeprecatedAllInOne represents the (deprecated) 'all-in-one' deployment strategy
-	// +k8s:openapi-gen=true
-	DeploymentStrategyDeprecatedAllInOne DeploymentStrategy = "all-in-one"
-
-	// DeploymentStrategyAllInOne represents the 'allInOne' deployment strategy (default)
-	// +k8s:openapi-gen=true
-	DeploymentStrategyAllInOne DeploymentStrategy = "allinone"
-
-	// DeploymentStrategyStreaming represents the 'streaming' deployment strategy
-	// +k8s:openapi-gen=true
-	DeploymentStrategyStreaming DeploymentStrategy = "streaming"
-
-	// DeploymentStrategyProduction represents the 'production' deployment strategy
-	// +k8s:openapi-gen=true
-	DeploymentStrategyProduction DeploymentStrategy = "production"
-)
-
 // JaegerSpec defines the desired state of Jaeger
 // +k8s:openapi-gen=true
 type JaegerSpec struct {

--- a/pkg/deployment/collector.go
+++ b/pkg/deployment/collector.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
-	"strings"
 
 	"github.com/spf13/viper"
 	appsv1 "k8s.io/api/apps/v1"
@@ -76,9 +75,9 @@ func (c *Collector) Get() *appsv1.Deployment {
 	}
 
 	storageType := c.jaeger.Spec.Storage.Type
-	// If strategy is "streaming", then change storage type
+	// If strategy is DeploymentStrategyStreaming, then change storage type
 	// to Kafka, and the storage options will be used in the Ingester instead
-	if strings.EqualFold(c.jaeger.Spec.Strategy, "streaming") {
+	if c.jaeger.Spec.Strategy == v1.DeploymentStrategyStreaming {
 		storageType = "kafka"
 	}
 	options := allArgs(c.jaeger.Spec.Collector.Options,

--- a/pkg/deployment/collector_test.go
+++ b/pkg/deployment/collector_test.go
@@ -377,7 +377,7 @@ func TestCollectorWithKafkaStorageType(t *testing.T) {
 			Name: "TestCollectorWithIngesterStorageType",
 		},
 		Spec: v1.JaegerSpec{
-			Strategy: "streaming",
+			Strategy: v1.DeploymentStrategyStreaming,
 			Collector: v1.JaegerCollectorSpec{
 				Options: v1.NewOptions(map[string]interface{}{
 					"kafka.producer.topic": "mytopic",
@@ -417,7 +417,7 @@ func TestCollectorWithIngesterNoOptionsStorageType(t *testing.T) {
 			Name: "TestCollectorWithIngesterNoOptionsStorageType",
 		},
 		Spec: v1.JaegerSpec{
-			Strategy: "streaming",
+			Strategy: v1.DeploymentStrategyStreaming,
 			Storage: v1.JaegerStorageSpec{
 				Type: "elasticsearch",
 				Options: v1.NewOptions(map[string]interface{}{

--- a/pkg/deployment/ingester.go
+++ b/pkg/deployment/ingester.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
-	"strings"
 
 	"github.com/spf13/viper"
 	appsv1 "k8s.io/api/apps/v1"
@@ -41,7 +40,7 @@ func NewIngester(jaeger *v1.Jaeger) *Ingester {
 
 // Get returns a ingester pod
 func (i *Ingester) Get() *appsv1.Deployment {
-	if !strings.EqualFold(i.jaeger.Spec.Strategy, "streaming") {
+	if i.jaeger.Spec.Strategy != v1.DeploymentStrategyStreaming {
 		return nil
 	}
 

--- a/pkg/deployment/ingester_test.go
+++ b/pkg/deployment/ingester_test.go
@@ -330,7 +330,7 @@ func TestIngesterWithStorageType(t *testing.T) {
 			Name: "TestIngesterStorageType",
 		},
 		Spec: v1.JaegerSpec{
-			Strategy: "streaming",
+			Strategy: v1.DeploymentStrategyStreaming,
 			Ingester: v1.JaegerIngesterSpec{
 				Options: v1.NewOptions(map[string]interface{}{
 					"kafka.consumer.topic":   "mytopic",
@@ -394,7 +394,7 @@ func newIngesterJaeger(name string) *v1.Jaeger {
 			Name: name,
 		},
 		Spec: v1.JaegerSpec{
-			Strategy: "streaming",
+			Strategy: v1.DeploymentStrategyStreaming,
 			Ingester: v1.JaegerIngesterSpec{
 				Options: v1.NewOptions(map[string]interface{}{
 					"any": "option",

--- a/pkg/ingress/query.go
+++ b/pkg/ingress/query.go
@@ -2,13 +2,12 @@ package ingress
 
 import (
 	"fmt"
-	"strings"
 
 	extv1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/service"
 	"github.com/jaegertracing/jaeger-operator/pkg/util"
 )
@@ -49,9 +48,9 @@ func (i *QueryIngress) Get() *extv1beta1.Ingress {
 		ServiceName: service.GetNameForQueryService(i.jaeger),
 		ServicePort: intstr.FromInt(service.GetPortForQueryService(i.jaeger)),
 	}
-	if _, ok := i.jaeger.Spec.AllInOne.Options.Map()["query.base-path"]; ok && strings.EqualFold(i.jaeger.Spec.Strategy, "allinone") {
+	if _, ok := i.jaeger.Spec.AllInOne.Options.Map()["query.base-path"]; ok && i.jaeger.Spec.Strategy == v1.DeploymentStrategyAllInOne {
 		spec.Rules = append(spec.Rules, getRule(i.jaeger.Spec.AllInOne.Options, backend))
-	} else if _, ok := i.jaeger.Spec.Query.Options.Map()["query.base-path"]; ok && strings.EqualFold(i.jaeger.Spec.Strategy, "production") {
+	} else if _, ok := i.jaeger.Spec.Query.Options.Map()["query.base-path"]; ok && i.jaeger.Spec.Strategy == v1.DeploymentStrategyProduction {
 		spec.Rules = append(spec.Rules, getRule(i.jaeger.Spec.Query.Options, backend))
 	} else {
 		spec.Backend = &backend

--- a/pkg/ingress/query_test.go
+++ b/pkg/ingress/query_test.go
@@ -49,7 +49,7 @@ func TestQueryIngressAllInOneBasePath(t *testing.T) {
 	name := "TestQueryIngressAllInOneBasePath"
 	jaeger := v1.NewJaeger(types.NamespacedName{Name: name})
 	jaeger.Spec.Ingress.Enabled = &enabled
-	jaeger.Spec.Strategy = "allInOne"
+	jaeger.Spec.Strategy = v1.DeploymentStrategyAllInOne
 	jaeger.Spec.AllInOne.Options = v1.NewOptions(map[string]interface{}{"query.base-path": "/jaeger"})
 	ingress := NewQueryIngress(jaeger)
 
@@ -68,7 +68,7 @@ func TestQueryIngressQueryBasePath(t *testing.T) {
 	name := "TestQueryIngressQueryBasePath"
 	jaeger := v1.NewJaeger(types.NamespacedName{Name: name})
 	jaeger.Spec.Ingress.Enabled = &enabled
-	jaeger.Spec.Strategy = "production"
+	jaeger.Spec.Strategy = v1.DeploymentStrategyProduction
 	jaeger.Spec.Query.Options = v1.NewOptions(map[string]interface{}{"query.base-path": "/jaeger"})
 	ingress := NewQueryIngress(jaeger)
 

--- a/pkg/strategy/all_in_one.go
+++ b/pkg/strategy/all_in_one.go
@@ -20,7 +20,7 @@ import (
 )
 
 func newAllInOneStrategy(jaeger *v1.Jaeger) S {
-	c := S{typ: AllInOne}
+	c := S{typ: v1.DeploymentStrategyAllInOne}
 	jaeger.Logger().Debug("Creating all-in-one deployment")
 
 	dep := deployment.NewAllInOne(jaeger)

--- a/pkg/strategy/controller_test.go
+++ b/pkg/strategy/controller_test.go
@@ -16,15 +16,15 @@ func TestNewControllerForAllInOneAsDefault(t *testing.T) {
 	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestNewControllerForAllInOneAsDefault"})
 
 	ctrl := For(context.TODO(), jaeger, []corev1.Secret{})
-	assert.Equal(t, ctrl.Type(), AllInOne)
+	assert.Equal(t, ctrl.Type(), v1.DeploymentStrategyAllInOne)
 }
 
 func TestNewControllerForAllInOneAsExplicitValue(t *testing.T) {
 	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestNewControllerForAllInOneAsExplicitValue"})
-	jaeger.Spec.Strategy = "ALL-IN-ONE" // same as 'all-in-one'
+	jaeger.Spec.Strategy = v1.DeploymentStrategyDeprecatedAllInOne // same as 'all-in-one'
 
 	ctrl := For(context.TODO(), jaeger, []corev1.Secret{})
-	assert.Equal(t, ctrl.Type(), AllInOne)
+	assert.Equal(t, ctrl.Type(), v1.DeploymentStrategyAllInOne)
 }
 
 func TestNewControllerForProduction(t *testing.T) {
@@ -33,7 +33,7 @@ func TestNewControllerForProduction(t *testing.T) {
 	jaeger.Spec.Storage.Type = "elasticsearch"
 
 	ctrl := For(context.TODO(), jaeger, []corev1.Secret{})
-	assert.Equal(t, ctrl.Type(), Production)
+	assert.Equal(t, ctrl.Type(), v1.DeploymentStrategyProduction)
 }
 
 func TestUnknownStorage(t *testing.T) {

--- a/pkg/strategy/controller_test.go
+++ b/pkg/strategy/controller_test.go
@@ -29,7 +29,7 @@ func TestNewControllerForAllInOneAsExplicitValue(t *testing.T) {
 
 func TestNewControllerForProduction(t *testing.T) {
 	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestNewControllerForProduction"})
-	jaeger.Spec.Strategy = "production"
+	jaeger.Spec.Strategy = v1.DeploymentStrategyProduction
 	jaeger.Spec.Storage.Type = "elasticsearch"
 
 	ctrl := For(context.TODO(), jaeger, []corev1.Secret{})
@@ -45,7 +45,7 @@ func TestUnknownStorage(t *testing.T) {
 
 func TestElasticsearchAsStorageOptions(t *testing.T) {
 	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestElasticsearchAsStorageOptions"})
-	jaeger.Spec.Strategy = "production"
+	jaeger.Spec.Strategy = v1.DeploymentStrategyProduction
 	jaeger.Spec.Storage.Type = "elasticsearch"
 	jaeger.Spec.Storage.Options = v1.NewOptions(map[string]interface{}{
 		"es.server-urls": "http://elasticsearch-example-es-cluster:9200",
@@ -75,63 +75,63 @@ func TestDefaultName(t *testing.T) {
 func TestIncompatibleMemoryStorageForProduction(t *testing.T) {
 	jaeger := &v1.Jaeger{
 		Spec: v1.JaegerSpec{
-			Strategy: "production",
+			Strategy: v1.DeploymentStrategyProduction,
 			Storage: v1.JaegerStorageSpec{
 				Type: "memory",
 			},
 		},
 	}
 	normalize(jaeger)
-	assert.Equal(t, "allInOne", jaeger.Spec.Strategy)
+	assert.Equal(t, v1.DeploymentStrategyAllInOne, jaeger.Spec.Strategy)
 }
 
 func TestIncompatibleBadgerStorageForProduction(t *testing.T) {
 	jaeger := &v1.Jaeger{
 		Spec: v1.JaegerSpec{
-			Strategy: "production",
+			Strategy: v1.DeploymentStrategyProduction,
 			Storage: v1.JaegerStorageSpec{
 				Type: "badger",
 			},
 		},
 	}
 	normalize(jaeger)
-	assert.Equal(t, "allInOne", jaeger.Spec.Strategy)
+	assert.Equal(t, v1.DeploymentStrategyAllInOne, jaeger.Spec.Strategy)
 }
 
 func TestIncompatibleStorageForStreaming(t *testing.T) {
 	jaeger := &v1.Jaeger{
 		Spec: v1.JaegerSpec{
-			Strategy: "streaming",
+			Strategy: v1.DeploymentStrategyStreaming,
 			Storage: v1.JaegerStorageSpec{
 				Type: "memory",
 			},
 		},
 	}
 	normalize(jaeger)
-	assert.Equal(t, "allInOne", jaeger.Spec.Strategy)
+	assert.Equal(t, v1.DeploymentStrategyAllInOne, jaeger.Spec.Strategy)
 }
 
 func TestDeprecatedAllInOneStrategy(t *testing.T) {
 	jaeger := &v1.Jaeger{
 		Spec: v1.JaegerSpec{
-			Strategy: "all-in-one",
+			Strategy: v1.DeploymentStrategyDeprecatedAllInOne,
 		},
 	}
 	For(context.TODO(), jaeger, []corev1.Secret{})
-	assert.Equal(t, "allInOne", jaeger.Spec.Strategy)
+	assert.Equal(t, v1.DeploymentStrategyAllInOne, jaeger.Spec.Strategy)
 }
 
 func TestStorageMemoryOnlyUsedWithAllInOneStrategy(t *testing.T) {
 	jaeger := &v1.Jaeger{
 		Spec: v1.JaegerSpec{
-			Strategy: "production",
+			Strategy: v1.DeploymentStrategyProduction,
 			Storage: v1.JaegerStorageSpec{
 				Type: "memory",
 			},
 		},
 	}
 	For(context.TODO(), jaeger, []corev1.Secret{})
-	assert.Equal(t, "allInOne", jaeger.Spec.Strategy)
+	assert.Equal(t, v1.DeploymentStrategyAllInOne, jaeger.Spec.Strategy)
 }
 
 func TestSetSecurityToNoneByDefault(t *testing.T) {

--- a/pkg/strategy/production.go
+++ b/pkg/strategy/production.go
@@ -21,7 +21,7 @@ import (
 )
 
 func newProductionStrategy(jaeger *v1.Jaeger, es *storage.ElasticsearchDeployment) S {
-	c := S{typ: Production}
+	c := S{typ: v1.DeploymentStrategyProduction}
 	collector := deployment.NewCollector(jaeger)
 	query := deployment.NewQuery(jaeger)
 	agent := deployment.NewAgent(jaeger)

--- a/pkg/strategy/production_test.go
+++ b/pkg/strategy/production_test.go
@@ -74,7 +74,7 @@ func TestOptionsArePassed(t *testing.T) {
 			Namespace: "simple-prod-ns",
 		},
 		Spec: v1.JaegerSpec{
-			Strategy: "production",
+			Strategy: v1.DeploymentStrategyProduction,
 			Storage: v1.JaegerStorageSpec{
 				Type: "elasticsearch",
 				Options: v1.NewOptions(map[string]interface{}{

--- a/pkg/strategy/strategy.go
+++ b/pkg/strategy/strategy.go
@@ -9,12 +9,13 @@ import (
 	"k8s.io/api/extensions/v1beta1"
 	rbac "k8s.io/api/rbac/v1"
 
+	jv1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 	esv1 "github.com/jaegertracing/jaeger-operator/pkg/storage/elasticsearch/v1"
 )
 
 // S knows what type of deployments to build based on a given spec
 type S struct {
-	typ                 Type
+	typ                 jv1.DeploymentStrategy
 	accounts            []v1.ServiceAccount
 	configMaps          []v1.ConfigMap
 	cronJobs            []batchv1beta1.CronJob
@@ -29,28 +30,13 @@ type S struct {
 	secrets             []v1.Secret
 }
 
-// Type represents a specific deployment strategy, like 'all-in-one'
-type Type string
-
-const (
-
-	// AllInOne represents the 'all-in-one' deployment strategy
-	AllInOne Type = "allInOne"
-
-	// Production represents the 'production' deployment strategy
-	Production Type = "production"
-
-	// Streaming represents the 'streaming' deployment strategy
-	Streaming Type = "streaming"
-)
-
 // New constructs a new strategy from scratch
 func New() *S {
 	return &S{}
 }
 
 // Type returns the strategy type for the given strategy
-func (s S) Type() Type {
+func (s S) Type() jv1.DeploymentStrategy {
 	return s.typ
 }
 

--- a/pkg/strategy/strategy.go
+++ b/pkg/strategy/strategy.go
@@ -5,19 +5,19 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	rbac "k8s.io/api/rbac/v1"
 
-	jv1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 	esv1 "github.com/jaegertracing/jaeger-operator/pkg/storage/elasticsearch/v1"
 )
 
 // S knows what type of deployments to build based on a given spec
 type S struct {
-	typ                 jv1.DeploymentStrategy
-	accounts            []v1.ServiceAccount
-	configMaps          []v1.ConfigMap
+	typ                 v1.DeploymentStrategy
+	accounts            []corev1.ServiceAccount
+	configMaps          []corev1.ConfigMap
 	cronJobs            []batchv1beta1.CronJob
 	clusterRoleBindings []rbac.ClusterRoleBinding
 	daemonSets          []appsv1.DaemonSet
@@ -26,8 +26,8 @@ type S struct {
 	elasticsearches     []esv1.Elasticsearch
 	ingresses           []v1beta1.Ingress
 	routes              []osv1.Route
-	services            []v1.Service
-	secrets             []v1.Secret
+	services            []corev1.Service
+	secrets             []corev1.Secret
 }
 
 // New constructs a new strategy from scratch
@@ -36,12 +36,12 @@ func New() *S {
 }
 
 // Type returns the strategy type for the given strategy
-func (s S) Type() jv1.DeploymentStrategy {
+func (s S) Type() v1.DeploymentStrategy {
 	return s.typ
 }
 
 // WithAccounts returns the strategy with the given list of service accounts
-func (s S) WithAccounts(accs []v1.ServiceAccount) S {
+func (s S) WithAccounts(accs []corev1.ServiceAccount) S {
 	s.accounts = accs
 	return s
 }
@@ -53,7 +53,7 @@ func (s S) WithClusterRoleBindings(c []rbac.ClusterRoleBinding) S {
 }
 
 // WithConfigMaps returns the strategy with the given list of config maps
-func (s S) WithConfigMaps(c []v1.ConfigMap) S {
+func (s S) WithConfigMaps(c []corev1.ConfigMap) S {
 	s.configMaps = c
 	return s
 }
@@ -101,19 +101,19 @@ func (s S) WithRoutes(r []osv1.Route) S {
 }
 
 // WithServices returns the strategy with the given list of routes
-func (s S) WithServices(svcs []v1.Service) S {
+func (s S) WithServices(svcs []corev1.Service) S {
 	s.services = svcs
 	return s
 }
 
 // WithSecrets returns the strategy with the given list of secrets
-func (s S) WithSecrets(secrets []v1.Secret) S {
+func (s S) WithSecrets(secrets []corev1.Secret) S {
 	s.secrets = secrets
 	return s
 }
 
 // Accounts returns the list of service accounts for this strategy
-func (s S) Accounts() []v1.ServiceAccount {
+func (s S) Accounts() []corev1.ServiceAccount {
 	return s.accounts
 }
 
@@ -123,7 +123,7 @@ func (s S) ClusterRoleBindings() []rbac.ClusterRoleBinding {
 }
 
 // ConfigMaps returns the list of config maps for this strategy
-func (s S) ConfigMaps() []v1.ConfigMap {
+func (s S) ConfigMaps() []corev1.ConfigMap {
 	return s.configMaps
 }
 
@@ -158,12 +158,12 @@ func (s S) Routes() []osv1.Route {
 }
 
 // Services returns the list of services for this strategy
-func (s S) Services() []v1.Service {
+func (s S) Services() []corev1.Service {
 	return s.services
 }
 
 // Secrets returns the list of secrets for this strategy
-func (s S) Secrets() []v1.Secret {
+func (s S) Secrets() []corev1.Secret {
 	return s.secrets
 }
 

--- a/pkg/strategy/streaming.go
+++ b/pkg/strategy/streaming.go
@@ -20,7 +20,7 @@ import (
 )
 
 func newStreamingStrategy(jaeger *v1.Jaeger) S {
-	c := S{typ: Streaming}
+	c := S{typ: v1.DeploymentStrategyStreaming}
 	collector := deployment.NewCollector(jaeger)
 	query := deployment.NewQuery(jaeger)
 	agent := deployment.NewAgent(jaeger)

--- a/pkg/strategy/streaming_test.go
+++ b/pkg/strategy/streaming_test.go
@@ -73,7 +73,7 @@ func TestStreamingOptionsArePassed(t *testing.T) {
 			Namespace: "simple-prod-ns",
 		},
 		Spec: v1.JaegerSpec{
-			Strategy: "streaming",
+			Strategy: v1.DeploymentStrategyStreaming,
 			Collector: v1.JaegerCollectorSpec{
 				Options: v1.NewOptions(map[string]interface{}{
 					"kafka.producer.topic": "mytopic",

--- a/test/e2e/all_in_one_test.go
+++ b/test/e2e/all_in_one_test.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 )
 
 const TrackingID = "MyTrackingId"
@@ -214,7 +214,7 @@ func getJaegerAllInOneWithUiDefinition(basePath string) *v1.Jaeger {
 			Namespace: namespace,
 		},
 		Spec: v1.JaegerSpec{
-			Strategy: "allInOne",
+			Strategy: v1.DeploymentStrategyAllInOne,
 			AllInOne: v1.JaegerAllInOneSpec{
 				Options: v1.NewOptions(map[string]interface{}{
 					"query.base-path": basePath,
@@ -246,7 +246,7 @@ func getJaegerAllInOneDefinition(namespace string, name string) *v1.Jaeger {
 			Namespace: namespace,
 		},
 		Spec: v1.JaegerSpec{
-			Strategy: "allInOne",
+			Strategy: v1.DeploymentStrategyAllInOne,
 			AllInOne: v1.JaegerAllInOneSpec{
 				Options: v1.NewOptions(map[string]interface{}{
 					"log-level":         "debug",

--- a/test/e2e/cassandra_test.go
+++ b/test/e2e/cassandra_test.go
@@ -93,7 +93,7 @@ func getJaegerWithCassandra(s string) *v1.Jaeger {
 			Namespace: namespace,
 		},
 		Spec: v1.JaegerSpec{
-			Strategy: "allInOne",
+			Strategy: v1.DeploymentStrategyAllInOne,
 			Storage: v1.JaegerStorageSpec{
 				Type:    "cassandra",
 				Options: v1.NewOptions(map[string]interface{}{"cassandra.servers": cassandraServiceName, "cassandra.keyspace": "jaeger_v1_datacenter1"}),

--- a/test/e2e/daemonset_test.go
+++ b/test/e2e/daemonset_test.go
@@ -222,7 +222,7 @@ func jaegerAgentAsDaemonsetDefinition(namespace string, name string) *v1.Jaeger 
 			Namespace: namespace,
 		},
 		Spec: v1.JaegerSpec{
-			Strategy: "allInOne",
+			Strategy: v1.DeploymentStrategyAllInOne,
 			AllInOne: v1.JaegerAllInOneSpec{},
 			Agent: v1.JaegerAgentSpec{
 				Strategy: "DaemonSet",

--- a/test/e2e/elasticsearch_test.go
+++ b/test/e2e/elasticsearch_test.go
@@ -20,7 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/portforward"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 )
 
 type ElasticSearchTestSuite struct {
@@ -163,7 +163,7 @@ func getJaegerSimpleProdWithServerUrls() *v1.Jaeger {
 			Namespace: namespace,
 		},
 		Spec: v1.JaegerSpec{
-			Strategy: "production",
+			Strategy: v1.DeploymentStrategyProduction,
 			Storage: v1.JaegerStorageSpec{
 				Type: "elasticsearch",
 				Options: v1.NewOptions(map[string]interface{}{
@@ -187,7 +187,7 @@ func getJaegerAllInOne(name string) *v1.Jaeger {
 			Namespace: namespace,
 		},
 		Spec: v1.JaegerSpec{
-			Strategy: "allInOne",
+			Strategy: v1.DeploymentStrategyAllInOne,
 			Storage: v1.JaegerStorageSpec{
 				Type: "elasticsearch",
 				Options: v1.NewOptions(map[string]interface{}{

--- a/test/e2e/self_provisioned_elasticsearch_test.go
+++ b/test/e2e/self_provisioned_elasticsearch_test.go
@@ -112,7 +112,7 @@ func getJaegerSimpleProd() *v1.Jaeger {
 			Namespace: namespace,
 		},
 		Spec: v1.JaegerSpec{
-			Strategy: "production",
+			Strategy: v1.DeploymentStrategyProduction,
 			Storage: v1.JaegerStorageSpec{
 				Type: "elasticsearch",
 				Elasticsearch: v1.ElasticsearchSpec{

--- a/test/e2e/sidecar_test.go
+++ b/test/e2e/sidecar_test.go
@@ -177,7 +177,7 @@ func getJaegerAgentAsSidecarDefinition(namespace string) *v1.Jaeger {
 			Namespace: namespace,
 		},
 		Spec: v1.JaegerSpec{
-			Strategy: "allInOne",
+			Strategy: v1.DeploymentStrategyAllInOne,
 			AllInOne: v1.JaegerAllInOneSpec{},
 			Agent: v1.JaegerAgentSpec{
 				Options: v1.NewOptions(map[string]interface{}{

--- a/test/e2e/spark_dependencies_test.go
+++ b/test/e2e/spark_dependencies_test.go
@@ -30,7 +30,7 @@ func sparkTest(t *testing.T, f *framework.Framework, testCtx *framework.TestCtx,
 			Namespace: namespace,
 		},
 		Spec: v1.JaegerSpec{
-			Strategy: "allInOne",
+			Strategy: v1.DeploymentStrategyAllInOne,
 			AllInOne: v1.JaegerAllInOneSpec{},
 			Storage:  storage,
 		},

--- a/test/e2e/streaming_test.go
+++ b/test/e2e/streaming_test.go
@@ -15,7 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 )
 
 type StreamingTestSuite struct {
@@ -129,7 +129,7 @@ func jaegerStreamingDefinition(namespace string, name string) *v1.Jaeger {
 			Namespace: namespace,
 		},
 		Spec: v1.JaegerSpec{
-			Strategy: "streaming",
+			Strategy: v1.DeploymentStrategyStreaming,
 			Collector: v1.JaegerCollectorSpec{
 				Options: v1.NewOptions(map[string]interface{}{
 					"kafka.producer.topic":   "jaeger-spans",
@@ -168,7 +168,7 @@ func jaegerStreamingDefinitionWithTLS(namespace string, name, kafkaUserName stri
 			Namespace: namespace,
 		},
 		Spec: v1.JaegerSpec{
-			Strategy: "streaming",
+			Strategy: v1.DeploymentStrategyStreaming,
 			Collector: v1.JaegerCollectorSpec{
 				Options: v1.NewOptions(map[string]interface{}{
 					"kafka.producer.authentication": "tls",

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -324,7 +324,7 @@ func smokeTestProductionExample(name, yamlFileName string) {
 	queryDeploymentName := name + "-query"
 	collectorDeploymentName := name + "-collector"
 
-	if jaegerInstance.Spec.Strategy == "streaming" {
+	if jaegerInstance.Spec.Strategy == v1.DeploymentStrategyStreaming {
 		ingesterDeploymentName := name + "-ingester"
 		err := WaitForDeployment(t, fw.KubeClient, namespace, ingesterDeploymentName, 1, retryInterval, timeout)
 		require.NoErrorf(t, err, "Error waiting for %s to deploy", ingesterDeploymentName)


### PR DESCRIPTION
This PR adds a new type, `DeploymentStrategy`, to be used in `JaegerSpec.Strategy` instead of just a `string`. Constants based on the new type are also defined to define valid values.

When merged, this PR will close #137. 

### To do
- [x] make sure all unserialized values are converted to lower case
- [x] a test ensuring that current CRs with a mixed-case strategy are correctly parsed
- [x] the constant in the strategy package, mentioned in #137