### PR TITLE
Use k8s client random port forward.  Replaces workaround from PR #545

### DIFF
--- a/test/e2e/all_in_one_test.go
+++ b/test/e2e/all_in_one_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -134,11 +135,13 @@ func (suite *AllInOneTestSuite) TestAllInOneWithUIConfig() {
 	require.NoError(t, err, "Error waiting for jaeger deployment")
 	defer undeployJaegerInstance(j)
 
-	queryPort := randomPortNumber()
-	ports := []string{queryPort + ":16686"}
+	ports := []string{"0:16686"}
 	portForward, closeChan := CreatePortForward(namespace, "all-in-one-with-ui-config", "all-in-one", ports, fw.KubeConfig)
 	defer portForward.Close()
 	defer close(closeChan)
+	forwardedPorts, err := portForward.GetPorts()
+	require.NoError(t, err)
+	queryPort := strconv.Itoa(int(forwardedPorts[0].Local))
 
 	url := fmt.Sprintf("http://localhost:%s/%s/search", queryPort, basePath)
 	c := http.Client{Timeout: 3 * time.Second}

--- a/test/e2e/elasticsearch_test.go
+++ b/test/e2e/elasticsearch_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -224,9 +225,10 @@ func hasIndexWithPrefix(prefix string, esPort string) (bool, error) {
 }
 
 func createEsPortForward() (portForwES *portforward.PortForwarder, closeChanES chan struct{}, esPort string) {
-	esPort = randomPortNumber()
-	portForwES, closeChanES = CreatePortForward(storageNamespace, "elasticsearch", "elasticsearch", []string{esPort + ":9200"}, fw.KubeConfig)
-	return portForwES, closeChanES, esPort
+	portForwES, closeChanES = CreatePortForward(storageNamespace, "elasticsearch", "elasticsearch", []string{"0:9200"}, fw.KubeConfig)
+	forwardedPorts, err := portForwES.GetPorts()
+	require.NoError(t, err)
+	return portForwES, closeChanES, strconv.Itoa(int(forwardedPorts[0].Local))
 }
 
 func turnOnEsIndexCleaner(name string, exampleJaeger *v1.Jaeger) {

--- a/test/e2e/examples1_test.go
+++ b/test/e2e/examples1_test.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os/exec"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -138,11 +139,13 @@ func (suite *ExamplesTestSuite) TestBusinessApp() {
 	}
 
 	// Confirm that we've created some traces
-	queryPort := randomPortNumber()
-	ports := []string{queryPort + ":16686"}
+	ports := []string{"0:16686"}
 	portForward, closeChan := CreatePortForward(namespace, "simplest", "all-in-one", ports, fw.KubeConfig)
 	defer portForward.Close()
 	defer close(closeChan)
+	forwardedPorts, err := portForward.GetPorts()
+	require.NoError(t, err)
+	queryPort := strconv.Itoa(int(forwardedPorts[0].Local))
 
 	url := "http://localhost:" + queryPort + "/api/traces?service=order"
 	err = WaitAndPollForHTTPResponse(url, func(response *http.Response) (bool, error) {

--- a/test/e2e/port_forward.go
+++ b/test/e2e/port_forward.go
@@ -3,7 +3,6 @@ package e2e
 import (
 	"bytes"
 	"fmt"
-	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -53,18 +52,4 @@ func CreatePortForward(namespace, podNamePrefix, containsImage string, ports []s
 	}()
 	<-forwarder.Ready
 	return forwarder, stopChan
-}
-
-// TODO use port-forward from k8s instead once we upgrade k8s API to 1.15.0+.  See https://github.com/jaegertracing/jaeger-operator/pull/288
-func randomPortNumber() string {
-	listener, err := net.Listen("tcp", "")
-	require.NoError(t, err)
-	defer listener.Close()
-
-	// listener.Addr().String looks like '[[::]:55807]' - strip out the colons and brackets to get the port number
-	port := strings.FieldsFunc(listener.Addr().String(), func(r rune) bool {
-		return r == ':' || r == '[' || r == ']'
-	})
-
-	return port[0]
 }


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com>

This is based on https://github.com/jaegertracing/jaeger-operator/pull/288 which is out of date.