### PR TITLE
Don't validate images when using OLM

### DIFF
--- a/test/e2e/misc_test.go
+++ b/test/e2e/misc_test.go
@@ -59,6 +59,11 @@ func (suite *MiscTestSuite) AfterTest(suiteName, testName string) {
 
 // Make sure we're testing correct image
 func (suite *MiscTestSuite) TestValidateBuildImage() {
+	// Skip for now with OLM, this may be re-instated later
+	if usingOLM {
+		t.Skip()
+	}
+
 	buildImage := os.Getenv("BUILD_IMAGE")
 	require.NotEmptyf(t, buildImage, "BUILD_IMAGE must be defined")
 

--- a/test/e2e/misc_test.go
+++ b/test/e2e/misc_test.go
@@ -59,7 +59,7 @@ func (suite *MiscTestSuite) AfterTest(suiteName, testName string) {
 
 // Make sure we're testing correct image
 func (suite *MiscTestSuite) TestValidateBuildImage() {
-	// Skip for now with OLM, this may be re-instated later
+	// TODO reinstate this if we come up with a good solution, but skip for now when using OLM installed operators
 	if usingOLM {
 		t.Skip()
 	}

--- a/test/e2e/self_provisioned_elasticsearch_test.go
+++ b/test/e2e/self_provisioned_elasticsearch_test.go
@@ -91,7 +91,7 @@ func (suite *SelfProvisionedTestSuite) TestSelfProvisionedESSmokeTest() {
 }
 
 func (suite *SelfProvisionedTestSuite) TestValidateEsOperatorImage() {
-	// Skip for now with OLM, this may be re-instated later
+	// TODO reinstate this if we come up with a good solution, but skip for now when using OLM installed operators
 	if usingOLM {
 		t.Skip()
 	}

--- a/test/e2e/self_provisioned_elasticsearch_test.go
+++ b/test/e2e/self_provisioned_elasticsearch_test.go
@@ -91,6 +91,10 @@ func (suite *SelfProvisionedTestSuite) TestSelfProvisionedESSmokeTest() {
 }
 
 func (suite *SelfProvisionedTestSuite) TestValidateEsOperatorImage() {
+	// Skip for now with OLM, this may be re-instated later
+	if usingOLM {
+		t.Skip()
+	}
 	expectedEsOperatorImage := os.Getenv("ES_OPERATOR_IMAGE")
 	require.NotEmpty(t, expectedEsOperatorImage, "ES_OPERATOR_IMAGE must be defined")
 	esOperatorNamespace := os.Getenv("ES_OPERATOR_NAMESPACE")

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -269,8 +269,8 @@ func handleSuiteTearDown() {
 
 func handleTestFailure() {
 	if debugMode && t.Failed() {
-		logrus.Errorf("Test %s failed - terminating suite\n", t.Name())
-		os.Exit(1)
+		logrus.Errorf("Test %s failed\n", t.Name())
+		// FIXME find a better way to terminate tests than os.Exit(1)
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com>

A couple of minor fixes here.  First, skip the two test cases that validate that we are using the correct jaeger-operator and elasticsearch-operator images when using OLM, as it's currently a bit difficult or at least cumbersome to know this ahead of time.  Also, while I originally added these as a sanity check, I'm not sure we really need them any longer.

Also, don't call os.Exit() when a test fails and we're in debug mode.  This is not working as I had thought it would, and I need to come up with another approach for this.