### PR TITLE
Handle test namespace creation and deletion as operator-sdk names are…

### DIFF
--- a/test/e2e/misc_test.go
+++ b/test/e2e/misc_test.go
@@ -48,10 +48,7 @@ func (suite *MiscTestSuite) SetupSuite() {
 }
 
 func (suite *MiscTestSuite) TearDownSuite() {
-	log.Info("Entering TearDownSuite()")
-	if !debugMode || !t.Failed() {
-		ctx.Cleanup()
-	}
+	handleSuiteTearDown()
 }
 
 func TestMiscSuite(t *testing.T) {


### PR DESCRIPTION
… too long.

The update to operator-sdk 0.15.1 included a change where namespace names became much longer.  https://github.com/operator-framework/operator-sdk/blob/master/pkg/test/context.go#L53  This resulted in a number of tests failing on OpenShift because of route names that were too long and other issues.

With this change tests run on OpenShift will manage the creation and deletion of namespaces instead of using the one created by the operator sdk.

Signed-off-by: Kevin Earls <kearls@redhat.com>