### PR TITLE
Add liveliness probe

### DIFF
--- a/pkg/deployment/agent.go
+++ b/pkg/deployment/agent.go
@@ -140,6 +140,17 @@ func (a *Agent) Get() *appsv1.DaemonSet {
 								Name:          "admin-http",
 							},
 						},
+						LivenessProbe: &corev1.Probe{
+							Handler: corev1.Handler{
+								HTTPGet: &corev1.HTTPGetAction{
+									Path: "/",
+									Port: intstr.FromInt(int(adminPort)),
+								},
+							},
+							InitialDelaySeconds: 1,
+							PeriodSeconds:       15,
+							FailureThreshold:    5,
+						},
 						ReadinessProbe: &corev1.Probe{
 							Handler: corev1.Handler{
 								HTTPGet: &corev1.HTTPGetAction{

--- a/pkg/deployment/agent.go
+++ b/pkg/deployment/agent.go
@@ -147,7 +147,7 @@ func (a *Agent) Get() *appsv1.DaemonSet {
 									Port: intstr.FromInt(int(adminPort)),
 								},
 							},
-							InitialDelaySeconds: 1,
+							InitialDelaySeconds: 5,
 							PeriodSeconds:       15,
 							FailureThreshold:    5,
 						},

--- a/pkg/deployment/all_in_one.go
+++ b/pkg/deployment/all_in_one.go
@@ -178,6 +178,8 @@ func (a *AllInOne) Get() *appsv1.Deployment {
 								},
 							},
 							InitialDelaySeconds: 1,
+							PeriodSeconds:       15,
+							FailureThreshold:    5,
 						},
 						ReadinessProbe: &corev1.Probe{
 							Handler: corev1.Handler{

--- a/pkg/deployment/all_in_one.go
+++ b/pkg/deployment/all_in_one.go
@@ -170,6 +170,15 @@ func (a *AllInOne) Get() *appsv1.Deployment {
 								Name:          "grpc",
 							},
 						},
+						LivenessProbe: &corev1.Probe{
+							Handler: corev1.Handler{
+								HTTPGet: &corev1.HTTPGetAction{
+									Path: "/",
+									Port: intstr.FromInt(int(adminPort)),
+								},
+							},
+							InitialDelaySeconds: 1,
+						},
 						ReadinessProbe: &corev1.Probe{
 							Handler: corev1.Handler{
 								HTTPGet: &corev1.HTTPGetAction{

--- a/pkg/deployment/all_in_one.go
+++ b/pkg/deployment/all_in_one.go
@@ -177,7 +177,7 @@ func (a *AllInOne) Get() *appsv1.Deployment {
 									Port: intstr.FromInt(int(adminPort)),
 								},
 							},
-							InitialDelaySeconds: 1,
+							InitialDelaySeconds: 5,
 							PeriodSeconds:       15,
 							FailureThreshold:    5,
 						},

--- a/pkg/deployment/collector.go
+++ b/pkg/deployment/collector.go
@@ -170,7 +170,7 @@ func (c *Collector) Get() *appsv1.Deployment {
 									Port: intstr.FromInt(int(adminPort)),
 								},
 							},
-							InitialDelaySeconds: 1,
+							InitialDelaySeconds: 5,
 							PeriodSeconds:       15,
 							FailureThreshold:    5,
 						},

--- a/pkg/deployment/collector.go
+++ b/pkg/deployment/collector.go
@@ -163,6 +163,17 @@ func (c *Collector) Get() *appsv1.Deployment {
 								Name:          "grpc",
 							},
 						},
