### PR TITLE
Use APIReader for Get/List resources for  autodetect

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	go.opentelemetry.io/otel/exporter/trace/jaeger v0.1.2
 	golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f // indirect
 	golang.org/x/net v0.0.0-20191028085509-fe3aa8a45271
-	golang.org/x/tools v0.0.0-20191130070609-6e064ea0cf2d // indirect
+	golang.org/x/tools v0.0.0-20191205002649-427c522ce2c7 // indirect
 	google.golang.org/grpc v1.24.0
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0

--- a/go.sum
+++ b/go.sum
@@ -777,6 +777,8 @@ golang.org/x/tools v0.0.0-20191101200257-8dbcdeb83d3f/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191125144606-a911d9008d1f/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191130070609-6e064ea0cf2d h1:/iIZNFGxc/a7C3yWjGcnboV+Tkc7mxr+p6fDztwoxuM=
 golang.org/x/tools v0.0.0-20191130070609-6e064ea0cf2d/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191205002649-427c522ce2c7 h1:R+waiss/kC/yzpcyEFoesbEJzgvWtLC4zRdYjBNKf1g=
+golang.org/x/tools v0.0.0-20191205002649-427c522ce2c7/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gomodules.xyz/jsonpatch/v2 v2.0.1 h1:xyiBuvkD2g5n7cYzx6u2sxQvsAy4QJsZFCzGVdzOXZ0=

