### PR TITLE
Use StatefulSet from apps/v1 API for ES and Cassandra

### DIFF
--- a/test/cassandra.yml
+++ b/test/cassandra.yml
@@ -24,7 +24,7 @@ items:
     clusterIP: None
     selector:
       app: cassandra
-- apiVersion: "apps/v1beta1"
+- apiVersion: "apps/v1"
   kind: StatefulSet
   metadata:
     name: cassandra
@@ -32,6 +32,9 @@ items:
       app: jaeger
       jaeger-infra: cassandra-statefulset
   spec:
+    selector:
+      matchLabels:
+        app: cassandra
     serviceName: cassandra
     replicas: 3
     template:

--- a/test/elasticsearch.yml
+++ b/test/elasticsearch.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: elasticsearch
@@ -6,6 +6,9 @@ metadata:
     app: jaeger
     jaeger-infra: elasticsearch-statefulset
 spec:
+  selector:
+    matchLabels:
+      app: jaeger-elasticsearch
   serviceName: elasticsearch
   replicas: 1
   template:


### PR DESCRIPTION
Minikube 1.4 use k8s 1.16 which removes `apps/v1beta1`.

apps/v1beta1 has been promoted to apps/v1 in k8s 1.9  https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.9.md

Signed-off-by: Pavol Loffay <ploffay@redhat.com>