### PR TITLE
Preserve generated cookie secret on the reconciliation process

### DIFF
--- a/pkg/inject/oauth_proxy.go
+++ b/pkg/inject/oauth_proxy.go
@@ -109,11 +109,11 @@ func PropagateOAuthCookieSecret(specSrc, specDst appsv1.DeploymentSpec) appsv1.D
 			break
 		}
 	}
-	// Found the cooke secretArg parameter, replace argument.
+	// Found the cookie secretArg parameter, replace argument.
 	if secretArg != "" {
 		for i, container := range spec.Template.Spec.Containers {
 			if container.Name == "oauth-proxy" {
-				util.ReplaceArgument("--cookie-secret", secretArg, spec.Template.Spec.Containers[i].Args, true)
+				util.ReplaceArgument("--cookie-secret", secretArg, spec.Template.Spec.Containers[i].Args)
 			}
 		}
 	}

--- a/pkg/inject/oauth_proxy.go
+++ b/pkg/inject/oauth_proxy.go
@@ -99,7 +99,7 @@ func getOAuthProxyContainer(jaeger *v1.Jaeger) corev1.Container {
 }
 
 //PropagateOAuthCookieSecret preserve the generated oauth cookie across multiple reconciliations
-func PropagateOAuthCookieSecret(specSrc, specDst *appsv1.DeploymentSpec) appsv1.DeploymentSpec {
+func PropagateOAuthCookieSecret(specSrc, specDst appsv1.DeploymentSpec) appsv1.DeploymentSpec {
 	spec := specDst.DeepCopy()
 	secretArg := ""
 	// Find secretArg from old object
@@ -113,7 +113,7 @@ func PropagateOAuthCookieSecret(specSrc, specDst *appsv1.DeploymentSpec) appsv1.
 	if secretArg != "" {
 		for i, container := range spec.Template.Spec.Containers {
 			if container.Name == "oauth-proxy" {
-				util.ReplaceArgument("--cookie-secret", secretArg, spec.Template.Spec.Containers[i].Args)
+				util.ReplaceArgument("--cookie-secret", secretArg, spec.Template.Spec.Containers[i].Args, true)
 			}
 		}
 	}

--- a/pkg/inventory/deployment.go
+++ b/pkg/inventory/deployment.go
@@ -29,7 +29,7 @@ func ForDeployments(existing []appsv1.Deployment, desired []appsv1.Deployment) D
 
 			// we can't blindly DeepCopyInto, so, we select what we bring from the new to the old object
 			tp.Spec = v.Spec
-			tp.Spec = inject.PropagateOAuthCookieSecret(&t.Spec, &tp.Spec)
+			tp.Spec = inject.PropagateOAuthCookieSecret(t.Spec, v.Spec)
 			tp.ObjectMeta.OwnerReferences = v.ObjectMeta.OwnerReferences
 
 			for k, v := range v.ObjectMeta.Annotations {

--- a/pkg/inventory/deployment.go
+++ b/pkg/inventory/deployment.go
@@ -5,6 +5,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 
+	"github.com/jaegertracing/jaeger-operator/pkg/inject"
 	"github.com/jaegertracing/jaeger-operator/pkg/util"
 )
 
@@ -28,6 +29,7 @@ func ForDeployments(existing []appsv1.Deployment, desired []appsv1.Deployment) D
 
 			// we can't blindly DeepCopyInto, so, we select what we bring from the new to the old object
 			tp.Spec = v.Spec
+			inject.PreserveOauthCookieSecret(&t.Spec, &tp.Spec)
 			tp.ObjectMeta.OwnerReferences = v.ObjectMeta.OwnerReferences
 
 			for k, v := range v.ObjectMeta.Annotations {

--- a/pkg/inventory/deployment.go
+++ b/pkg/inventory/deployment.go
@@ -29,7 +29,7 @@ func ForDeployments(existing []appsv1.Deployment, desired []appsv1.Deployment) D
 
 			// we can't blindly DeepCopyInto, so, we select what we bring from the new to the old object
 			tp.Spec = v.Spec
-			inject.PreserveOauthCookieSecret(&t.Spec, &tp.Spec)
+			tp.Spec = inject.PropagateOAuthCookieSecret(&t.Spec, &tp.Spec)
 			tp.ObjectMeta.OwnerReferences = v.ObjectMeta.OwnerReferences
 
 			for k, v := range v.ObjectMeta.Annotations {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -177,15 +177,12 @@ func FindItem(prefix string, args []string) string {
 }
 
 // ReplaceArgument replace argument value with given value.
-func ReplaceArgument(prefix string, newValue string, args []string, firstOccurrence bool) int {
+func ReplaceArgument(prefix string, newValue string, args []string) int {
 	found := 0
 	for argIndex, arg := range args {
 		if strings.HasPrefix(arg, prefix) {
 			args[argIndex] = newValue
 			found++
-			if firstOccurrence {
-				return found
-			}
 		}
 	}
 	return found

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -177,13 +177,18 @@ func FindItem(prefix string, args []string) string {
 }
 
 // ReplaceArgument replace argument value with given value.
-func ReplaceArgument(prefix string, newValue string, args []string) {
+func ReplaceArgument(prefix string, newValue string, args []string, firstOccurrence bool) int {
+	found := 0
 	for argIndex, arg := range args {
 		if strings.HasPrefix(arg, prefix) {
 			args[argIndex] = newValue
-			return
+			found++
+			if firstOccurrence {
+				return found
+			}
 		}
 	}
+	return found
 }
 
 // GetPort returns a port, either from supplied default port, or extracted from supplied arg value

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -176,6 +176,16 @@ func FindItem(prefix string, args []string) string {
 	return ""
 }
 
+// ReplaceArgument replace argument value with given value.
+func ReplaceArgument(prefix string, newValue string, args []string) {
+	for argIndex, arg := range args {
+		if strings.HasPrefix(arg, prefix) {
+			args[argIndex] = newValue
+			return
+		}
+	}
+}
+
 // GetPort returns a port, either from supplied default port, or extracted from supplied arg value
 func GetPort(arg string, args []string, port int32) int32 {
 	portArg := FindItem(arg, args)

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -458,3 +458,83 @@ func TestCreateFromSecret(t *testing.T) {
 		assert.Equal(t, test.expected, exp)
 	}
 }
+
+func TestReplaceArgument(t *testing.T) {
+
+	newValue := "SECRET2"
+	prefix := "--cookie-secret="
+
+	tests := []struct {
+		input           []string
+		expected        []string
+		count           int
+		firstOccurrence bool
+	}{
+		{
+			input: []string{
+				"--cookie-secret=SECRET1",
+				"--https-address=:8443",
+				"--provider=openshift",
+			},
+			expected: []string{
+				"--cookie-secret=" + newValue,
+				"--https-address=:8443",
+				"--provider=openshift",
+			},
+			count:           1,
+			firstOccurrence: false,
+		},
+		{
+			input: []string{
+				"--cookie-secret=SECRET1",
+				"--cookie-secret=SECRET3",
+				"--https-address=:8443",
+				"--provider=openshift",
+			},
+			expected: []string{
+				"--cookie-secret=" + newValue,
+				"--cookie-secret=SECRET3",
+				"--https-address=:8443",
+				"--provider=openshift",
+			},
+			count:           1,
+			firstOccurrence: true,
+		},
+
+		{
+			input: []string{
+				"--cookie-secret=SECRET1",
+				"--cookie-secret=SECRET3",
+				"--https-address=:8443",
+				"--provider=openshift",
+			},
+			expected: []string{
+				"--cookie-secret=" + newValue,
+				"--cookie-secret=" + newValue,
+				"--https-address=:8443",
+				"--provider=openshift",
+			},
+			count:           2,
+			firstOccurrence: false,
+		},
+		{
+			input: []string{
+				"--https-address=:8443",
+				"--provider=openshift",
+			},
+			expected: []string{
+				"--https-address=:8443",
+				"--provider=openshift",
+			},
+			count:           0,
+			firstOccurrence: false,
+		},
+	}
+
+	for _, test := range tests {
+		counter := ReplaceArgument(prefix, prefix+newValue, test.input, test.firstOccurrence)
+		assert.Equal(t, test.count, counter)
+		assert.Equal(t, test.expected, test.input)
+	}
+
+}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -465,10 +465,9 @@ func TestReplaceArgument(t *testing.T) {
 	prefix := "--cookie-secret="
 
 	tests := []struct {
-		input           []string
-		expected        []string
-		count           int
-		firstOccurrence bool
+		input    []string
+		expected []string
+		count    int
 	}{
 		{
 			input: []string{
@@ -481,8 +480,7 @@ func TestReplaceArgument(t *testing.T) {
 				"--https-address=:8443",
 				"--provider=openshift",
 			},
-			count:           1,
-			firstOccurrence: false,
+			count: 1,
 		},
 		{
 			input: []string{
@@ -493,29 +491,11 @@ func TestReplaceArgument(t *testing.T) {
 			},
 			expected: []string{
 				"--cookie-secret=" + newValue,
-				"--cookie-secret=SECRET3",
-				"--https-address=:8443",
-				"--provider=openshift",
-			},
-			count:           1,
-			firstOccurrence: true,
-		},
-
-		{
-			input: []string{
-				"--cookie-secret=SECRET1",
-				"--cookie-secret=SECRET3",
-				"--https-address=:8443",
-				"--provider=openshift",
-			},
-			expected: []string{
-				"--cookie-secret=" + newValue,
 				"--cookie-secret=" + newValue,
 				"--https-address=:8443",
 				"--provider=openshift",
 			},
-			count:           2,
-			firstOccurrence: false,
+			count: 2,
 		},
 		{
 			input: []string{
@@ -526,13 +506,12 @@ func TestReplaceArgument(t *testing.T) {
 				"--https-address=:8443",
 				"--provider=openshift",
 			},
-			count:           0,
-			firstOccurrence: false,
+			count: 0,
 		},
 	}
 
 	for _, test := range tests {
-		counter := ReplaceArgument(prefix, prefix+newValue, test.input, test.firstOccurrence)
+		counter := ReplaceArgument(prefix, prefix+newValue, test.input)
 		assert.Equal(t, test.count, counter)
 		assert.Equal(t, test.expected, test.input)
 	}


### PR DESCRIPTION
This is another patch for prevent multiple creations of deployments  when a jaeger resource is created.

// cc: @kevinearls 

I only tested with all-in-one strategy, I'll test tomorrow with-cassandra yaml file