### PR TITLE
Correctly expose injected UDP container ports

### DIFF
--- a/pkg/inject/sidecar.go
+++ b/pkg/inject/sidecar.go
@@ -159,6 +159,7 @@ func container(jaeger *v1.Jaeger, dep *appsv1.Deployment) corev1.Container {
 			{
 				ContainerPort: zkCompactTrft,
 				Name:          "zk-compact-trft",
+				Protocol:      corev1.ProtocolUDP,
 			},
 			{
 				ContainerPort: configRest,
@@ -167,10 +168,12 @@ func container(jaeger *v1.Jaeger, dep *appsv1.Deployment) corev1.Container {
 			{
 				ContainerPort: jgCompactTrft,
 				Name:          "jg-compact-trft",
+				Protocol:      corev1.ProtocolUDP,
 			},
 			{
 				ContainerPort: jgBinaryTrft,
 				Name:          "jg-binary-trft",
+				Protocol:      corev1.ProtocolUDP,
 			},
 		},
 		Resources: commonSpec.Resources,

--- a/pkg/service/agent_test.go
+++ b/pkg/service/agent_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
@@ -26,10 +27,17 @@ func TestAgentServiceNameAndPorts(t *testing.T) {
 
 	for _, port := range svc.Spec.Ports {
 		ports[port.Port] = true
+		switch port.Port {
+		case
+			5775,
+			6831,
+			6832:
+			assert.Equal(t, corev1.ProtocolUDP, port.Protocol, "Expected port %v to be UDP, but wasn't", port)
+		}
 	}
 
 	for k, v := range ports {
-		assert.Equal(t, v, true, "Expected port %v to be specified, but wasn't", k)
+		assert.Equal(t, true, v, "Expected port %v to be specified, but wasn't", k)
 	}
 
 }


### PR DESCRIPTION
This MR should fix the missing `Protocol` properties for three of the created container ports of injected sidecar containers (#771). A test case should cover this - at least for default port numbers. Also, I updated the test case for standalone agent containers to cover the protocols.