### PR TITLE
Run rollover cronjob by default daily at midnight

### DIFF
--- a/pkg/strategy/controller.go
+++ b/pkg/strategy/controller.go
@@ -183,7 +183,7 @@ func normalizeElasticsearch(spec *v1.ElasticsearchSpec) {
 func normalizeRollover(spec *v1.JaegerEsRolloverSpec) {
 	spec.Image = util.ImageName(spec.Image, "jaeger-es-rollover-image")
 	if spec.Schedule == "" {
-		spec.Schedule = "0 3 * * *"
+		spec.Schedule = "0 0 * * *"
 	}
 }
 

--- a/pkg/strategy/controller.go
+++ b/pkg/strategy/controller.go
@@ -183,7 +183,7 @@ func normalizeElasticsearch(spec *v1.ElasticsearchSpec) {
 func normalizeRollover(spec *v1.JaegerEsRolloverSpec) {
 	spec.Image = util.ImageName(spec.Image, "jaeger-es-rollover-image")
 	if spec.Schedule == "" {
-		spec.Schedule = "*/30 * * * *"
+		spec.Schedule = "0 3 * * *"
 	}
 }
 

--- a/pkg/strategy/controller_test.go
+++ b/pkg/strategy/controller_test.go
@@ -208,7 +208,7 @@ func TestNormalizeRollover(t *testing.T) {
 		expected  v1.JaegerEsRolloverSpec
 	}{
 		{underTest: v1.JaegerEsRolloverSpec{},
-			expected: v1.JaegerEsRolloverSpec{Image: "hoo:0.0.0", Schedule: "*/30 * * * *"}},
+			expected: v1.JaegerEsRolloverSpec{Image: "hoo:0.0.0", Schedule: "0 3 * * *"}},
 		{underTest: v1.JaegerEsRolloverSpec{Image: "bla", Schedule: "lol"},
 			expected: v1.JaegerEsRolloverSpec{Image: "bla", Schedule: "lol"}},
 	}

--- a/pkg/strategy/controller_test.go
+++ b/pkg/strategy/controller_test.go
@@ -208,7 +208,7 @@ func TestNormalizeRollover(t *testing.T) {
 		expected  v1.JaegerEsRolloverSpec
 	}{
 		{underTest: v1.JaegerEsRolloverSpec{},
-			expected: v1.JaegerEsRolloverSpec{Image: "hoo:0.0.0", Schedule: "0 3 * * *"}},
+			expected: v1.JaegerEsRolloverSpec{Image: "hoo:0.0.0", Schedule: "0 0 * * *"}},
 		{underTest: v1.JaegerEsRolloverSpec{Image: "bla", Schedule: "lol"},
 			expected: v1.JaegerEsRolloverSpec{Image: "bla", Schedule: "lol"}},
 	}


### PR DESCRIPTION
https://issues.jboss.org/browse/TRACING-824

The currently the default rollover configuration creates:

```
NAME SCHEDULE SUSPEND ACTIVE LAST SCHEDULE AGE
cronjob.batch/simple-prod-es-index-cleaner 55 23 * * * False 0 <none> 2m15s
cronjob.batch/simple-prod-es-lookback */30 * * * * False 0 <none> 2m15s
cronjob.batch/simple-prod-es-rollover */30 * * * * False 0 <none> 2m15s
```

The rollover condition: `'{"max_age": "7d"}'`

This means we run rollover cronjob every 30 minutes and the action takes place every week. Multiple runs a day make might make sense if the conditions are based on the size of the index - however this is supported only in ES6.

We should change the schedule to run once a day. I think it makes the most sense at the moment.

Regarding the default conditions - rollover every 7 days might be too much given the default (no rollover) strategy creates an index every day and some organizations keep the data only for 7 days. We should shrink it to 2 days by default - and raise discussion on the PR.

Signed-off-by: Pavol Loffay <ploffay@redhat.com>