### PR TITLE
Increase timeout to avoid test failures

### DIFF
--- a/test/e2e/elasticsearch_test.go
+++ b/test/e2e/elasticsearch_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
@@ -236,7 +237,7 @@ func turnOnEsIndexCleaner(name string, exampleJaeger *v1.Jaeger) {
 	err = fw.Client.Update(context.Background(), exampleJaeger)
 	require.NoError(t, err)
 
-	err = WaitForCronJob(t, fw.KubeClient, namespace, fmt.Sprintf("%s-es-index-cleaner", name), retryInterval, timeout)
+	err = WaitForCronJob(t, fw.KubeClient, namespace, fmt.Sprintf("%s-es-index-cleaner", name), retryInterval, 3*time.Minute)
 	require.NoError(t, err, "Error waiting for Cron Job")
 
 	err = WaitForJobOfAnOwner(t, fw.KubeClient, namespace, fmt.Sprintf("%s-es-index-cleaner", name), retryInterval, timeout)

--- a/test/e2e/elasticsearch_test.go
+++ b/test/e2e/elasticsearch_test.go
@@ -237,7 +237,7 @@ func turnOnEsIndexCleaner(name string, exampleJaeger *v1.Jaeger) {
 	err = fw.Client.Update(context.Background(), exampleJaeger)
 	require.NoError(t, err)
 
-	err = WaitForCronJob(t, fw.KubeClient, namespace, fmt.Sprintf("%s-es-index-cleaner", name), retryInterval, 3*time.Minute)
+	err = WaitForCronJob(t, fw.KubeClient, namespace, fmt.Sprintf("%s-es-index-cleaner", name), retryInterval, timeout+1*time.Minute)
 	require.NoError(t, err, "Error waiting for Cron Job")
 
 	err = WaitForJobOfAnOwner(t, fw.KubeClient, namespace, fmt.Sprintf("%s-es-index-cleaner", name), retryInterval, timeout)


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com>  I've increased the timeout for this cron job as it often takes close to the default 2 minutes, and can sometimes take more than that (at least on OCP 4.1) resulting in test failures.
