### PR TITLE
Remove deployment updates from autodetect loop

### DIFF
--- a/pkg/autodetect/main.go
+++ b/pkg/autodetect/main.go
@@ -78,64 +78,6 @@ func (b *Background) Stop() {
 	b.ticker.Stop()
 }
 
-func (b *Background) requireUpdates(deps *appsv1.DeploymentList) []*appsv1.Deployment {
-	instances := &v1.JaegerList{}
-	if err := b.clReader.List(context.Background(), instances); err != nil {
-		log.WithError(err).Info("failed to retrieve the list of Jaeger instances")
-		return nil
-	}
-
-	requireUpdates := make([]*appsv1.Deployment, 0)
-	for i := 0; i < len(deps.Items); i++ {
-		dep := &deps.Items[i]
-		if inject.Needed(dep) { // If sidecar is not present and should be
-			jaeger := inject.Select(dep, instances)
-			if jaeger != nil { // Instance exists.
-				jaeger.Logger().WithFields(log.Fields{
-					"deploymentName":      dep.Name,
-					"deploymentNamespace": dep.Namespace,
-				}).Info("Injecting Jaeger Agent sidecar")
-				dep.Annotations[inject.Annotation] = jaeger.Name
-				newDep := inject.Sidecar(jaeger, dep)
-				requireUpdates = append(requireUpdates, newDep)
-			}
-		} else {
-			// Try to update the sidecar if is required
-			jaeger := inject.Select(dep, instances)
-			if jaeger == nil {
-				log.WithFields(log.Fields{
-					"deploymentName":      dep.Name,
-					"deploymentNamespace": dep.Namespace,
-				}).Debug("no suitable jaeger for this instance, skipping injection")
-				continue
-			}
-
-			updated := inject.UpdateSidecar(jaeger, dep)
-			if updated {
-				if err := b.cl.Update(context.Background(), dep); err != nil {
-					return nil
-				}
-			}
-		}
-	}
-	return requireUpdates
-}
-
-func (b *Background) detectDeploymentUpdates() error {
-	deps := &appsv1.DeploymentList{}
-	if err := b.clReader.List(context.Background(), deps); err != nil {
-		return err
-	}
-	injectedDeps := b.requireUpdates(deps)
-	for _, d := range injectedDeps {
-		if err := b.cl.Update(context.Background(), d); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 func (b *Background) autoDetectCapabilities() {
 	apiList, err := b.availableAPIs()
 	if err != nil {
@@ -151,8 +93,6 @@ func (b *Background) autoDetectCapabilities() {
 
 	b.detectClusterRoles()
 	b.cleanDeployments()
-	b.detectDeploymentUpdates()
-
 }
 
 func (b *Background) availableAPIs() (*metav1.APIGroupList, error) {

--- a/pkg/autodetect/main_test.go
+++ b/pkg/autodetect/main_test.go
@@ -495,37 +495,6 @@ func TestCleanDeployments(t *testing.T) {
 	assert.Contains(t, persisted2.Labels, inject.Label)
 }
 
-func TestRequireUpdates(t *testing.T) {
-	s := scheme.Scheme
-	s.AddKnownTypes(v1.SchemeGroupVersion, &v1.JaegerList{})
-
-	dcl := &fakeDiscoveryClient{}
-	cl := customFakeClient()
-	b := WithClients(cl, dcl, cl)
-
-	deps := &appsv1.DeploymentList{
-		Items: []appsv1.Deployment{{
-			Spec: appsv1.DeploymentSpec{
-				Template: corev1.PodTemplateSpec{
-					Spec: corev1.PodSpec{
-						Containers: []corev1.Container{
-							{
-								Name: "my-business-container",
-							},
-							{
-								Name: "jaeger-agent", // manually added sidecar
-							},
-						},
-					},
-				},
-			},
-		}},
-	}
-
-	out := b.requireUpdates(deps)
-	assert.Len(t, out, 0)
-}
-
 type fakeClient struct {
 	client.Client
 	CreateFunc func(ctx context.Context, obj runtime.Object, opts ...client.CreateOption) error


### PR DESCRIPTION
Signed-off-by: Ruben Vargas <ruben.vp8510@gmail.com>

In https://github.com/jaegertracing/jaeger-operator/pull/454 we introduced the detection/update of deployments to address https://github.com/jaegertracing/jaeger-operator/issues/442, But after seen this closely, I think this is not the right approach. We should run the scan only at start.

More than that, In my latest tests debugging for fix https://github.com/jaegertracing/jaeger-operator/issues/855.  I see that we don't need to run the scan any more (operator-sdk 0.12.0) , because for some reason (I'm still not sure why) the reconciliation run on each deployment at bootstrap time (see logs). Not sure when this behaviour changed.



[bootstrap-operator.txt](https://github.com/jaegertracing/jaeger-operator/files/4088376/bootstrap-operator.txt)


