### PR TITLE
Fixed the publishing of versioned container images

### DIFF
--- a/.ci/publish-images.sh
+++ b/.ci/publish-images.sh
@@ -6,7 +6,7 @@ OPERATOR_VERSION=${OPERATOR_VERSION:-$(git describe --tags)}
 ## if we are on a release tag, let's extract the version number
 ## the other possible value, currently, is 'master' (or another branch name)
 ## if we are not running in the CI, it fallsback to the `git describe` above
-if [[ $OPERATOR_VERSION == release* ]]; then
+if [[ $OPERATOR_VERSION == v* ]]; then
     OPERATOR_VERSION=$(echo ${OPERATOR_VERSION} | grep -Po "([\d\.]+)")
     MAJOR_MINOR=$(echo ${OPERATOR_VERSION} | awk -F. '{print $1"."$2}')
 fi


### PR DESCRIPTION
Before this PR, the release procedure would publish one image, tagged as `v1.2.3`. After this PR, it publishes two images: `1.2` and `1.2.3`, inline with what we had before moving to GitHub Workflow.

Previously, we had two builds happening for the same commit: one for master, one for the tag. The one for the tag would publish the two images. With GitHub Workflow, only one build is triggered, and `master` is what is detected by the script.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>