### PR TITLE
Docker image version fix (1.15.0 -> v1.15.0)

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: jaeger-operator
       containers:
         - name: jaeger-operator
-          image: jaegertracing/jaeger-operator:1.15.0
+          image: jaegertracing/jaeger-operator:v1.15.0
           ports:
           - containerPort: 8383
             name: metrics


### PR DESCRIPTION
Hi.

I noticed that the operator configuration file has a wrong docker image version.
[Docker Hub](https://hub.docker.com/r/jaegertracing/jaeger-operator/tags) - according to this there is no version of jaeger-operator `1.15.0` but `v1.15.0`.