### PR TITLE
Delete PVCs from auto provisioned Jaeger at end of test

### DIFF
--- a/test/e2e/self_provisioned_elasticsearch_kafka_test.go
+++ b/test/e2e/self_provisioned_elasticsearch_kafka_test.go
@@ -88,6 +88,7 @@ func (suite *SelfProvisionedTestSuite) TestSelfProvisionedESAndKafkaSmokeTest() 
 	err := fw.Client.Create(goctx.TODO(), exampleJaeger, &framework.CleanupOptions{TestContext: ctx, Timeout: timeout, RetryInterval: retryInterval})
 	require.NoError(t, err, "Error deploying example Jaeger")
 	defer undeployJaegerInstance(exampleJaeger)
+	defer deletePersistentVolumeClaims(namespace)
 
 	err = WaitForStatefulset(t, fw.KubeClient, namespace, jaegerInstanceName+"-zookeeper", retryInterval, timeout+1*time.Minute)
 	require.NoError(t, err)

--- a/test/e2e/streaming_test.go
+++ b/test/e2e/streaming_test.go
@@ -132,6 +132,7 @@ func (suite *StreamingTestSuite) TestStreamingWithAutoProvisioning() {
 	err := fw.Client.Create(context.TODO(), jaegerInstance, &framework.CleanupOptions{TestContext: ctx, Timeout: timeout, RetryInterval: retryInterval})
 	require.NoError(t, err, "Error deploying jaeger")
 	defer undeployJaegerInstance(jaegerInstance)
+	defer deletePersistentVolumeClaims(namespace)
 
 	err = WaitForStatefulset(t, fw.KubeClient, namespace, jaegerInstanceName+"-zookeeper", retryInterval, timeout+1*time.Minute)
 	require.NoError(t, err)

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -414,3 +414,14 @@ func createSecret(secretName, secretNamespace string, secretData map[string][]by
 	WaitForSecret(secretName, secretNamespace)
 	return createdSecret
 }
+
+func deletePersistentVolumeClaims(namespace string) {
+	pvcs, err := fw.KubeClient.CoreV1().PersistentVolumeClaims(kafkaNamespace).List(metav1.ListOptions{})
+	require.NoError(t, err)
+
+	emptyDeleteOptions := metav1.DeleteOptions{}
+	for _, pvc := range pvcs.Items {
+		logrus.Infof("Deleting PVC %s from namespace %s", pvc.Name, namespace)
+		fw.KubeClient.CoreV1().PersistentVolumeClaims(kafkaNamespace).Delete(pvc.Name, &emptyDeleteOptions)
+	}
+}


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com>

Delete PVCs at the end of tests which create Kafka instances with persistent storage.   This should not strictly be necessary, as the PVCs should be deleted when the namespace is deleted.  

However, we have had times where a subsequent test gets a panic, particularly because of port-forwarding problems, and then the namespace doesn't get deleted.  This can cause problems with some of our clusters which do not have a lot of resources for volumes.

