### PR TITLE
Increase timeout for cassandra example

### DIFF
--- a/test/e2e/examples1_test.go
+++ b/test/e2e/examples1_test.go
@@ -3,14 +3,21 @@
 package e2e
 
 import (
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
 	"os/exec"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/kubernetes/kubernetes/staging/src/k8s.io/apimachinery/pkg/util/intstr"
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 type ExamplesTestSuite struct {

--- a/test/e2e/examples1_test.go
+++ b/test/e2e/examples1_test.go
@@ -3,21 +3,14 @@
 package e2e
 
 import (
-	"context"
-	"encoding/json"
-	"io/ioutil"
-	"net/http"
 	"os/exec"
 	"strings"
 	"testing"
+	"time"
 
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 type ExamplesTestSuite struct {
@@ -97,7 +90,7 @@ func (suite *ExamplesTestSuite) TestWithCassandra() {
 	require.NoError(t, err, "Error waiting for cassandra")
 
 	yamlFileName := "../../deploy/examples/with-cassandra.yaml"
-	smokeTestAllInOneExample("with-cassandra", yamlFileName)
+	smokeTestAllInOneExampleWithTimeout("with-cassandra", yamlFileName, timeout+1*time.Minute)
 }
 
 func (suite *ExamplesTestSuite) TestBusinessApp() {

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -312,10 +312,14 @@ func createJaegerInstanceFromFile(name, filename string) *v1.Jaeger {
 }
 
 func smokeTestAllInOneExample(name, yamlFileName string) {
+	smokeTestAllInOneExampleWithTimeout(name, yamlFileName, timeout)
+}
+
+func smokeTestAllInOneExampleWithTimeout(name, yamlFileName string, to time.Duration) {
 	jaegerInstance := createJaegerInstanceFromFile(name, yamlFileName)
 	defer undeployJaegerInstance(jaegerInstance)
 
-	err := WaitForDeployment(t, fw.KubeClient, namespace, name, 1, retryInterval, timeout)
+	err := WaitForDeployment(t, fw.KubeClient, namespace, name, 1, retryInterval, to)
 	require.NoErrorf(t, err, "Error waiting for %s to deploy", name)
 
 	AllInOneSmokeTest(name)


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com>

This is the same case as https://github.com/jaegertracing/jaeger-operator/pull/857 except here it occurs when we test the example.
