### PR TITLE
ci: minikube vm mem: 8192 MB (cf. issue 894)

### DIFF
--- a/.ci/start-minikube.sh
+++ b/.ci/start-minikube.sh
@@ -32,7 +32,7 @@ minikube config set WantNoneDriverWarning false
 minikube config set vm-driver none
 
 minikube version
-sudo ${MINIKUBE} start --kubernetes-version=$KUBERNETES_VERSION --extra-config=apiserver.authorization-mode=RBAC
+sudo ${MINIKUBE} start --kubernetes-version=$KUBERNETES_VERSION --extra-config=apiserver.authorization-mode=RBAC --memory=8192
 sudo chown -R $USER $HOME/.kube $HOME/.minikube
 
 minikube update-context


### PR DESCRIPTION
Let's see if this makes `e2e-tests-examples2` pass in Travis again.

Context: https://github.com/jaegertracing/jaeger-operator/issues/894