+						LivenessProbe: &corev1.Probe{
+							Handler: corev1.Handler{
+								HTTPGet: &corev1.HTTPGetAction{
+									Path: "/",
+									Port: intstr.FromInt(int(adminPort)),
+								},
+							},
+							InitialDelaySeconds: 1,
+							PeriodSeconds:       15,
+							FailureThreshold:    5,
+						},
 						ReadinessProbe: &corev1.Probe{
 							Handler: corev1.Handler{
 								HTTPGet: &corev1.HTTPGetAction{

--- a/pkg/deployment/ingester.go
+++ b/pkg/deployment/ingester.go
@@ -143,7 +143,7 @@ func (i *Ingester) Get() *appsv1.Deployment {
 									Port: intstr.FromInt(int(adminPort)),
 								},
 							},
-							InitialDelaySeconds: 1,
+							InitialDelaySeconds: 5,
 							PeriodSeconds:       15,
 							FailureThreshold:    5,
 						},
@@ -171,7 +171,7 @@ func (i *Ingester) Get() *appsv1.Deployment {
 
 func (i *Ingester) labels() map[string]string {
 	return map[string]string{
-		"app":                          "jaeger", // TODO(jpkroehling): see collector.go in this package
+		"app": "jaeger", // TODO(jpkroehling): see collector.go in this package
 		"app.kubernetes.io/name":       i.name(),
 		"app.kubernetes.io/instance":   i.jaeger.Name,
 		"app.kubernetes.io/component":  "ingester",

--- a/pkg/deployment/ingester.go
+++ b/pkg/deployment/ingester.go
@@ -171,7 +171,7 @@ func (i *Ingester) Get() *appsv1.Deployment {
 
 func (i *Ingester) labels() map[string]string {
 	return map[string]string{
-		"app": "jaeger", // TODO(jpkroehling): see collector.go in this package
+		"app":                          "jaeger", // TODO(jpkroehling): see collector.go in this package
 		"app.kubernetes.io/name":       i.name(),
 		"app.kubernetes.io/instance":   i.jaeger.Name,
 		"app.kubernetes.io/component":  "ingester",

--- a/pkg/deployment/ingester.go
+++ b/pkg/deployment/ingester.go
@@ -136,6 +136,17 @@ func (i *Ingester) Get() *appsv1.Deployment {
 								Name:          "admin-http",
 							},
 						},
+						LivenessProbe: &corev1.Probe{
+							Handler: corev1.Handler{
+								HTTPGet: &corev1.HTTPGetAction{
+									Path: "/",
+									Port: intstr.FromInt(int(adminPort)),
+								},
+							},
+							InitialDelaySeconds: 1,
+							PeriodSeconds:       15,
+							FailureThreshold:    5,
+						},
 						ReadinessProbe: &corev1.Probe{
 							Handler: corev1.Handler{
 								HTTPGet: &corev1.HTTPGetAction{

--- a/pkg/deployment/query.go
+++ b/pkg/deployment/query.go
@@ -153,7 +153,7 @@ func (q *Query) Get() *appsv1.Deployment {
 									Port: intstr.FromInt(int(adminPort)),
 								},
 							},
-							InitialDelaySeconds: 1,
+							InitialDelaySeconds: 5,
 							PeriodSeconds:       15,
 							FailureThreshold:    5,
 						},
@@ -189,7 +189,7 @@ func (q *Query) Services() []*corev1.Service {
 
 func (q *Query) labels() map[string]string {
 	return map[string]string{
-		"app":                          "jaeger", // TODO(jpkroehling): see collector.go in this package
+		"app": "jaeger", // TODO(jpkroehling): see collector.go in this package
 		"app.kubernetes.io/name":       q.name(),
 		"app.kubernetes.io/instance":   q.jaeger.Name,
 		"app.kubernetes.io/component":  "query",

--- a/pkg/deployment/query.go
+++ b/pkg/deployment/query.go
@@ -146,6 +146,17 @@ func (q *Query) Get() *appsv1.Deployment {
 								Name:          "admin-http",
 							},
 						},
+						LivenessProbe: &corev1.Probe{
+							Handler: corev1.Handler{
+								HTTPGet: &corev1.HTTPGetAction{
+									Path: "/",
+									Port: intstr.FromInt(int(adminPort)),
+								},
+							},
+							InitialDelaySeconds: 1,
+							PeriodSeconds:       15,
+							FailureThreshold:    5,
+						},
 						ReadinessProbe: &corev1.Probe{
 							Handler: corev1.Handler{
 								HTTPGet: &corev1.HTTPGetAction{

--- a/pkg/deployment/query.go
+++ b/pkg/deployment/query.go
@@ -189,7 +189,7 @@ func (q *Query) Services() []*corev1.Service {
 
 func (q *Query) labels() map[string]string {
 	return map[string]string{
-		"app": "jaeger", // TODO(jpkroehling): see collector.go in this package
+		"app":                          "jaeger", // TODO(jpkroehling): see collector.go in this package
 		"app.kubernetes.io/name":       q.name(),
 		"app.kubernetes.io/instance":   q.jaeger.Name,
 		"app.kubernetes.io/component":  "query",


### PR DESCRIPTION
- Adding liveliness probe #56 

PeriodSeconds: 15
FailureThreshold: 5

I decided for longer liveliness probes, so it would be the last resort if application is not responsive for longer(75s here).

Decision was mostly influenced by similar experiences to what is discussed [here](https://srcco.de/posts/kubernetes-liveness-probes-are-dangerous.html)




