### PR TITLE
Fixed the release script to only replace the container image on CSV

### DIFF
--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -43,7 +43,7 @@ operator-sdk olm-catalog gen-csv \
     --from-version=${PREVIOUS_VERSION}
 
 # changes to deploy/olm-catalog/jaeger-operator/newversion/...
-sed "s~${PREVIOUS_VERSION}~${OPERATOR_VERSION}~gi" -i deploy/olm-catalog/jaeger-operator/${OPERATOR_VERSION}/jaeger-operator.v${OPERATOR_VERSION}.clusterserviceversion.yaml
+sed "s~containerImage: docker.io/jaegertracing/jaeger-operator:${PREVIOUS_VERSION}~containerImage: docker.io/jaegertracing/jaeger-operator:${OPERATOR_VERSION}~i" -i deploy/olm-catalog/jaeger-operator/${OPERATOR_VERSION}/jaeger-operator.v${OPERATOR_VERSION}.clusterserviceversion.yaml
 
 git diff -s --exit-code
 if [[ $? == 0 ]]; then

--- a/deploy/olm-catalog/jaeger-operator/1.15.1/jaeger-operator.v1.15.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/jaeger-operator/1.15.1/jaeger-operator.v1.15.1.clusterserviceversion.yaml
@@ -334,7 +334,7 @@ spec:
   maturity: alpha
   provider:
     name: CNCF
-  replaces: jaeger-operator.v1.15.1
+  replaces: jaeger-operator.v1.15.0
   selector:
     matchLabels:
       name: jaeger-operator


### PR DESCRIPTION
With this change, the `containerImage` is still being replaced, while the `replaces` isn't.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>