### PR TITLE
Added workflows publishing the 'master' container image

### DIFF
--- a/.ci/publish-images.sh
+++ b/.ci/publish-images.sh
@@ -5,7 +5,7 @@ OPERATOR_VERSION=${OPERATOR_VERSION:-$(git describe --tags)}
 
 ## if we are on a release tag, let's extract the version number
 ## the other possible value, currently, is 'master' (or another branch name)
-## if we are not running in travis, it fallsback to the `git describe` above
+## if we are not running in the CI, it fallsback to the `git describe` above
 if [[ $OPERATOR_VERSION == release* ]]; then
     OPERATOR_VERSION=$(echo ${OPERATOR_VERSION} | grep -Po "([\d\.]+)")
     MAJOR_MINOR=$(echo ${OPERATOR_VERSION} | awk -F. '{print $1"."$2}')

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -1,22 +1,17 @@
-name: "Release"
 on:
   push:
-    tags:
-    - 'release/v*'
+    branches:
+      - master
 
 jobs:
-  release:
+  publish:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - name: "perform the release"
-      env:
-        GH_WRITE_TOKEN: ${{ secrets.GH_WRITE_TOKEN }}
-      run: ./.ci/release.sh
     - name: "publishes the images"
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
         QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+        OPERATOR_VERSION: master
       run: ./.ci/publish-images.sh


### PR DESCRIPTION
The script that is used for this workflow is the same we had before with Travis. It works locally when setting the username/password vars and I did add the same secrets to this repository. I _believe_ this will work, but we'll only know when this gets merged.

Resolves #715

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>