### PR TITLE
Add waitfors for cassandra instance and schema job

### DIFF
--- a/test/e2e/cassandra_test.go
+++ b/test/e2e/cassandra_test.go
@@ -35,6 +35,9 @@ func (suite *CassandraTestSuite) SetupSuite() {
 	require.NotNil(t, namespace, "GetNamespace failed")
 
 	addToFrameworkSchemeForSmokeTests(t)
+
+	err = WaitForStatefulset(t, fw.KubeClient, storageNamespace, "cassandra", retryInterval, timeout)
+	require.NoError(t, err, "Error waiting for cassandra stateful set")
 }
 
 func (suite *CassandraTestSuite) TearDownSuite() {

--- a/test/e2e/spark_dependencies_test.go
+++ b/test/e2e/spark_dependencies_test.go
@@ -43,6 +43,13 @@ func sparkTest(t *testing.T, f *framework.Framework, testCtx *framework.TestCtx,
 	}
 	defer undeployJaegerInstance(j)
 
+	if storage.Type == "cassandra" {
+		err = WaitForJob(t, fw.KubeClient, namespace, fmt.Sprintf("%s-cassandra-schema-job", name), retryInterval, timeout+1*time.Minute)
+		if err != nil {
+			return errors.WithMessage(err, "Failed waiting for cassandra schema  job")
+		}
+	}
+
 	err = WaitForCronJob(t, f.KubeClient, namespace, fmt.Sprintf("%s-spark-dependencies", name), retryInterval, timeout+1*time.Minute)
 	if err != nil {
 		return errors.WithMessage(err, "Failed waiting for cron job")

--- a/test/e2e/wait_util.go
+++ b/test/e2e/wait_util.go
@@ -36,10 +36,10 @@ func WaitForStatefulset(t *testing.T, kubeclient kubernetes.Interface, namespace
 		return false, nil
 	})
 	if err != nil {
-		t.Logf("Failed waiting for statefulset after %s\n", time.Since(start))
+		t.Logf("Failed waiting for statefulset %s after %s\n", name, time.Since(start))
 		return err
 	}
-	t.Logf("Statefulset available after %s\n", time.Since(start))
+	t.Logf("Statefulset %s available after %s\n", name, time.Since(start))
 	return nil
 }
 
@@ -64,10 +64,10 @@ func WaitForDaemonSet(t *testing.T, kubeclient kubernetes.Interface, namespace, 
 		return false, nil
 	})
 	if err != nil {
-		t.Logf("Failed waiting for daemonset after %s\n", time.Since(start))
+		t.Logf("Failed waiting for daemonset %s after %s\n", name, time.Since(start))
 		return err
 	}
-	t.Logf("DaemonSet available after %s\n", time.Since(start))
+	t.Logf("DaemonSet %s available after %s\n", name, time.Since(start))
 	return nil
 }
 
@@ -121,10 +121,10 @@ func WaitForJob(t *testing.T, kubeclient kubernetes.Interface, namespace, name s
 		return false, nil
 	})
 	if err != nil {
-		t.Logf("Failed waiting for job after %s\n", time.Since(start))
+		t.Logf("Failed waiting for job %s after %s\n", name, time.Since(start))
 		return err
 	}
-	t.Logf("Jobs succeeded after %s\n", time.Since(start))
+	t.Logf("Job %s succeeded after %s\n", name, time.Since(start))
 	return nil
 }
 
@@ -152,10 +152,10 @@ func WaitForJobOfAnOwner(t *testing.T, kubeclient kubernetes.Interface, namespac
 		return false, nil
 	})
 	if err != nil {
-		t.Logf("Failed waiting for job of an owner after %s\n", time.Since(start))
+		t.Logf("Failed waiting for job of an owner %s after %s\n", ownerName, time.Since(start))
 		return err
 	}
-	t.Logf("Jobs succeeded after %s\n", time.Since(start))
+	t.Logf("Job of owner %s succeeded after %s\n", ownerName, time.Since(start))
 	return nil
 }
 
@@ -179,10 +179,10 @@ func WaitForCronJob(t *testing.T, kubeclient kubernetes.Interface, namespace, na
 		return false, nil
 	})
 	if err != nil {
-		t.Logf("Failed waiting for cronjob after %s\n", time.Since(start))
+		t.Logf("Failed waiting for cronjob %s after %s\n", name, time.Since(start))
 		return err
 	}
-	t.Logf("CronJob succeeded after %s\n", time.Since(start))
+	t.Logf("CronJob %s succeeded after %s\n", name, time.Since(start))
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com>

This is another attempt to fix the failures we've been seeing in CI with cassandra related tests.  I can't guarantee this will work as I've had trouble reproducing it, but these are checks we should be doing anyway, and it will at least give us better information about what is really causing the problem.

The changes are:

1. Add a WaitForStatefulSet to make sure the Cassandra instance is available
2. Add a WaitForJob for the Cassandra schema job
3. Some minor improvements to logging.
