### PR TITLE
Do not use resources from common spec in spark dependencies

### DIFF
--- a/pkg/cronjob/spark_dependencies.go
+++ b/pkg/cronjob/spark_dependencies.go
@@ -87,7 +87,7 @@ func CreateSparkDependencies(jaeger *v1.Jaeger) *batchv1beta1.CronJob {
 									// let spark job use its default values
 									Env:       util.RemoveEmptyVars(envVars),
 									EnvFrom:   envFromSource,
-									Resources: commonSpec.Resources,
+									Resources: jaeger.Spec.Storage.Dependencies.Resources,
 								},
 							},
 							RestartPolicy:      corev1.RestartPolicyNever,

--- a/pkg/cronjob/spark_dependencies_test.go
+++ b/pkg/cronjob/spark_dependencies_test.go
@@ -177,7 +177,7 @@ func TestSparkDependenciesResources(t *testing.T) {
 					Resources: parentResources,
 				},
 			}},
-			expected: parentResources,
+			expected: corev1.ResourceRequirements{},
 		},
 		{
 			jaeger: &v1.Jaeger{Spec: v1.JaegerSpec{


### PR DESCRIPTION
Relates to https://github.com/jaegertracing/jaeger-operator/issues/745#issuecomment-579319297

Using common resources in spark dependencies can be risky because it requires much more memory than other components (collector, query). 

The question is whether we should define default resources for spark (if nothing is defined). The default would be probably 4Gi, which is quite a lot, therefore I would rather do not define anything and depend on good documentation.

Signed-off-by: Pavol Loffay <ploffay@redhat.com>