### PR TITLE
Disable agent injection to jaeger instances and when false value is used

### DIFF
--- a/pkg/inject/sidecar.go
+++ b/pkg/inject/sidecar.go
@@ -72,6 +72,11 @@ func Needed(dep *appsv1.Deployment, ns *corev1.Namespace) bool {
 		}).Debug("annotation not present, not injecting")
 		return false
 	}
+	// do not inject jaeger due to port collision
+	// do not inject if deployment's Annotation value is false
+	if dep.Labels["app"] == "jaeger" || dep.Annotations[Annotation] == "false" {
+		return false
+	}
 	return !HasJaegerAgent(dep)
 }
 
@@ -98,6 +103,9 @@ func Select(target *appsv1.Deployment, ns *corev1.Namespace, availableJaegerPods
 		// jaeger instance to use!
 		// first, we make sure we normalize the name:
 		jaeger := &availableJaegerPods.Items[0]
+		if target.Annotations == nil {
+			target.Annotations = map[string]string{}
+		}
 		target.Annotations[Annotation] = jaeger.Name
 		return jaeger
 	}

--- a/pkg/inject/sidecar.go
+++ b/pkg/inject/sidecar.go
@@ -74,7 +74,7 @@ func Needed(dep *appsv1.Deployment, ns *corev1.Namespace) bool {
 	}
 	// do not inject jaeger due to port collision
 	// do not inject if deployment's Annotation value is false
-	if dep.Labels["app"] == "jaeger" || dep.Annotations[Annotation] == "false" {
+	if dep.Labels["app"] == "jaeger" {
 		return false
 	}
 	return !HasJaegerAgent(dep)

--- a/pkg/inject/sidecar_test.go
+++ b/pkg/inject/sidecar_test.go
@@ -232,6 +232,16 @@ func TestSidecarNeeded(t *testing.T) {
 			ns:     ns(map[string]string{}),
 			needed: false,
 		},
+		{
+			dep:    dep(map[string]string{}, map[string]string{"app": "jaeger"}),
+			ns:     ns(map[string]string{Annotation: "true"}),
+			needed: false,
+		},
+		{
+			dep:    dep(map[string]string{Annotation: "false"}, map[string]string{}),
+			ns:     ns(map[string]string{Annotation: "some-jaeger-instance"}),
+			needed: false,
+		},
 	}
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("dep:%s, ns: %s", test.dep.Annotations, test.ns.Annotations), func(t *testing.T) {
@@ -534,6 +544,7 @@ func dep(annotations map[string]string, labels map[string]string) *appsv1.Deploy
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: annotations,
+			Labels:      labels,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Template: corev1.PodTemplateSpec{

--- a/pkg/inject/sidecar_test.go
+++ b/pkg/inject/sidecar_test.go
@@ -237,11 +237,6 @@ func TestSidecarNeeded(t *testing.T) {
 			ns:     ns(map[string]string{Annotation: "true"}),
 			needed: false,
 		},
-		{
-			dep:    dep(map[string]string{Annotation: "false"}, map[string]string{}),
-			ns:     ns(map[string]string{Annotation: "some-jaeger-instance"}),
-			needed: false,
-		},
 	}
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("dep:%s, ns: %s", test.dep.Annotations, test.ns.Annotations), func(t *testing.T) {


### PR DESCRIPTION
Resolves #900 

Disables agent injection on:
* deployments with label `app=jaeger`
* deployment with the inject annotation value `false`

Signed-off-by: Pavol Loffay <ploffay@redhat.com>