### PR TITLE
Added basic status to CR{D}

### DIFF
--- a/deploy/crds/jaegertracing.io_jaegers_crd.yaml
+++ b/deploy/crds/jaegertracing.io_jaegers_crd.yaml
@@ -3,6 +3,15 @@ kind: CustomResourceDefinition
 metadata:
   name: jaegers.jaegertracing.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.phase
+    description: Instance's status
+    name: Status
+    type: string
+  - JSONPath: .status.version
+    description: Jaeger Version
+    name: Version
+    type: string
   group: jaegertracing.io
   names:
     kind: Jaeger
@@ -10,6 +19,8 @@ spec:
     plural: jaegers
     singular: jaeger
   scope: Namespaced
+  subresources:
+    status: {}
   version: v1
   versions:
   - name: v1

--- a/deploy/crds/jaegertracing.io_jaegers_crd.yaml
+++ b/deploy/crds/jaegertracing.io_jaegers_crd.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   additionalPrinterColumns:
   - JSONPath: .status.phase
-    description: Instance's status
+    description: Jaeger instance's status
     name: Status
     type: string
   - JSONPath: .status.version

--- a/pkg/apis/jaegertracing/v1/jaeger_types.go
+++ b/pkg/apis/jaegertracing/v1/jaeger_types.go
@@ -11,6 +11,10 @@ import (
 // +k8s:openapi-gen=true
 type IngressSecurityType string
 
+// JaegerPhase represents the current phase of Jaeger instances
+// +k8s:openapi-gen=true
+type JaegerPhase string
+
 const (
 	// FlagPlatformKubernetes represents the value for the 'platform' flag for Kubernetes
 	// +k8s:openapi-gen=true
@@ -67,6 +71,14 @@ const (
 	// AnnotationProvisionedKafkaValue is a label to be added to Kafkas that have been provisioned by Jaeger
 	// +k8s:openapi-gen=true
 	AnnotationProvisionedKafkaValue string = "true"
+
+	// JaegerPhaseFailed indicates that the Jaeger instance failed to be provisioned
+	// +k8s:openapi-gen=true
+	JaegerPhaseFailed JaegerPhase = "Failed"
+
+	// JaegerPhaseRunning indicates that the Jaeger instance is ready and running
+	// +k8s:openapi-gen=true
+	JaegerPhaseRunning JaegerPhase = "Running"
 )
 
 // JaegerSpec defines the desired state of Jaeger
@@ -110,12 +122,18 @@ type JaegerSpec struct {
 // +k8s:openapi-gen=true
 type JaegerStatus struct {
 	Version string `json:"version"`
+
+	// +kubebuilder:validation:Default=Pending
+	Phase JaegerPhase `json:"phase"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Jaeger is the Schema for the jaegers API
 // +k8s:openapi-gen=true
+// +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.phase",description="Instance's status"
+// +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".status.version",description="Jaeger Version"
 type Jaeger struct {
 	metav1.TypeMeta `json:",inline"`
 

--- a/pkg/apis/jaegertracing/v1/jaeger_types.go
+++ b/pkg/apis/jaegertracing/v1/jaeger_types.go
@@ -121,10 +121,8 @@ type JaegerSpec struct {
 // JaegerStatus defines the observed state of Jaeger
 // +k8s:openapi-gen=true
 type JaegerStatus struct {
-	Version string `json:"version"`
-
-	// +kubebuilder:validation:Default=Pending
-	Phase JaegerPhase `json:"phase"`
+	Version string      `json:"version"`
+	Phase   JaegerPhase `json:"phase"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -132,7 +130,7 @@ type JaegerStatus struct {
 // Jaeger is the Schema for the jaegers API
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.phase",description="Instance's status"
+// +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.phase",description="Jaeger instance's status"
 // +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".status.version",description="Jaeger Version"
 type Jaeger struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/controller/jaeger/jaeger_controller.go
+++ b/pkg/controller/jaeger/jaeger_controller.go
@@ -202,7 +202,7 @@ func (r *ReconcileJaeger) Reconcile(request reconcile.Request) (reconcile.Result
 	if instance.Status.Phase != v1.JaegerPhaseRunning {
 		instance.Status.Phase = v1.JaegerPhaseRunning
 		if err := r.client.Status().Update(ctx, instance); err != nil {
-			logFields.WithError(err).Error("failed to store the status into the current CustomResource")
+			logFields.WithError(err).Error("failed to store the running status into the current CustomResource")
 			return reconcile.Result{}, tracing.HandleError(err, span)
 		}
 	}

--- a/pkg/controller/jaeger/jaeger_controller_test.go
+++ b/pkg/controller/jaeger/jaeger_controller_test.go
@@ -53,9 +53,10 @@ func TestNewJaegerInstance(t *testing.T) {
 	assert.NoError(t, err)
 
 	// these are filled with default values
-	// TODO(jpkroehling): enable the assertion when the following issue is fixed:
-	// https://github.com/jaegertracing/jaeger-operator/issues/231
-	// assert.Equal(t, "custom-strategy", persisted.Spec.Strategy)
+	assert.Equal(t, v1.DeploymentStrategyAllInOne, persisted.Spec.Strategy)
+
+	// the status object got updated as well
+	assert.Equal(t, v1.JaegerPhaseRunning, persisted.Status.Phase)
 }
 
 func TestDeletedInstance(t *testing.T) {
@@ -145,6 +146,9 @@ func TestSkipOnNonOwnedCR(t *testing.T) {
 
 	// the only way to reliably test this is to verify that the operator didn't attempt to set the ownership field
 	assert.Equal(t, "another-identity", persisted.Labels[v1.LabelOperatedBy])
+
+	// condition shouldn't be touched when the object belongs to another operator
+	assert.Equal(t, v1.JaegerPhase(""), persisted.Status.Phase)
 }
 
 func getReconciler(objs []runtime.Object) (*ReconcileJaeger, client.Client) {

--- a/pkg/controller/jaeger/jaeger_controller_test.go
+++ b/pkg/controller/jaeger/jaeger_controller_test.go
@@ -146,8 +146,6 @@ func TestSkipOnNonOwnedCR(t *testing.T) {
 
 	// the only way to reliably test this is to verify that the operator didn't attempt to set the ownership field
 	assert.Equal(t, "another-identity", persisted.Labels[v1.LabelOperatedBy])
-
-	// condition shouldn't be touched when the object belongs to another operator
 	assert.Equal(t, v1.JaegerPhase(""), persisted.Status.Phase)
 }
 


### PR DESCRIPTION
This PR adds a new `JaegerPhase` type, added to the `JaegerStatus`. When running `kubectl get jaegers`, this is what is shown now:

```
$ kubectl get jaegers
NAME                         STATUS    VERSION
jaeger-all-in-one-inmemory   Running   1.15.1
```

When getting the output as YAML for a specific instance, here's the output:

```
$ kubectl get jaegers jaeger-all-in-one-inmemory -o yaml | tail
      resources: {}
      schedule: '*/30 * * * *'
    options: {}
    type: memory
  strategy: allinone
  ui:
    options: {}
status:
  phase: Running
  version: 1.15.1
```

And here's how it shows up in OLM:

![image](https://user-images.githubusercontent.com/13387/70068061-9e92a880-15ef-11ea-90b7-58121eb5a481.png)

Note that the `Version` field isn't being showed in OLM yet.

This is related to #259, although it won't close it, as we might want to keep that open to discuss further status fields in the future.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>