--- a/pkg/autodetect/main_test.go
+++ b/pkg/autodetect/main_test.go
@@ -36,7 +36,7 @@ func TestStart(t *testing.T) {
 	// prepare
 	dcl := &fakeDiscoveryClient{}
 	cl := fake.NewFakeClient()
-	b := WithClients(cl, dcl)
+	b := WithClients(cl, dcl, cl)
 
 	done := make(chan bool)
 	go func() {
@@ -71,7 +71,7 @@ func TestStartContinuesInBackground(t *testing.T) {
 	cl.CreateFunc = func(ctx context.Context, obj runtime.Object, opts ...client.CreateOption) error {
 		return fmt.Errorf("faked error")
 	}
-	b := WithClients(cl, dcl)
+	b := WithClients(cl, dcl, cl)
 
 	done := make(chan bool)
 	go func() {
@@ -123,7 +123,7 @@ func TestAutoDetectFallback(t *testing.T) {
 
 	dcl := &fakeDiscoveryClient{}
 	cl := fake.NewFakeClient()
-	b := WithClients(cl, dcl)
+	b := WithClients(cl, dcl, cl)
 
 	// sanity check
 	assert.False(t, viper.IsSet("platform"))
@@ -149,7 +149,7 @@ func TestAutoDetectOpenShift(t *testing.T) {
 
 	dcl := &fakeDiscoveryClient{}
 	cl := fake.NewFakeClient()
-	b := WithClients(cl, dcl)
+	b := WithClients(cl, dcl, cl)
 
 	dcl.ServerGroupsFunc = func() (apiGroupList *metav1.APIGroupList, err error) {
 		return &metav1.APIGroupList{
@@ -173,7 +173,7 @@ func TestAutoDetectKubernetes(t *testing.T) {
 
 	dcl := &fakeDiscoveryClient{}
 	cl := fake.NewFakeClient()
-	b := WithClients(cl, dcl)
+	b := WithClients(cl, dcl, cl)
 
 	// test
 	b.autoDetectCapabilities()
@@ -189,7 +189,7 @@ func TestExplicitPlatform(t *testing.T) {
 
 	dcl := &fakeDiscoveryClient{}
 	cl := fake.NewFakeClient()
-	b := WithClients(cl, dcl)
+	b := WithClients(cl, dcl, cl)
 
 	// test
 	b.autoDetectCapabilities()
@@ -205,7 +205,7 @@ func TestAutoDetectEsProvisionNoEsOperator(t *testing.T) {
 
 	dcl := &fakeDiscoveryClient{}
 	cl := fake.NewFakeClient()
-	b := WithClients(cl, dcl)
+	b := WithClients(cl, dcl, cl)
 
 	// test
 	b.autoDetectCapabilities()
@@ -221,7 +221,7 @@ func TestAutoDetectEsProvisionWithEsOperator(t *testing.T) {
 
 	dcl := &fakeDiscoveryClient{}
 	cl := fake.NewFakeClient()
-	b := WithClients(cl, dcl)
+	b := WithClients(cl, dcl, cl)
 
 	dcl.ServerGroupsFunc = func() (apiGroupList *metav1.APIGroupList, err error) {
 		return &metav1.APIGroupList{
@@ -245,7 +245,7 @@ func TestAutoDetectKafkaProvisionNoKafkaOperator(t *testing.T) {
 
 	dcl := &fakeDiscoveryClient{}
 	cl := fake.NewFakeClient()
-	b := WithClients(cl, dcl)
+	b := WithClients(cl, dcl, cl)
 
 	// test
 	b.autoDetectCapabilities()
@@ -261,7 +261,7 @@ func TestAutoDetectKafkaProvisionWithKafkaOperator(t *testing.T) {
 
 	dcl := &fakeDiscoveryClient{}
 	cl := fake.NewFakeClient()
-	b := WithClients(cl, dcl)
+	b := WithClients(cl, dcl, cl)
 
 	dcl.ServerGroupsFunc = func() (apiGroupList *metav1.APIGroupList, err error) {
 		return &metav1.APIGroupList{
@@ -285,7 +285,7 @@ func TestAutoDetectKafkaExplicitYes(t *testing.T) {
 
 	dcl := &fakeDiscoveryClient{}
 	cl := fake.NewFakeClient()
-	b := WithClients(cl, dcl)
+	b := WithClients(cl, dcl, cl)
 
 	// test
 	b.autoDetectCapabilities()
@@ -301,7 +301,7 @@ func TestAutoDetectKafkaExplicitNo(t *testing.T) {
 
 	dcl := &fakeDiscoveryClient{}
 	cl := fake.NewFakeClient()
-	b := WithClients(cl, dcl)
+	b := WithClients(cl, dcl, cl)
 
 	// test
 	b.autoDetectCapabilities()
@@ -317,7 +317,7 @@ func TestAutoDetectKafkaDefaultNoOperator(t *testing.T) {
 
 	dcl := &fakeDiscoveryClient{}
 	cl := fake.NewFakeClient()
-	b := WithClients(cl, dcl)
+	b := WithClients(cl, dcl, cl)
 
 	// test
 	b.autoDetectCapabilities()
@@ -333,7 +333,7 @@ func TestAutoDetectKafkaDefaultWithOperator(t *testing.T) {
 
 	dcl := &fakeDiscoveryClient{}
 	cl := fake.NewFakeClient()
-	b := WithClients(cl, dcl)
+	b := WithClients(cl, dcl, cl)
 
 	dcl.ServerGroupsFunc = func() (apiGroupList *metav1.APIGroupList, err error) {
 		return &metav1.APIGroupList{
@@ -359,7 +359,7 @@ func TestNoAuthDelegatorAvailable(t *testing.T) {
 	cl.CreateFunc = func(ctx context.Context, obj runtime.Object, opts ...client.CreateOption) error {
 		return fmt.Errorf("faked error")
 	}
-	b := WithClients(cl, dcl)
+	b := WithClients(cl, dcl, cl)
 
 	// test
 	b.detectClusterRoles()
@@ -377,7 +377,7 @@ func TestAuthDelegatorBecomesAvailable(t *testing.T) {
 	cl.CreateFunc = func(ctx context.Context, obj runtime.Object, opts ...client.CreateOption) error {
 		return fmt.Errorf("faked error")
 	}
-	b := WithClients(cl, dcl)
+	b := WithClients(cl, dcl, cl)
 
 	// test
 	b.detectClusterRoles()
@@ -394,7 +394,7 @@ func TestAuthDelegatorBecomesUnavailable(t *testing.T) {
 
 	dcl := &fakeDiscoveryClient{}
 	cl := customFakeClient()
-	b := WithClients(cl, dcl)
+	b := WithClients(cl, dcl, cl)
 
 	// test
 	b.detectClusterRoles()
@@ -474,7 +474,7 @@ func TestCleanDeployments(t *testing.T) {
 	err = cl.Create(context.TODO(), jaeger2)
 	require.NoError(t, err)
 
-	b := WithClients(cl, dcl)
+	b := WithClients(cl, dcl, cl)
 	b.cleanDeployments()
 	persisted1 := &appsv1.Deployment{}
 	err = cl.Get(context.Background(), types.NamespacedName{
@@ -501,7 +501,7 @@ func TestRequireUpdates(t *testing.T) {
 
 	dcl := &fakeDiscoveryClient{}
 	cl := customFakeClient()
-	b := WithClients(cl, dcl)
+	b := WithClients(cl, dcl, cl)
 
 	deps := &appsv1.DeploymentList{
 		Items: []appsv1.Deployment{{

--- a/pkg/cmd/start/bootstrap.go
+++ b/pkg/cmd/start/bootstrap.go
@@ -203,7 +203,7 @@ func performUpgrades(ctx context.Context, mgr manager.Manager) {
 	defer span.End()
 
 	// upgrades all the instances managed by this operator
-	if err := upgrade.ManagedInstances(ctx, mgr.GetClient()); err != nil {
+	if err := upgrade.ManagedInstances(ctx, mgr.GetClient(), mgr.GetAPIReader()); err != nil {
 		log.WithError(err).Warn("failed to upgrade managed instances")
 	}
 }

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -14,7 +14,7 @@ import (
 )
 
 // ManagedInstances finds all the Jaeger instances for the current operator and upgrades them, if necessary
-func ManagedInstances(ctx context.Context, c client.Client) error {
+func ManagedInstances(ctx context.Context, c client.Client, reader client.Reader) error {
 	tracer := global.TraceProvider().GetTracer(v1.ReconciliationTracer)
 	ctx, span := tracer.Start(ctx, "ManagedInstances")
 	defer span.End()
@@ -24,7 +24,7 @@ func ManagedInstances(ctx context.Context, c client.Client) error {
 	opts := client.MatchingLabels(map[string]string{
 		v1.LabelOperatedBy: identity,
 	})
-	if err := c.List(ctx, list, opts); err != nil {
+	if err := reader.List(ctx, list, opts); err != nil {
 		return tracing.HandleError(err, span)
 	}
 

--- a/pkg/upgrade/upgrade_test.go
+++ b/pkg/upgrade/upgrade_test.go
@@ -28,7 +28,7 @@ func TestVersionUpgradeToLatest(t *testing.T) {
 	cl := fake.NewFakeClient(objs...)
 
 	// test
-	assert.NoError(t, ManagedInstances(context.Background(), cl))
+	assert.NoError(t, ManagedInstances(context.Background(), cl, cl))
 
 	// verify
 	persisted := &v1.Jaeger{}
@@ -56,7 +56,7 @@ func TestVersionUpgradeToLatestOwnedResource(t *testing.T) {
 	cl := fake.NewFakeClient(objs...)
 
 	// test
-	assert.NoError(t, ManagedInstances(context.Background(), cl))
+	assert.NoError(t, ManagedInstances(context.Background(), cl, cl))
 
 	// verify
 	persisted := &v1.Jaeger{}
@@ -78,7 +78,7 @@ func TestUnknownVersion(t *testing.T) {
 	cl := fake.NewFakeClient(objs...)
 
 	// test
-	assert.NoError(t, ManagedInstances(context.Background(), cl))
+	assert.NoError(t, ManagedInstances(context.Background(), cl, cl))
 
 	// verify
 	persisted := &v1.Jaeger{}
@@ -106,7 +106,7 @@ func TestSkipForNonOwnedInstances(t *testing.T) {
 	cl := fake.NewFakeClient(objs...)
 
 	// test
-	assert.NoError(t, ManagedInstances(context.Background(), cl))
+	assert.NoError(t, ManagedInstances(context.Background(), cl, cl))
 
 	// verify
 	persisted := &v1.Jaeger{}

--- a/pkg/upgrade/v1_15_0_test.go
+++ b/pkg/upgrade/v1_15_0_test.go
@@ -28,7 +28,7 @@ func TestUpgradeDeprecatedOptions(t *testing.T) {
 	cl := fake.NewFakeClient(objs...)
 
 	// test
-	assert.NoError(t, ManagedInstances(context.Background(), cl))
+	assert.NoError(t, ManagedInstances(context.Background(), cl, cl))
 
 	// verify
 	persisted := &v1.Jaeger{}


### PR DESCRIPTION
This might Fix https://github.com/jaegertracing/jaeger-operator/issues/809

Now the errors are gone..

Not sure how bad is to use a "non-cached" client to do the reads, specially on routines that are executed periodically.

@jpkrohling 