### PR TITLE
Add timeout for Cassandra Schema creation job

### DIFF
--- a/deploy/examples/with-cassandra.yaml
+++ b/deploy/examples/with-cassandra.yaml
@@ -15,4 +15,4 @@ spec:
     cassandraCreateSchema:
       datacenter: "datacenter3"
       mode: "test"
-      timeout: 180
+      timeout: "3m"

--- a/deploy/examples/with-cassandra.yaml
+++ b/deploy/examples/with-cassandra.yaml
@@ -15,3 +15,4 @@ spec:
     cassandraCreateSchema:
       datacenter: "datacenter3"
       mode: "test"
+      timeout: 180

--- a/pkg/apis/jaegertracing/v1/jaeger_types.go
+++ b/pkg/apis/jaegertracing/v1/jaeger_types.go
@@ -399,8 +399,9 @@ type JaegerCassandraCreateSchemaSpec struct {
 	// +optional
 	Mode string `json:"mode,omitempty"`
 
+	// we parse it with time.ParseDuration
 	// +optional
-	Timeout *int64 `json:"timeout,omitempty"`
+	Timeout string `json:"timeout,omitempty"`
 
 	// +optional
 	TTLSecondsAfterFinished *int32 `json:"ttlSecondsAfterFinished,omitempty"`

--- a/pkg/apis/jaegertracing/v1/jaeger_types.go
+++ b/pkg/apis/jaegertracing/v1/jaeger_types.go
@@ -400,6 +400,9 @@ type JaegerCassandraCreateSchemaSpec struct {
 	Mode string `json:"mode,omitempty"`
 
 	// +optional
+	Timeout *int64 `json:"timeout,omitempty"`
+
+	// +optional
 	TTLSecondsAfterFinished *int32 `json:"ttlSecondsAfterFinished,omitempty"`
 }
 

--- a/pkg/apis/jaegertracing/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/jaegertracing/v1/zz_generated.deepcopy.go
@@ -131,6 +131,11 @@ func (in *JaegerCassandraCreateSchemaSpec) DeepCopyInto(out *JaegerCassandraCrea
 		*out = new(bool)
 		**out = **in
 	}
+	if in.Timeout != nil {
+		in, out := &in.Timeout, &out.Timeout
+		*out = new(int64)
+		**out = **in
+	}
 	if in.TTLSecondsAfterFinished != nil {
 		in, out := &in.TTLSecondsAfterFinished, &out.TTLSecondsAfterFinished
 		*out = new(int32)

--- a/pkg/apis/jaegertracing/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/jaegertracing/v1/zz_generated.deepcopy.go
@@ -131,11 +131,6 @@ func (in *JaegerCassandraCreateSchemaSpec) DeepCopyInto(out *JaegerCassandraCrea
 		*out = new(bool)
 		**out = **in
 	}
-	if in.Timeout != nil {
-		in, out := &in.Timeout, &out.Timeout
-		*out = new(int64)
-		**out = **in
-	}
 	if in.TTLSecondsAfterFinished != nil {
 		in, out := &in.TTLSecondsAfterFinished, &out.TTLSecondsAfterFinished
 		*out = new(int32)

--- a/pkg/storage/cassandra_dependencies_test.go
+++ b/pkg/storage/cassandra_dependencies_test.go
@@ -56,3 +56,22 @@ func TestCassandraCreateSchemaEnabledNil(t *testing.T) {
 	assert.Nil(t, jaeger.Spec.Storage.CassandraCreateSchema.Enabled)
 	assert.Len(t, cassandraDeps(jaeger), 1)
 }
+
+func TestCassandraCreateSchemaCustomTimeout(t *testing.T) {
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestCassandraCreateSchemaCustomTimeout"})
+
+	threeMinutes := int64(180)
+	jaeger.Spec.Storage.CassandraCreateSchema.Timeout = &threeMinutes
+
+	b := cassandraDeps(jaeger)
+	assert.Len(t, b, 1)
+	assert.Equal(t, threeMinutes, *b[0].Spec.ActiveDeadlineSeconds)
+}
+
+func TestCassandraCreateSchemaDefaultTimeout(t *testing.T) {
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestCassandraCreateSchemaDefaultTimeout"})
+
+	b := cassandraDeps(jaeger)
+	assert.Len(t, b, 1)
+	assert.Equal(t, int64(120), *b[0].Spec.ActiveDeadlineSeconds)
+}

--- a/pkg/storage/cassandra_dependencies_test.go
+++ b/pkg/storage/cassandra_dependencies_test.go
@@ -60,16 +60,25 @@ func TestCassandraCreateSchemaEnabledNil(t *testing.T) {
 func TestCassandraCreateSchemaCustomTimeout(t *testing.T) {
 	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestCassandraCreateSchemaCustomTimeout"})
 
-	threeMinutes := int64(180)
-	jaeger.Spec.Storage.CassandraCreateSchema.Timeout = &threeMinutes
+	jaeger.Spec.Storage.CassandraCreateSchema.Timeout = "3m"
 
 	b := cassandraDeps(jaeger)
 	assert.Len(t, b, 1)
-	assert.Equal(t, threeMinutes, *b[0].Spec.ActiveDeadlineSeconds)
+	assert.Equal(t, int64(180), *b[0].Spec.ActiveDeadlineSeconds)
 }
 
 func TestCassandraCreateSchemaDefaultTimeout(t *testing.T) {
 	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestCassandraCreateSchemaDefaultTimeout"})
+
+	b := cassandraDeps(jaeger)
+	assert.Len(t, b, 1)
+	assert.Equal(t, int64(120), *b[0].Spec.ActiveDeadlineSeconds)
+}
+
+func TestCassandraCreateSchemaInvalidTimeout(t *testing.T) {
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestCassandraCreateSchemaInvalidTimeout"})
+
+	jaeger.Spec.Storage.CassandraCreateSchema.Timeout = "3mm"
 
 	b := cassandraDeps(jaeger)
 	assert.Len(t, b, 1)


### PR DESCRIPTION
Cassandra pods need sometimes more than 2 minutes to bootstrap. When
this happens, the Cassandra Schema job is failing, and prevents further
deployment of Jaeger components.

By allowing to define a custome timeout for this job, we can circumvent
this problem.

Resolves #818

Signed-off-by: Alexandre Figura <arugifa@users.noreply.github.com>