### PR TITLE
No modify annotation when injecting

### DIFF
--- a/pkg/autodetect/main.go
+++ b/pkg/autodetect/main.go
@@ -243,7 +243,10 @@ func (b *Background) cleanDeployments(ctx context.Context) {
 
 	// check deployments to see which one needs to be cleaned.
 	for _, dep := range deployments.Items {
-		if instanceName, ok := dep.Annotations[inject.Annotation]; ok {
+		if dep.Labels == nil {
+			continue
+		}
+		if instanceName, ok := dep.Labels[inject.Label]; ok {
 			_, instanceExists := instancesMap[instanceName]
 			if !instanceExists { // Jaeger instance not exist anymore, we need to clean this up.
 				inject.CleanSidecar(&dep)

--- a/pkg/autodetect/main.go
+++ b/pkg/autodetect/main.go
@@ -243,9 +243,6 @@ func (b *Background) cleanDeployments(ctx context.Context) {
 
 	// check deployments to see which one needs to be cleaned.
 	for _, dep := range deployments.Items {
-		if dep.Labels == nil {
-			continue
-		}
 		if instanceName, ok := dep.Labels[inject.Label]; ok {
 			_, instanceExists := instancesMap[instanceName]
 			if !instanceExists { // Jaeger instance not exist anymore, we need to clean this up.

--- a/pkg/inject/sidecar.go
+++ b/pkg/inject/sidecar.go
@@ -41,7 +41,6 @@ const (
 func Sidecar(jaeger *v1.Jaeger, dep *appsv1.Deployment) *appsv1.Deployment {
 	deployment.NewAgent(jaeger) // we need some initialization from that, but we don't actually need the agent's instance here
 	logFields := jaeger.Logger().WithField("deployment", dep.Name)
-
 	if jaeger == nil || (dep.Annotations[Annotation] != jaeger.Name && dep.Annotations[AnnotationLegacy] != jaeger.Name) {
 		logFields.Trace("skipping sidecar injection")
 	} else {

--- a/pkg/inject/sidecar_test.go
+++ b/pkg/inject/sidecar_test.go
@@ -187,7 +187,7 @@ func TestSidecarDefaultPorts(t *testing.T) {
 func TestSkipInjectSidecar(t *testing.T) {
 	// prepare
 	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestSkipInjectSidecar"})
-	dep := dep(map[string]string{Annotation: "non-existing-operator"}, map[string]string{})
+	dep := dep(map[string]string{}, map[string]string{Label: "non-existing-operator"})
 
 	// test
 	dep = Sidecar(jaeger, dep)

--- a/test/e2e/sidecar_test.go
+++ b/test/e2e/sidecar_test.go
@@ -66,17 +66,11 @@ func (suite *SidecarTestSuite) AfterTest(suiteName, testName string) {
 // Sidecar runs a test with the agent as sidecar
 func (suite *SidecarTestSuite) TestSidecar() {
 
-	agentAsSideCarDeleted := false
-
 	cleanupOptions := &framework.CleanupOptions{TestContext: ctx, Timeout: timeout, RetryInterval: retryInterval}
 
 	jaegerInstanceName := "agent-as-sidecar"
 	j := getJaegerAgentAsSidecarDefinition(jaegerInstanceName, namespace)
-	defer func() {
-		if !agentAsSideCarDeleted {
-			undeployJaegerInstance(j)
-		}
-	}()
+	undeployJaegerInstance(j)
 	err := fw.Client.Create(goctx.TODO(), j, cleanupOptions)
 	require.NoError(t, err, "Failed to create jaeger instance")
 
@@ -128,7 +122,6 @@ func (suite *SidecarTestSuite) TestSidecar() {
 
 	err = fw.Client.Delete(goctx.TODO(), j)
 	require.NoError(t, err, "Error deleting instance")
-	agentAsSideCarDeleted = true
 
 	url, httpClient = getQueryURLAndHTTPClient(otherJaegerInstanceName, "%s/api/traces?service=order", true)
 	req, err = http.NewRequest(http.MethodGet, url, nil)

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -228,13 +228,20 @@ func printTestStackTrace() {
 	}
 }
 
-func undeployJaegerInstance(jaeger *v1.Jaeger) {
+func undeployJaegerInstance(jaeger *v1.Jaeger) bool {
 	if !debugMode || !t.Failed() {
 		err := fw.Client.Delete(goctx.TODO(), jaeger)
-		require.NoError(t, err, "Error undeploying Jaeger")
-		err = e2eutil.WaitForDeletion(t, fw.Client.Client, jaeger, retryInterval, timeout)
-		require.NoError(t, err)
+		if err := fw.Client.Delete(goctx.TODO(), jaeger); err != nil {
+			return false
+		}
+
+		if err = e2eutil.WaitForDeletion(t, fw.Client.Client, jaeger, retryInterval, timeout); err != nil {
+			return false
+		}
+		return true
 	}
+	// Always return true, we don't care
+	return true
 }
 
 func getJaegerInstance(name, namespace string) *v1.Jaeger {


### PR DESCRIPTION
Signed-off-by: Ruben Vargas <ruben.vp8510@gmail.com>

Resolves #899 

In the actual code, when Select is called to select a jaeger instance, it modifies the annotation and set the value to the jaeger instance name.

I think this can lead to the scenario when you rename (or recreate) the Jaeger instance and there is no way to map the old name instance to the new one. I would prefer to preserve the value.

