### PR TITLE
Remove unnecessary options from auto-kafka-prov example

### DIFF
--- a/deploy/examples/auto-provision-kafka.yaml
+++ b/deploy/examples/auto-provision-kafka.yaml
@@ -11,13 +11,6 @@ metadata:
   name: auto-provision-kafka
 spec:
   strategy: streaming
-  collector:
-    image: jaegertracing/jaeger-collector:latest # TLS configuration is supported starting from 1.15
-  ingester:
-    image: jaegertracing/jaeger-ingester:latest # TLS configuration is supported starting from 1.15
-    options:
-      ingester:
-        deadlockInterval: 0
   storage:
     type: elasticsearch
     options:


### PR DESCRIPTION
Signed-off-by: Gary Brown <gary@brownuk.com>

Update to reflect snippet used in https://github.com/jaegertracing/documentation/pull/333. Specific images no longer required, and deadlockInterval defaults to 0 now.