### PR TITLE
tracegen uses a versioned image

### DIFF
--- a/deploy/examples/tracegen.yaml
+++ b/deploy/examples/tracegen.yaml
@@ -20,12 +20,12 @@ spec:
     spec:
       containers:
       - name: tracegen
-        image: jaegertracing/jaeger-tracegen:latest
+        image: jaegertracing/jaeger-tracegen:1.17
         args:
         - -duration=30m
         - -workers=10
       - name: jaeger-agent
-        image: jaegertracing/jaeger-agent:1.16.0
+        image: jaegertracing/jaeger-agent:1.17
         args:
         - --reporter.grpc.host-port=dns:///simple-prod-collector-headless.default:14250
         - --reporter.type=grpc


### PR DESCRIPTION
fixes #866 
This PR can be merged once the jaeger 1.17 released.


Signed-off-by: Jeeva Kandasamy <jkandasa@gmail.com>