### PR TITLE
Fixed permissions for ServiceMonitor objects

### DIFF
--- a/deploy/olm-catalog/jaeger-operator/1.15.1/jaeger-operator.v1.15.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/jaeger-operator/1.15.1/jaeger-operator.v1.15.1.clusterserviceversion.yaml
@@ -80,6 +80,7 @@ spec:
           resources:
           - pods
           - services
+          - services/finalizers
           - endpoints
           - persistentvolumeclaims
           - events
@@ -208,6 +209,7 @@ spec:
           resources:
           - pods
           - services
+          - services/finalizers
           - endpoints
           - persistentvolumeclaims
           - events
@@ -235,6 +237,10 @@ spec:
         - apiGroups:
           - extensions
           resources:
+          - replicasets
+          - deployments
+          - daemonsets
+          - statefulsets
           - ingresses
           verbs:
           - '*'
@@ -246,6 +252,24 @@ spec:
           verbs:
           - '*'
         - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - '*'
+        - apiGroups:
+          - logging.openshift.io
+          resources:
+          - elasticsearches
+          verbs:
+          - '*'
+        - apiGroups:
+          - jaegertracing.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
           - rbac.authorization.k8s.io
           resources:
           - clusterrolebindings
@@ -253,12 +277,20 @@ spec:
           - '*'
         - apiGroups:
           - apps
+          - extensions
           resourceNames:
           - jaeger-operator
           resources:
           - deployments/finalizers
           verbs:
           - update
+        - apiGroups:
+          - kafka.strimzi.io
+          resources:
+          - kafkas
+          - kafkausers
+          verbs:
+          - '*'
         serviceAccountName: jaeger-operator
     strategy: deployment
   installModes:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -10,6 +10,7 @@ rules:
   resources:
   - pods
   - services
+  - services/finalizers
   - endpoints
   - persistentvolumeclaims
   - events

--- a/pkg/cmd/start/bootstrap.go
+++ b/pkg/cmd/start/bootstrap.go
@@ -180,11 +180,11 @@ func serveCRMetrics(ctx context.Context, cfg *rest.Config, operatorNs string) {
 	defer span.End()
 
 	// Below function returns filtered operator/CustomResource specific GVKs.
-	// For more control override the below GVK list with your own custom logic.
-	filteredGVK, err := k8sutil.GetGVKsFromAddToScheme(apis.AddToScheme)
+	// this should list all the AddToScheme funcs for GKVs that are managed by this operator
+	filteredGVK, err := k8sutil.GetGVKsFromAddToScheme(v1.SchemeBuilder.AddToScheme)
 	if err != nil {
 		span.SetStatus(codes.Internal)
-		log.WithError(err).Warn("could not generate and serve custom resource metrics")
+		log.WithError(err).Warn("could not retrieve group/version/kind managed by this operator")
 		return
 	}
 

--- a/test/role.yaml
+++ b/test/role.yaml
@@ -9,6 +9,7 @@ rules:
   resources:
   - pods
   - services
+  - services/finalizers
   - endpoints
   - persistentvolumeclaims
   - events


### PR DESCRIPTION
This PR fixes the permissions problems related to the creation of `ServiceMonitor` objects. After this PR, this is how a Jaeger Operator bootstrap looks like:

```
$ kubectl logs jaeger-operator-798b484d4b-zssb6 -f
time="2019-12-17T10:05:19Z" level=info msg=Versions arch=amd64 identity=openshift-marketplace.jaeger-operator jaeger=1.15.1 jaeger-operator=v1.15.1-29-g08132f63 operator-sdk=v0.12.0 os=linux version=go1.13.4
time="2019-12-17T10:05:23Z" level=info msg="Auto-detected the platform" platform=openshift
time="2019-12-17T10:05:23Z" level=info msg="Automatically adjusted the 'es-provision' flag" es-provision=no
time="2019-12-17T10:05:23Z" level=info msg="Automatically adjusted the 'kafka-provision' flag" kafka-provision=no
time="2019-12-17T10:05:23Z" level=info msg="The service account running this operator does not have the role 'system:auth-delegator', consider granting it for additional capabilities"
```

If the pod is killed and a new operator is started in the same namespace, the following is seen:
```
$ kubectl logs -f jaeger-operator-798b484d4b-tdfrg
time="2019-12-17T10:11:33Z" level=info msg=Versions arch=amd64 identity=openshift-marketplace.jaeger-operator jaeger=1.15.1 jaeger-operator=v1.15.1-29-g08132f63 operator-sdk=v0.12.0 os=linux version=go1.13.4
time="2019-12-17T10:11:37Z" level=info msg="Auto-detected the platform" platform=openshift
time="2019-12-17T10:11:37Z" level=info msg="Automatically adjusted the 'es-provision' flag" es-provision=no
time="2019-12-17T10:11:37Z" level=info msg="Automatically adjusted the 'kafka-provision' flag" kafka-provision=no
time="2019-12-17T10:11:37Z" level=info msg="The service account running this operator does not have the role 'system:auth-delegator', consider granting it for additional capabilities"
time="2019-12-17T10:11:44Z" level=warning msg="could not create ServiceMonitor object" error="servicemonitors.monitoring.coreos.com \"jaeger-operator-metrics\" already exists"
```

Fixes #804.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>