### PR TITLE
Add wait for jaeger deployment to fix race conditions

### DIFF
--- a/test/e2e/sidecar_test.go
+++ b/test/e2e/sidecar_test.go
@@ -72,6 +72,9 @@ func (suite *SidecarTestSuite) TestSidecar() {
 	require.NoError(t, err, "Failed to create jaeger instance")
 	defer undeployJaegerInstance(j)
 
+	err = e2eutil.WaitForDeployment(t, fw.KubeClient, namespace, jaegerInstanceName, 1, retryInterval, timeout)
+	require.NoError(t, err, "Error waiting for Jaeger instance deployment")
+
 	dep := getVertxDefinition(namespace)
 	err = fw.Client.Create(goctx.TODO(), dep, cleanupOptions)
 	require.NoError(t, err, "Failed to create vertx instance")


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com>

This should fix a couple of different test failures that occur intermittently with this test.  Previously the vertx app could finish deploying before the Jaeger instance did, and no traces would actually get logged.
