### PR TITLE
Breaking change - removed 'Size' property from components

### DIFF
--- a/deploy/crds/jaegertracing.io_jaegers_crd.yaml
+++ b/deploy/crds/jaegertracing.io_jaegers_crd.yaml
@@ -5457,10 +5457,6 @@ spec:
                   type: object
                 serviceAccount:
                   type: string
-                size:
-                  description: Size represents the number of replicas to create for
-                    this service. DEPRECATED, use `Replicas` instead.
-                  type: integer
                 tolerations:
                   items:
                     description: The pod this Toleration is attached to tolerates
@@ -7508,10 +7504,6 @@ spec:
                   type: object
                 serviceAccount:
                   type: string
-                size:
-                  description: Size represents the number of replicas to create for
-                    this service. DEPRECATED, use `Replicas` instead.
-                  type: integer
                 tolerations:
                   items:
                     description: The pod this Toleration is attached to tolerates
@@ -11637,10 +11629,6 @@ spec:
                   type: object
                 serviceAccount:
                   type: string
-                size:
-                  description: Size represents the number of replicas to create for
-                    this service. DEPRECATED, use `Replicas` instead.
-                  type: integer
                 tolerations:
                   items:
                     description: The pod this Toleration is attached to tolerates

--- a/pkg/apis/jaegertracing/v1/jaeger_types.go
+++ b/pkg/apis/jaegertracing/v1/jaeger_types.go
@@ -182,10 +182,6 @@ type JaegerCommonSpec struct {
 // JaegerQuerySpec defines the options to be used when deploying the query
 // +k8s:openapi-gen=true
 type JaegerQuerySpec struct {
-	// Size represents the number of replicas to create for this service. DEPRECATED, use `Replicas` instead.
-	// +optional
-	Size int `json:"size,omitempty"`
-
 	// Replicas represents the number of replicas to create for this service.
 	// +optional
 	Replicas *int32 `json:"replicas,omitempty"`
@@ -283,10 +279,6 @@ type JaegerAllInOneSpec struct {
 // JaegerCollectorSpec defines the options to be used when deploying the collector
 // +k8s:openapi-gen=true
 type JaegerCollectorSpec struct {
-	// Size represents the number of replicas to create for this service. DEPRECATED, use `Replicas` instead.
-	// +optional
-	Size int `json:"size,omitempty"`
-
 	// Replicas represents the number of replicas to create for this service.
 	// +optional
 	Replicas *int32 `json:"replicas,omitempty"`
@@ -304,10 +296,6 @@ type JaegerCollectorSpec struct {
 // JaegerIngesterSpec defines the options to be used when deploying the ingester
 // +k8s:openapi-gen=true
 type JaegerIngesterSpec struct {
-	// Size represents the number of replicas to create for this service. DEPRECATED, use `Replicas` instead.
-	// +optional
-	Size int `json:"size,omitempty"`
-
 	// Replicas represents the number of replicas to create for this service.
 	// +optional
 	Replicas *int32 `json:"replicas,omitempty"`

--- a/pkg/apis/jaegertracing/v1/zz_generated.openapi.go
+++ b/pkg/apis/jaegertracing/v1/zz_generated.openapi.go
@@ -450,13 +450,6 @@ func schema_pkg_apis_jaegertracing_v1_JaegerCollectorSpec(ref common.ReferenceCa
 				Description: "JaegerCollectorSpec defines the options to be used when deploying the collector",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
-					"size": {
-						SchemaProps: spec.SchemaProps{
-							Description: "Size represents the number of replicas to create for this service. DEPRECATED, use `Replicas` instead.",
-							Type:        []string{"integer"},
-							Format:      "int32",
-						},
-					},
 					"replicas": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Replicas represents the number of replicas to create for this service.",
@@ -1031,13 +1024,6 @@ func schema_pkg_apis_jaegertracing_v1_JaegerIngesterSpec(ref common.ReferenceCal
 				Description: "JaegerIngesterSpec defines the options to be used when deploying the ingester",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
-					"size": {
-						SchemaProps: spec.SchemaProps{
-							Description: "Size represents the number of replicas to create for this service. DEPRECATED, use `Replicas` instead.",
-							Type:        []string{"integer"},
-							Format:      "int32",
-						},
-					},
 					"replicas": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Replicas represents the number of replicas to create for this service.",
@@ -1413,13 +1399,6 @@ func schema_pkg_apis_jaegertracing_v1_JaegerQuerySpec(ref common.ReferenceCallba
 				Description: "JaegerQuerySpec defines the options to be used when deploying the query",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
-					"size": {
-						SchemaProps: spec.SchemaProps{
-							Description: "Size represents the number of replicas to create for this service. DEPRECATED, use `Replicas` instead.",
-							Type:        []string{"integer"},
-							Format:      "int32",
-						},
-					},
 					"replicas": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Replicas represents the number of replicas to create for this service.",

--- a/pkg/deployment/collector_test.go
+++ b/pkg/deployment/collector_test.go
@@ -19,15 +19,6 @@ func init() {
 	viper.SetDefault("jaeger-collector-image", "jaegertracing/all-in-one")
 }
 
-func TestNegativeSize(t *testing.T) {
-	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestNegativeSize"})
-	jaeger.Spec.Collector.Size = -1
-
-	collector := NewCollector(jaeger)
-	dep := collector.Get()
-	assert.Equal(t, int32(1), *dep.Spec.Replicas)
-}
-
 func TestNegativeReplicas(t *testing.T) {
 	size := int32(-1)
 	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestNegativeReplicas"})
@@ -54,26 +45,6 @@ func TestReplicaSize(t *testing.T) {
 	collector := NewCollector(jaeger)
 	dep := collector.Get()
 	assert.Equal(t, int32(0), *dep.Spec.Replicas)
-}
-
-func TestSize(t *testing.T) {
-	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestSize"})
-	jaeger.Spec.Collector.Size = 2
-
-	collector := NewCollector(jaeger)
-	dep := collector.Get()
-	assert.Equal(t, int32(2), *dep.Spec.Replicas)
-}
-
-func TestReplicaWinsOverSize(t *testing.T) {
-	size := int32(3)
-	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestReplicaWinsOverSize"})
-	jaeger.Spec.Collector.Size = 2
-	jaeger.Spec.Collector.Replicas = &size
-
-	collector := NewCollector(jaeger)
-	dep := collector.Get()
-	assert.Equal(t, int32(3), *dep.Spec.Replicas)
 }
 
 func TestName(t *testing.T) {

--- a/pkg/deployment/ingester.go
+++ b/pkg/deployment/ingester.go
@@ -23,16 +23,6 @@ type Ingester struct {
 
 // NewIngester builds a new Ingester struct based on the given spec
 func NewIngester(jaeger *v1.Jaeger) *Ingester {
-	if jaeger.Spec.Ingester.Replicas == nil || *jaeger.Spec.Ingester.Replicas < 0 {
-		replicaSize := int32(1)
-		if jaeger.Spec.Ingester.Size > 0 {
-			jaeger.Logger().Warn("The 'size' property for the ingester is deprecated. Use 'replicas' instead.")
-			replicaSize = int32(jaeger.Spec.Ingester.Size)
-		}
-
-		jaeger.Spec.Ingester.Replicas = &replicaSize
-	}
-
 	return &Ingester{jaeger: jaeger}
 }
 
@@ -81,6 +71,12 @@ func (i *Ingester) Get() *appsv1.Deployment {
 	// see https://github.com/jaegertracing/jaeger-operator/issues/334
 	sort.Strings(options)
 
+	replicaSize := i.jaeger.Spec.Ingester.Replicas
+	if replicaSize == nil || *replicaSize < 0 {
+		s := int32(1)
+		replicaSize = &s
+	}
+
 	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apps/v1",
@@ -101,7 +97,7 @@ func (i *Ingester) Get() *appsv1.Deployment {
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: i.jaeger.Spec.Ingester.Replicas,
+			Replicas: replicaSize,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: labels,
 			},

--- a/pkg/deployment/ingester_test.go
+++ b/pkg/deployment/ingester_test.go
@@ -26,15 +26,6 @@ func TestIngesterNotDefined(t *testing.T) {
 	assert.Nil(t, ingester.Get())
 }
 
-func TestIngesterNegativeSize(t *testing.T) {
-	jaeger := newIngesterJaeger("TestIngesterNegativeSize")
-	jaeger.Spec.Ingester.Size = -1
-
-	ingester := NewIngester(jaeger)
-	dep := ingester.Get()
-	assert.Equal(t, int32(1), *dep.Spec.Replicas)
-}
-
 func TestIngesterNegativeReplicas(t *testing.T) {
 	size := int32(-1)
 	jaeger := newIngesterJaeger("TestIngesterNegativeReplicas")
@@ -61,26 +52,6 @@ func TestIngesterReplicaSize(t *testing.T) {
 	ingester := NewIngester(jaeger)
 	dep := ingester.Get()
 	assert.Equal(t, int32(0), *dep.Spec.Replicas)
-}
-
-func TestIngesterSize(t *testing.T) {
-	jaeger := newIngesterJaeger("TestIngesterSize")
-	jaeger.Spec.Ingester.Size = 2
-
-	ingester := NewIngester(jaeger)
-	dep := ingester.Get()
-	assert.Equal(t, int32(2), *dep.Spec.Replicas)
-}
-
-func TestIngesterReplicaWinsOverSize(t *testing.T) {
-	size := int32(3)
-	jaeger := newIngesterJaeger("TestIngesterReplicaWinsOverSize")
-	jaeger.Spec.Ingester.Size = 2
-	jaeger.Spec.Ingester.Replicas = &size
-
-	ingester := NewIngester(jaeger)
-	dep := ingester.Get()
-	assert.Equal(t, int32(3), *dep.Spec.Replicas)
 }
 
 func TestIngesterName(t *testing.T) {

--- a/pkg/deployment/query_test.go
+++ b/pkg/deployment/query_test.go
@@ -18,15 +18,6 @@ func init() {
 	viper.SetDefault("jaeger-query-image", "jaegertracing/all-in-one")
 }
 
-func TestQueryNegativeSize(t *testing.T) {
-	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestQueryNegativeSize"})
-	jaeger.Spec.Query.Size = -1
-
-	query := NewQuery(jaeger)
-	dep := query.Get()
-	assert.Equal(t, int32(1), *dep.Spec.Replicas)
-}
-
 func TestQueryNegativeReplicas(t *testing.T) {
 	size := int32(-1)
 	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestQueryNegativeReplicas"})
@@ -53,26 +44,6 @@ func TestQueryReplicaSize(t *testing.T) {
 	ingester := NewQuery(jaeger)
 	dep := ingester.Get()
 	assert.Equal(t, int32(0), *dep.Spec.Replicas)
-}
-
-func TestQuerySize(t *testing.T) {
-	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestQuerySize"})
-	jaeger.Spec.Query.Size = 2
-
-	query := NewQuery(jaeger)
-	dep := query.Get()
-	assert.Equal(t, int32(2), *dep.Spec.Replicas)
-}
-
-func TestQueryReplicaWinsOverSize(t *testing.T) {
-	size := int32(3)
-	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestQueryReplicaWinsOverSize"})
-	jaeger.Spec.Query.Size = 2
-	jaeger.Spec.Query.Replicas = &size
-
-	query := NewQuery(jaeger)
-	dep := query.Get()
-	assert.Equal(t, int32(3), *dep.Spec.Replicas)
 }
 
 func TestDefaultQueryImage(t *testing.T) {


### PR DESCRIPTION
In preparation for #848, this would be a good time to remove the `Size` property from the `Collector`, `Ingester` and `Query`. It's been deprecated for quite some time, with a message similar to this:

> The 'size' property for the collector is deprecated. Use 'replicas' instead.

The documentation also shows that `Replicas` should be used:

> Size represents the number of replicas to create for this service. DEPRECATED, use `Replicas` instead.

CRs using `Size` should have been migrated automatically by the operator upon reconciliation, so, existing installations shouldn't break.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>