### PR TITLE
Added checkout step to publish-images

### DIFF
--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -7,6 +7,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v1
     - name: "publishes the images"
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
The publish-images workflow failed with:

```
/home/runner/work/_temp/541137e8-6b47-4ce2-b49f-be1ebfc6e9b1.sh: line 1: ./.ci/publish-images.sh: No such file or directory
```

This is due to the missing `checkout` action, which is included in this PR.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>