### PR TITLE
Use Elasticsearch 6 in tests

### DIFF
--- a/test/elasticsearch.yml
+++ b/test/elasticsearch.yml
@@ -19,14 +19,13 @@ spec:
     spec:
       containers:
         - name: elasticsearch
-          image: docker.elastic.co/elasticsearch/elasticsearch:5.6.12
+          image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.4
           imagePullPolicy: Always
           command:
             - bin/elasticsearch
           args:
             - "-Ehttp.host=0.0.0.0"
             - "-Etransport.host=127.0.0.1"
-            - "-Expack.security.enabled=false"
           volumeMounts:
             - name: data
               mountPath: /data

--- a/test/elasticsearch.yml
+++ b/test/elasticsearch.yml
@@ -19,16 +19,16 @@ spec:
     spec:
       containers:
         - name: elasticsearch
-          image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.4
+          image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.6
           imagePullPolicy: Always
-          command:
-            - bin/elasticsearch
-          args:
-            - "-Ehttp.host=0.0.0.0"
-            - "-Etransport.host=127.0.0.1"
+          env:
+            - name: "http.host"
+              value: "0.0.0.0"
+            - name: "transport.host"
+              value: "127.0.0.1"
           volumeMounts:
             - name: data
-              mountPath: /data
+              mountPath: /usr/share/elasticsearch/data
           readinessProbe:
             httpGet:
               path: /


### PR DESCRIPTION
Old Elasticsearch (5.x) does not on OCP 4.x.

Signed-off-by: Pavol Loffay <ploffay@redhat.com>