### PR TITLE
Limit some properties to use at most 63 chars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,8 @@ JAEGER_VERSION ?= "$(shell grep jaeger= versions.txt | awk -F= '{print $$2}')"
 OPERATOR_VERSION ?= "$(shell git describe --tags)"
 STORAGE_NAMESPACE ?= "${shell kubectl get sa default -o jsonpath='{.metadata.namespace}' || oc project -q}"
 KAFKA_NAMESPACE ?= "kafka"
-KAFKA_EXAMPLE ?= "https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/0.14.0/examples/kafka/kafka-persistent-single.yaml"
-KAFKA_YAML ?= "https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.14.0/strimzi-cluster-operator-0.14.0.yaml"
+KAFKA_EXAMPLE ?= "https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/0.16.2/examples/kafka/kafka-persistent-single.yaml"
+KAFKA_YAML ?= "https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.16.2/strimzi-cluster-operator-0.16.2.yaml"
 ES_OPERATOR_NAMESPACE ?= openshift-logging
 ES_OPERATOR_BRANCH ?= release-4.3
 PROMETHEUS_OPERATOR_TAG ?= v0.34.0
@@ -147,7 +147,7 @@ run: crd
 
 .PHONY: run-debug
 run-debug: run
-run-debug: CLI_FLAGS = "--log-level=debug"
+run-debug: CLI_FLAGS = --log-level=debug --tracing-enabled=true
 
 .PHONY: set-max-map-count
 set-max-map-count:

--- a/pkg/account/main.go
+++ b/pkg/account/main.go
@@ -28,14 +28,7 @@ func getMain(jaeger *v1.Jaeger) *corev1.ServiceAccount {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      JaegerServiceAccountFor(jaeger, ""),
 			Namespace: jaeger.Namespace,
-			Labels: map[string]string{
-				"app":                          "jaeger",
-				"app.kubernetes.io/name":       JaegerServiceAccountFor(jaeger, ""),
-				"app.kubernetes.io/instance":   jaeger.Name,
-				"app.kubernetes.io/component":  "service-account",
-				"app.kubernetes.io/part-of":    "jaeger",
-				"app.kubernetes.io/managed-by": "jaeger-operator",
-			},
+			Labels:    util.Labels(JaegerServiceAccountFor(jaeger, ""), "service-account", *jaeger),
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					APIVersion: jaeger.APIVersion,

--- a/pkg/account/oauth_proxy.go
+++ b/pkg/account/oauth_proxy.go
@@ -21,14 +21,7 @@ func OAuthProxy(jaeger *v1.Jaeger) *corev1.ServiceAccount {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      OAuthProxyAccountNameFor(jaeger),
 			Namespace: jaeger.Namespace,
-			Labels: map[string]string{
-				"app":                          "jaeger",
-				"app.kubernetes.io/name":       OAuthProxyAccountNameFor(jaeger),
-				"app.kubernetes.io/instance":   jaeger.Name,
-				"app.kubernetes.io/component":  "service-account-oauth-proxy",
-				"app.kubernetes.io/part-of":    "jaeger",
-				"app.kubernetes.io/managed-by": "jaeger-operator",
-			},
+			Labels:    util.Labels(OAuthProxyAccountNameFor(jaeger), "service-account-oauth-proxy", *jaeger),
 			Annotations: map[string]string{
 				"serviceaccounts.openshift.io/oauth-redirectreference.primary": getOAuthRedirectReference(jaeger),
 			},

--- a/pkg/clusterrolebinding/main.go
+++ b/pkg/clusterrolebinding/main.go
@@ -31,15 +31,8 @@ func oauthProxyAuthDelegator(jaeger *v1.Jaeger) rbac.ClusterRoleBinding {
 
 	return rbac.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-			Labels: map[string]string{
-				"app":                          "jaeger",
-				"app.kubernetes.io/name":       name,
-				"app.kubernetes.io/instance":   jaeger.Name,
-				"app.kubernetes.io/component":  "service-account",
-				"app.kubernetes.io/part-of":    "jaeger",
-				"app.kubernetes.io/managed-by": "jaeger-operator",
-			},
+			Name:   name,
+			Labels: util.Labels(name, "service-account", *jaeger),
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					APIVersion: jaeger.APIVersion,

--- a/pkg/config/sampling/sampling.go
+++ b/pkg/config/sampling/sampling.go
@@ -59,14 +59,7 @@ func (u *Config) Get() *corev1.ConfigMap {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-sampling-configuration", u.jaeger.Name),
 			Namespace: u.jaeger.Namespace,
-			Labels: map[string]string{
-				"app":                          "jaeger",
-				"app.kubernetes.io/name":       fmt.Sprintf("%s-sampling-configuration", u.jaeger.Name),
-				"app.kubernetes.io/instance":   u.jaeger.Name,
-				"app.kubernetes.io/component":  "sampling-configuration",
-				"app.kubernetes.io/part-of":    "jaeger",
-				"app.kubernetes.io/managed-by": "jaeger-operator",
-			},
+			Labels:    util.Labels(fmt.Sprintf("%s-sampling-configuration", u.jaeger.Name), "sampling-configuration", *u.jaeger),
 			OwnerReferences: []metav1.OwnerReference{
 				metav1.OwnerReference{
 					APIVersion: u.jaeger.APIVersion,
@@ -136,5 +129,5 @@ func Update(jaeger *v1.Jaeger, commonSpec *v1.JaegerCommonSpec, options *[]strin
 }
 
 func samplingConfigVolumeName(jaeger *v1.Jaeger) string {
-	return util.DNSName(fmt.Sprintf("%s-sampling-configuration-volume", jaeger.Name))
+	return util.DNSName(util.Truncate("%s-sampling-configuration-volume", 63, jaeger.Name))
 }

--- a/pkg/config/ui/ui.go
+++ b/pkg/config/ui/ui.go
@@ -46,14 +46,7 @@ func (u *UIConfig) Get() *corev1.ConfigMap {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-ui-configuration", u.jaeger.Name),
 			Namespace: u.jaeger.Namespace,
-			Labels: map[string]string{
-				"app":                          "jaeger",
-				"app.kubernetes.io/name":       fmt.Sprintf("%s-ui-configuration", u.jaeger.Name),
-				"app.kubernetes.io/instance":   u.jaeger.Name,
-				"app.kubernetes.io/component":  "ui-configuration",
-				"app.kubernetes.io/part-of":    "jaeger",
-				"app.kubernetes.io/managed-by": "jaeger-operator",
-			},
+			Labels:    util.Labels(fmt.Sprintf("%s-ui-configuration", u.jaeger.Name), "ui-configuration", *u.jaeger),
 			OwnerReferences: []metav1.OwnerReference{
 				metav1.OwnerReference{
 					APIVersion: u.jaeger.APIVersion,
@@ -103,5 +96,5 @@ func Update(jaeger *v1.Jaeger, commonSpec *v1.JaegerCommonSpec, options *[]strin
 }
 
 func configurationVolumeName(jaeger *v1.Jaeger) string {
-	return util.DNSName(fmt.Sprintf("%s-ui-configuration-volume", jaeger.Name))
+	return util.DNSName(util.Truncate("%s-ui-configuration-volume", 63, jaeger.Name))
 }

--- a/pkg/controller/jaeger/kafka.go
+++ b/pkg/controller/jaeger/kafka.go
@@ -33,10 +33,8 @@ func (r *ReconcileJaeger) applyKafkas(ctx context.Context, jaeger v1.Jaeger, des
 	opts := []client.ListOption{
 		client.InNamespace(jaeger.Namespace),
 		client.MatchingLabels(map[string]string{
-			"app.kubernetes.io/instance": jaeger.Name,
-
-			// workaround for https://github.com/strimzi/strimzi-kafka-operator/issues/2107
-			"app.kubernetes.io/managed---by": "jaeger-operator",
+			"app.kubernetes.io/instance":   jaeger.Name,
+			"app.kubernetes.io/managed-by": "jaeger-operator",
 		}),
 	}
 	list := &kafkav1beta1.KafkaList{}

--- a/pkg/controller/jaeger/kafka_test.go
+++ b/pkg/controller/jaeger/kafka_test.go
@@ -42,10 +42,8 @@ func TestKafkaCreate(t *testing.T) {
 				Name:      jaeger.Name,
 				Namespace: jaeger.Namespace,
 				Labels: map[string]string{
-					"app.kubernetes.io/instance": nsn.Name,
-
-					// workaround for https://github.com/strimzi/strimzi-kafka-operator/issues/2107
-					"app.kubernetes.io/managed---by": "jaeger-operator",
+					"app.kubernetes.io/instance":   nsn.Name,
+					"app.kubernetes.io/managed-by": "jaeger-operator",
 				},
 			},
 			Status: kafkav1beta1.KafkaStatus{
@@ -91,10 +89,8 @@ func TestKafkaUpdate(t *testing.T) {
 			Namespace:   nsn.Namespace,
 			Annotations: map[string]string{"key": "value"},
 			Labels: map[string]string{
-				"app.kubernetes.io/instance": nsn.Name,
-
-				// workaround for https://github.com/strimzi/strimzi-kafka-operator/issues/2107
-				"app.kubernetes.io/managed---by": "jaeger-operator",
+				"app.kubernetes.io/instance":   nsn.Name,
+				"app.kubernetes.io/managed-by": "jaeger-operator",
 			},
 		},
 		Status: kafkav1beta1.KafkaStatus{
@@ -118,10 +114,8 @@ func TestKafkaUpdate(t *testing.T) {
 				Namespace:   nsn.Namespace,
 				Annotations: map[string]string{"key": "new-value"},
 				Labels: map[string]string{
-					"app.kubernetes.io/instance": nsn.Name,
-
-					// workaround for https://github.com/strimzi/strimzi-kafka-operator/issues/2107
-					"app.kubernetes.io/managed---by": "jaeger-operator",
+					"app.kubernetes.io/instance":   nsn.Name,
+					"app.kubernetes.io/managed-by": "jaeger-operator",
 				},
 			},
 			Status: kafkav1beta1.KafkaStatus{
@@ -168,10 +162,8 @@ func TestKafkaDelete(t *testing.T) {
 			Name:      nsn.Name,
 			Namespace: nsn.Namespace,
 			Labels: map[string]string{
-				"app.kubernetes.io/instance": nsn.Name,
-
-				// workaround for https://github.com/strimzi/strimzi-kafka-operator/issues/2107
-				"app.kubernetes.io/managed---by": "jaeger-operator",
+				"app.kubernetes.io/instance":   nsn.Name,
+				"app.kubernetes.io/managed-by": "jaeger-operator",
 			},
 		},
 	}
@@ -223,10 +215,8 @@ func TestKafkaCreateExistingNameInAnotherNamespace(t *testing.T) {
 				Name:      nsnExisting.Name,
 				Namespace: nsnExisting.Namespace,
 				Labels: map[string]string{
-					"app.kubernetes.io/instance": nsnExisting.Name,
-
-					// workaround for https://github.com/strimzi/strimzi-kafka-operator/issues/2107
-					"app.kubernetes.io/managed---by": "jaeger-operator",
+					"app.kubernetes.io/instance":   nsnExisting.Name,
+					"app.kubernetes.io/managed-by": "jaeger-operator",
 				},
 			},
 			Status: kafkav1beta1.KafkaStatus{
@@ -249,10 +239,8 @@ func TestKafkaCreateExistingNameInAnotherNamespace(t *testing.T) {
 				Name:      nsn.Name,
 				Namespace: nsn.Namespace,
 				Labels: map[string]string{
-					"app.kubernetes.io/instance": nsn.Name,
-
-					// workaround for https://github.com/strimzi/strimzi-kafka-operator/issues/2107
-					"app.kubernetes.io/managed---by": "jaeger-operator",
+					"app.kubernetes.io/instance":   nsn.Name,
+					"app.kubernetes.io/managed-by": "jaeger-operator",
 				},
 			},
 			Status: kafkav1beta1.KafkaStatus{

--- a/pkg/controller/jaeger/kafkauser.go
+++ b/pkg/controller/jaeger/kafkauser.go
@@ -33,10 +33,8 @@ func (r *ReconcileJaeger) applyKafkaUsers(ctx context.Context, jaeger v1.Jaeger,
 	opts := []client.ListOption{
 		client.InNamespace(jaeger.Namespace),
 		client.MatchingLabels(map[string]string{
-			"app.kubernetes.io/instance": jaeger.Name,
-
-			// workaround for https://github.com/strimzi/strimzi-kafka-operator/issues/2107
-			"app.kubernetes.io/managed---by": "jaeger-operator",
+			"app.kubernetes.io/instance":   jaeger.Name,
+			"app.kubernetes.io/managed-by": "jaeger-operator",
 		}),
 	}
 	list := &kafkav1beta1.KafkaUserList{}

--- a/pkg/controller/jaeger/kafkauser_test.go
+++ b/pkg/controller/jaeger/kafkauser_test.go
@@ -42,10 +42,8 @@ func TestKafkaUserCreate(t *testing.T) {
 				Name:      jaeger.Name,
 				Namespace: jaeger.Namespace,
 				Labels: map[string]string{
-					"app.kubernetes.io/instance": nsn.Name,
-
-					// workaround for https://github.com/strimzi/strimzi-kafka-operator/issues/2107
-					"app.kubernetes.io/managed---by": "jaeger-operator",
+					"app.kubernetes.io/instance":   nsn.Name,
+					"app.kubernetes.io/managed-by": "jaeger-operator",
 				},
 			},
 			Status: kafkav1beta1.KafkaUserStatus{
@@ -91,10 +89,8 @@ func TestKafkaUserUpdate(t *testing.T) {
 			Namespace:   nsn.Namespace,
 			Annotations: map[string]string{"key": "value"},
 			Labels: map[string]string{
-				"app.kubernetes.io/instance": nsn.Name,
-
-				// workaround for https://github.com/strimzi/strimzi-kafka-operator/issues/2107
-				"app.kubernetes.io/managed---by": "jaeger-operator",
+				"app.kubernetes.io/instance":   nsn.Name,
+				"app.kubernetes.io/managed-by": "jaeger-operator",
 			},
 		},
 		Status: kafkav1beta1.KafkaUserStatus{
@@ -118,10 +114,8 @@ func TestKafkaUserUpdate(t *testing.T) {
 				Namespace:   nsn.Namespace,
 				Annotations: map[string]string{"key": "new-value"},
 				Labels: map[string]string{
-					"app.kubernetes.io/instance": nsn.Name,
-
-					// workaround for https://github.com/strimzi/strimzi-kafka-operator/issues/2107
-					"app.kubernetes.io/managed---by": "jaeger-operator",
+					"app.kubernetes.io/instance":   nsn.Name,
+					"app.kubernetes.io/managed-by": "jaeger-operator",
 				},
 			},
 			Status: kafkav1beta1.KafkaUserStatus{
@@ -167,10 +161,8 @@ func TestKafkaUserDelete(t *testing.T) {
 			Name:      nsn.Name,
 			Namespace: nsn.Namespace,
 			Labels: map[string]string{
-				"app.kubernetes.io/instance": nsn.Name,
-
-				// workaround for https://github.com/strimzi/strimzi-kafka-operator/issues/2107
-				"app.kubernetes.io/managed---by": "jaeger-operator",
+				"app.kubernetes.io/instance":   nsn.Name,
+				"app.kubernetes.io/managed-by": "jaeger-operator",
 			},
 		},
 	}
@@ -222,10 +214,8 @@ func TestKafkaUserCreateExistingNameInAnotherNamespace(t *testing.T) {
 				Name:      nsnExisting.Name,
 				Namespace: nsnExisting.Namespace,
 				Labels: map[string]string{
-					"app.kubernetes.io/instance": nsnExisting.Name,
-
-					// workaround for https://github.com/strimzi/strimzi-kafka-operator/issues/2107
-					"app.kubernetes.io/managed---by": "jaeger-operator",
+					"app.kubernetes.io/instance":   nsnExisting.Name,
+					"app.kubernetes.io/managed-by": "jaeger-operator",
 				},
 			},
 			Status: kafkav1beta1.KafkaUserStatus{
@@ -248,10 +238,8 @@ func TestKafkaUserCreateExistingNameInAnotherNamespace(t *testing.T) {
 				Name:      nsn.Name,
 				Namespace: nsn.Namespace,
 				Labels: map[string]string{
-					"app.kubernetes.io/instance": nsn.Name,
-
-					// workaround for https://github.com/strimzi/strimzi-kafka-operator/issues/2107
-					"app.kubernetes.io/managed---by": "jaeger-operator",
+					"app.kubernetes.io/instance":   nsn.Name,
+					"app.kubernetes.io/managed-by": "jaeger-operator",
 				},
 			},
 			Status: kafkav1beta1.KafkaUserStatus{

--- a/pkg/cronjob/es_rollover.go
+++ b/pkg/cronjob/es_rollover.go
@@ -1,7 +1,6 @@
 package cronjob
 
 import (
-	"fmt"
 	"math/big"
 	"strconv"
 	"time"
@@ -30,7 +29,8 @@ func CreateRollover(jaeger *v1.Jaeger) []batchv1beta1.CronJob {
 }
 
 func rollover(jaeger *v1.Jaeger) batchv1beta1.CronJob {
-	name := fmt.Sprintf("%s-es-rollover", jaeger.Name)
+	// CronJob names are restricted to 52 chars
+	name := util.Truncate("%s-es-rollover", 52, jaeger.Name)
 	envs := EsScriptEnvVars(jaeger.Spec.Storage.Options)
 	if jaeger.Spec.Storage.EsRollover.Conditions != "" {
 		envs = append(envs, corev1.EnvVar{Name: "CONDITIONS", Value: jaeger.Spec.Storage.EsRollover.Conditions})
@@ -98,7 +98,8 @@ func createTemplate(name, action string, jaeger *v1.Jaeger, envs []corev1.EnvVar
 }
 
 func lookback(jaeger *v1.Jaeger) batchv1beta1.CronJob {
-	name := fmt.Sprintf("%s-es-lookback", jaeger.Name)
+	// CronJob names are restricted to 52 chars
+	name := util.Truncate("%s-es-lookback", 52, jaeger.Name)
 	envs := EsScriptEnvVars(jaeger.Spec.Storage.Options)
 	if jaeger.Spec.Storage.EsRollover.ReadTTL != "" {
 		dur, err := time.ParseDuration(jaeger.Spec.Storage.EsRollover.ReadTTL)

--- a/pkg/cronjob/spark_dependencies.go
+++ b/pkg/cronjob/spark_dependencies.go
@@ -1,7 +1,6 @@
 package cronjob
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -36,7 +35,9 @@ func CreateSparkDependencies(jaeger *v1.Jaeger) *batchv1beta1.CronJob {
 
 	trueVar := true
 	one := int32(1)
-	name := fmt.Sprintf("%s-spark-dependencies", jaeger.Name)
+
+	// cron job names are restricted to 52 chars
+	name := util.Truncate("%s-spark-dependencies", 52, jaeger.Name)
 
 	baseCommonSpec := v1.JaegerCommonSpec{
 		Annotations: map[string]string{
@@ -44,14 +45,7 @@ func CreateSparkDependencies(jaeger *v1.Jaeger) *batchv1beta1.CronJob {
 			"sidecar.istio.io/inject": "false",
 			"linkerd.io/inject":       "disabled",
 		},
-		Labels: map[string]string{
-			"app":                          "jaeger",
-			"app.kubernetes.io/name":       name,
-			"app.kubernetes.io/instance":   jaeger.Name,
-			"app.kubernetes.io/component":  "cronjob-es-index-cleaner",
-			"app.kubernetes.io/part-of":    "jaeger",
-			"app.kubernetes.io/managed-by": "jaeger-operator",
-		},
+		Labels: util.Labels(name, "spark-dependencies", *jaeger),
 	}
 
 	commonSpec := util.Merge([]v1.JaegerCommonSpec{jaeger.Spec.Storage.Dependencies.JaegerCommonSpec, jaeger.Spec.JaegerCommonSpec, baseCommonSpec})

--- a/pkg/deployment/agent.go
+++ b/pkg/deployment/agent.go
@@ -52,7 +52,7 @@ func (a *Agent) Get() *appsv1.DaemonSet {
 	adminPort := util.GetPort("--admin-http-port=", args, 14271)
 
 	trueVar := true
-	labels := a.labels()
+	labels := util.Labels(a.name(), "agent", *a.jaeger)
 
 	baseCommonSpec := v1.JaegerCommonSpec{
 		Annotations: map[string]string{
@@ -162,17 +162,6 @@ func (a *Agent) Get() *appsv1.DaemonSet {
 				},
 			},
 		},
-	}
-}
-
-func (a *Agent) labels() map[string]string {
-	return map[string]string{
-		"app":                          "jaeger", // TODO(jpkroehling): see collector.go in this package
-		"app.kubernetes.io/name":       a.name(),
-		"app.kubernetes.io/instance":   a.jaeger.Name,
-		"app.kubernetes.io/component":  "agent",
-		"app.kubernetes.io/part-of":    "jaeger",
-		"app.kubernetes.io/managed-by": "jaeger-operator",
 	}
 }
 

--- a/pkg/deployment/all_in_one.go
+++ b/pkg/deployment/all_in_one.go
@@ -205,14 +205,7 @@ func (a *AllInOne) Services() []*corev1.Service {
 }
 
 func (a *AllInOne) labels() map[string]string {
-	return map[string]string{
-		"app":                          "jaeger", // TODO(jpkroehling): see collector.go in this package
-		"app.kubernetes.io/name":       a.name(),
-		"app.kubernetes.io/instance":   a.jaeger.Name,
-		"app.kubernetes.io/component":  "all-in-one",
-		"app.kubernetes.io/part-of":    "jaeger",
-		"app.kubernetes.io/managed-by": "jaeger-operator",
-	}
+	return util.Labels(a.name(), "all-in-one", *a.jaeger)
 }
 
 func (a *AllInOne) name() string {

--- a/pkg/deployment/collector.go
+++ b/pkg/deployment/collector.go
@@ -282,19 +282,7 @@ func (c *Collector) Autoscalers() []autoscalingv2beta2.HorizontalPodAutoscaler {
 }
 
 func (c *Collector) labels() map[string]string {
-	return map[string]string{
-		"app":                          "jaeger", // kept for backwards compatibility, remove by version 2.0
-		"app.kubernetes.io/name":       c.name(),
-		"app.kubernetes.io/instance":   c.jaeger.Name,
-		"app.kubernetes.io/component":  "collector",
-		"app.kubernetes.io/part-of":    "jaeger",
-		"app.kubernetes.io/managed-by": "jaeger-operator", // should we qualify this with the operator's namespace?
-
-		// the 'version' label is out for now for two reasons:
-		// 1. https://github.com/jaegertracing/jaeger-operator/issues/166
-		// 2. these labels are also used as selectors, and as such, need to be consistent... this
-		// might be a problem once we support updating the jaeger version
-	}
+	return util.Labels(c.name(), "collector", *c.jaeger)
 }
 
 func (c *Collector) name() string {

--- a/pkg/deployment/ingester.go
+++ b/pkg/deployment/ingester.go
@@ -159,14 +159,7 @@ func (i *Ingester) Get() *appsv1.Deployment {
 }
 
 func (i *Ingester) labels() map[string]string {
-	return map[string]string{
-		"app":                          "jaeger", // TODO(jpkroehling): see collector.go in this package
-		"app.kubernetes.io/name":       i.name(),
-		"app.kubernetes.io/instance":   i.jaeger.Name,
-		"app.kubernetes.io/component":  "ingester",
-		"app.kubernetes.io/part-of":    "jaeger",
-		"app.kubernetes.io/managed-by": "jaeger-operator",
-	}
+	return util.Labels(i.name(), "ingester", *i.jaeger)
 }
 
 func (i *Ingester) name() string {

--- a/pkg/deployment/query.go
+++ b/pkg/deployment/query.go
@@ -177,14 +177,7 @@ func (q *Query) Services() []*corev1.Service {
 }
 
 func (q *Query) labels() map[string]string {
-	return map[string]string{
-		"app":                          "jaeger", // TODO(jpkroehling): see collector.go in this package
-		"app.kubernetes.io/name":       q.name(),
-		"app.kubernetes.io/instance":   q.jaeger.Name,
-		"app.kubernetes.io/component":  "query",
-		"app.kubernetes.io/part-of":    "jaeger",
-		"app.kubernetes.io/managed-by": "jaeger-operator",
-	}
+	return util.Labels(q.name(), "query", *q.jaeger)
 }
 
 func (q *Query) name() string {

--- a/pkg/ingress/query.go
+++ b/pkg/ingress/query.go
@@ -31,14 +31,7 @@ func (i *QueryIngress) Get() *extv1beta1.Ingress {
 	trueVar := true
 
 	baseCommonSpec := v1.JaegerCommonSpec{
-		Labels: map[string]string{
-			"app":                          "jaeger",
-			"app.kubernetes.io/name":       fmt.Sprintf("%s-query", i.jaeger.Name),
-			"app.kubernetes.io/instance":   i.jaeger.Name,
-			"app.kubernetes.io/component":  "query-ingress",
-			"app.kubernetes.io/part-of":    "jaeger",
-			"app.kubernetes.io/managed-by": "jaeger-operator",
-		},
+		Labels: util.Labels(fmt.Sprintf("%s-query", i.jaeger.Name), "query-ingress", *i.jaeger),
 	}
 
 	commonSpec := util.Merge([]v1.JaegerCommonSpec{i.jaeger.Spec.Ingress.JaegerCommonSpec, i.jaeger.Spec.JaegerCommonSpec, baseCommonSpec})

--- a/pkg/inject/sidecar.go
+++ b/pkg/inject/sidecar.go
@@ -50,10 +50,11 @@ func Sidecar(jaeger *v1.Jaeger, dep *appsv1.Deployment) *appsv1.Deployment {
 		logFields.Debug("injecting sidecar")
 		dep.Spec.Template.Spec.Containers = append(dep.Spec.Template.Spec.Containers, container(jaeger, dep))
 
+		jaegerName := util.Truncate(jaeger.Name, 63)
 		if dep.Labels == nil {
-			dep.Labels = map[string]string{Label: jaeger.Name}
+			dep.Labels = map[string]string{Label: jaegerName}
 		} else {
-			dep.Labels[Label] = jaeger.Name
+			dep.Labels[Label] = jaegerName
 		}
 	}
 

--- a/pkg/route/query.go
+++ b/pkg/route/query.go
@@ -6,6 +6,7 @@ import (
 
 	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/service"
+	"github.com/jaegertracing/jaeger-operator/pkg/util"
 )
 
 // QueryRoute builds a route for jaegertracing/jaeger-query
@@ -39,16 +40,9 @@ func (r *QueryRoute) Get() *corev1.Route {
 			APIVersion: "route.openshift.io/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      r.jaeger.Name,
+			Name:      util.Truncate(r.jaeger.Name, 62-len(r.jaeger.Namespace)), // -namespace is added to the host by OpenShift
 			Namespace: r.jaeger.Namespace,
-			Labels: map[string]string{
-				"app":                          "jaeger",
-				"app.kubernetes.io/name":       r.jaeger.Name,
-				"app.kubernetes.io/instance":   r.jaeger.Name,
-				"app.kubernetes.io/component":  "query-route",
-				"app.kubernetes.io/part-of":    "jaeger",
-				"app.kubernetes.io/managed-by": "jaeger-operator",
-			},
+			Labels:    util.Labels(r.jaeger.Name, "query-route", *r.jaeger),
 			OwnerReferences: []metav1.OwnerReference{
 				metav1.OwnerReference{
 					APIVersion: r.jaeger.APIVersion,

--- a/pkg/service/agent.go
+++ b/pkg/service/agent.go
@@ -1,8 +1,6 @@
 package service
 
 import (
-	"fmt"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -13,6 +11,7 @@ import (
 // NewAgentService returns a new Kubernetes service for Jaeger Agent backed by the pods matching the selector
 func NewAgentService(jaeger *v1.Jaeger, selector map[string]string) *corev1.Service {
 	trueVar := true
+	name := util.DNSName(util.Truncate("%s-agent", 63, jaeger.Name))
 
 	return &corev1.Service{
 		TypeMeta: metav1.TypeMeta{
@@ -20,16 +19,9 @@ func NewAgentService(jaeger *v1.Jaeger, selector map[string]string) *corev1.Serv
 			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      util.DNSName(fmt.Sprintf("%s-agent", jaeger.Name)),
+			Name:      name,
 			Namespace: jaeger.Namespace,
-			Labels: map[string]string{
-				"app":                          "jaeger",
-				"app.kubernetes.io/name":       fmt.Sprintf("%s-agent", jaeger.Name),
-				"app.kubernetes.io/instance":   jaeger.Name,
-				"app.kubernetes.io/component":  "service-agent",
-				"app.kubernetes.io/part-of":    "jaeger",
-				"app.kubernetes.io/managed-by": "jaeger-operator",
-			},
+			Labels:    util.Labels(name, "service-agent", *jaeger),
 			OwnerReferences: []metav1.OwnerReference{
 				metav1.OwnerReference{
 					APIVersion: jaeger.APIVersion,

--- a/pkg/service/collector.go
+++ b/pkg/service/collector.go
@@ -1,8 +1,6 @@
 package service
 
 import (
-	"fmt"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -42,14 +40,7 @@ func collectorService(jaeger *v1.Jaeger, selector map[string]string) *corev1.Ser
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      GetNameForCollectorService(jaeger),
 			Namespace: jaeger.Namespace,
-			Labels: map[string]string{
-				"app":                          "jaeger",
-				"app.kubernetes.io/name":       GetNameForCollectorService(jaeger),
-				"app.kubernetes.io/instance":   jaeger.Name,
-				"app.kubernetes.io/component":  "service-collector",
-				"app.kubernetes.io/part-of":    "jaeger",
-				"app.kubernetes.io/managed-by": "jaeger-operator",
-			},
+			Labels:    util.Labels(GetNameForCollectorService(jaeger), "service-collector", *jaeger),
 			OwnerReferences: []metav1.OwnerReference{
 				metav1.OwnerReference{
 					APIVersion: jaeger.APIVersion,
@@ -88,10 +79,10 @@ func collectorService(jaeger *v1.Jaeger, selector map[string]string) *corev1.Ser
 
 // GetNameForCollectorService returns the service name for the collector in this Jaeger instance
 func GetNameForCollectorService(jaeger *v1.Jaeger) string {
-	return util.DNSName(fmt.Sprintf("%s-collector", jaeger.Name))
+	return util.DNSName(util.Truncate("%s-collector", 63, jaeger.Name))
 }
 
 // GetNameForHeadlessCollectorService returns the headless service name for the collector in this Jaeger instance
 func GetNameForHeadlessCollectorService(jaeger *v1.Jaeger) string {
-	return util.DNSName(fmt.Sprintf("%s-collector-headless", jaeger.Name))
+	return util.DNSName(util.Truncate("%s-collector-headless", 63, jaeger.Name))
 }

--- a/pkg/service/query.go
+++ b/pkg/service/query.go
@@ -1,8 +1,6 @@
 package service
 
 import (
-	"fmt"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -26,16 +24,9 @@ func NewQueryService(jaeger *v1.Jaeger, selector map[string]string) *corev1.Serv
 			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      GetNameForQueryService(jaeger),
-			Namespace: jaeger.Namespace,
-			Labels: map[string]string{
-				"app":                          "jaeger",
-				"app.kubernetes.io/name":       GetNameForQueryService(jaeger),
-				"app.kubernetes.io/instance":   jaeger.Name,
-				"app.kubernetes.io/component":  "service-query",
-				"app.kubernetes.io/part-of":    "jaeger",
-				"app.kubernetes.io/managed-by": "jaeger-operator",
-			},
+			Name:        GetNameForQueryService(jaeger),
+			Namespace:   jaeger.Namespace,
+			Labels:      util.Labels(GetNameForQueryService(jaeger), "service-query", *jaeger),
 			Annotations: annotations,
 			OwnerReferences: []metav1.OwnerReference{
 				metav1.OwnerReference{
@@ -63,12 +54,12 @@ func NewQueryService(jaeger *v1.Jaeger, selector map[string]string) *corev1.Serv
 
 // GetNameForQueryService returns the query service name for this Jaeger instance
 func GetNameForQueryService(jaeger *v1.Jaeger) string {
-	return util.DNSName(fmt.Sprintf("%s-query", jaeger.Name))
+	return util.DNSName(util.Truncate("%s-query", 63, jaeger.Name))
 }
 
 // GetTLSSecretNameForQueryService returns the auto-generated TLS secret name for the Query Service for the given Jaeger instance
 func GetTLSSecretNameForQueryService(jaeger *v1.Jaeger) string {
-	return fmt.Sprintf("%s-ui-oauth-proxy-tls", jaeger.Name)
+	return util.DNSName(util.Truncate("%s-ui-oauth-proxy-tls", 63, jaeger.Name))
 }
 
 // GetPortForQueryService returns the query service name for this Jaeger instance

--- a/pkg/storage/elasticsearch.go
+++ b/pkg/storage/elasticsearch.go
@@ -140,7 +140,10 @@ func (ed *ElasticsearchDeployment) InjectSecretsConfiguration(p *corev1.PodSpec)
 
 // Elasticsearch returns an ES CR for the deployment
 func (ed *ElasticsearchDeployment) Elasticsearch() *esv1.Elasticsearch {
-	uuid := strings.Replace(util.Truncate(util.DNSName(ed.Jaeger.Namespace+ed.Jaeger.Name), 63), "-", "", -1)
+	// this might yield names like:
+	// elasticsearch-cdm-osdke2ee7864afba6854e498f316bd37347f666simpleprod-1
+	// for the above value to contain at most 63 chars, our uuid has to have at most 42 chars
+	uuid := strings.Replace(util.Truncate(util.DNSName(ed.Jaeger.Namespace+ed.Jaeger.Name), 42), "-", "", -1)
 	var res corev1.ResourceRequirements
 	if ed.Jaeger.Spec.Storage.Elasticsearch.Resources != nil {
 		res = *ed.Jaeger.Spec.Storage.Elasticsearch.Resources

--- a/pkg/storage/elasticsearch.go
+++ b/pkg/storage/elasticsearch.go
@@ -140,7 +140,7 @@ func (ed *ElasticsearchDeployment) InjectSecretsConfiguration(p *corev1.PodSpec)
 
 // Elasticsearch returns an ES CR for the deployment
 func (ed *ElasticsearchDeployment) Elasticsearch() *esv1.Elasticsearch {
-	uuid := strings.Replace(util.DNSName(ed.Jaeger.Namespace+ed.Jaeger.Name), "-", "", -1)
+	uuid := strings.Replace(util.Truncate(util.DNSName(ed.Jaeger.Namespace+ed.Jaeger.Name), 63), "-", "", -1)
 	var res corev1.ResourceRequirements
 	if ed.Jaeger.Spec.Storage.Elasticsearch.Resources != nil {
 		res = *ed.Jaeger.Spec.Storage.Elasticsearch.Resources
@@ -151,8 +151,8 @@ func (ed *ElasticsearchDeployment) Elasticsearch() *esv1.Elasticsearch {
 			Name:      esSecret.name,
 			Labels: map[string]string{
 				"app":                         "jaeger",
-				"app.kubernetes.io/name":      esSecret.name,
-				"app.kubernetes.io/instance":  ed.Jaeger.Name,
+				"app.kubernetes.io/name":      util.Truncate(esSecret.name, 63),
+				"app.kubernetes.io/instance":  util.Truncate(ed.Jaeger.Name, 63),
 				"app.kubernetes.io/component": "elasticsearch",
 				"app.kubernetes.io/part-of":   "jaeger",
 				// We cannot use jaeger-operator label because our controllers would try

--- a/pkg/storage/elasticsearch_dependencies.go
+++ b/pkg/storage/elasticsearch_dependencies.go
@@ -1,7 +1,6 @@
 package storage
 
 import (
-	"fmt"
 	"strings"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -20,7 +19,7 @@ func EnableRollover(spec v1.JaegerStorageSpec) bool {
 }
 
 func elasticsearchDependencies(jaeger *v1.Jaeger) []batchv1.Job {
-	name := fmt.Sprintf("%s-es-rollover-create-mapping", jaeger.Name)
+	name := util.Truncate("%s-es-rollover-create-mapping", 63, jaeger.Name)
 	envFromSource := util.CreateEnvsFromSecret(jaeger.Spec.Storage.SecretName)
 	commonSpec := &v1.JaegerCommonSpec{
 		Annotations: map[string]string{

--- a/pkg/storage/elasticsearch_secrets.go
+++ b/pkg/storage/elasticsearch_secrets.go
@@ -155,16 +155,9 @@ func createESCerts(script string, jaeger *v1.Jaeger) error {
 func createSecret(jaeger *v1.Jaeger, secretName string, data map[string][]byte) corev1.Secret {
 	return corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      secretName,
-			Namespace: jaeger.Namespace,
-			Labels: map[string]string{
-				"app":                          "jaeger",
-				"app.kubernetes.io/name":       secretName,
-				"app.kubernetes.io/instance":   jaeger.Name,
-				"app.kubernetes.io/component":  "es-secret",
-				"app.kubernetes.io/part-of":    "jaeger",
-				"app.kubernetes.io/managed-by": "jaeger-operator",
-			},
+			Name:            secretName,
+			Namespace:       jaeger.Namespace,
+			Labels:          util.Labels(secretName, "es-secret", *jaeger),
 			OwnerReferences: []metav1.OwnerReference{util.AsOwner(jaeger)},
 		},
 		Type: corev1.SecretTypeOpaque,

--- a/pkg/util/truncate.go
+++ b/pkg/util/truncate.go
@@ -1,0 +1,42 @@
+package util
+
+import (
+	"fmt"
+)
+
+// Truncate will shorten the length of the instance name so that it contains at most max chars when combined with the fixed part
+// If the fixed part is already bigger than the max, this function is noop.
+func Truncate(format string, max int, values ...interface{}) string {
+	var truncated []interface{}
+	result := fmt.Sprintf(format, values...)
+
+	if excess := len(result) - max; excess > 0 {
+		// we try to reduce the first string we find
+		for _, value := range values {
+			if excess == 0 {
+				continue
+			}
+
+			if s, ok := value.(string); ok {
+				if len(s) > excess {
+					value = s[:len(s)-excess]
+					excess = 0
+				} else {
+					value = "" // skip this value entirely
+					excess = excess - len(s)
+				}
+			}
+
+			truncated = append(truncated, value)
+		}
+
+		result = fmt.Sprintf(format, truncated...)
+	}
+
+	// if at this point, the result is still bigger than max, apply a hard cap:
+	if len(result) > max {
+		return result[:max]
+	}
+
+	return result
+}

--- a/pkg/util/truncate_test.go
+++ b/pkg/util/truncate_test.go
@@ -1,0 +1,55 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTruncate(t *testing.T) {
+	for _, tt := range []struct {
+		format   string
+		max      int
+		values   []interface{}
+		expected string
+		cap      string
+	}{
+		{
+			format:   "%s-collector",
+			max:      63,
+			values:   []interface{}{"simplest"},
+			expected: "simplest-collector",
+			cap:      "the standard case",
+		},
+		{
+			format:   "d0c1e62-4d96-11ea-b174-c85b7644b6b5-5d0c1e62-4d96-11ea-b174-c85b7644b6b5",
+			max:      63,
+			values:   []interface{}{},
+			expected: "d0c1e62-4d96-11ea-b174-c85b7644b6b5-5d0c1e62-4d96-11ea-b174-c85",
+			cap:      "first N case",
+		},
+		{
+			format:   "%s-collector",
+			max:      63,
+			values:   []interface{}{"d0c1e62-4d96-11ea-b174-c85b7644b6b5-5d0c1e62-4d96-11ea-b174-c85b7644b6b5"},
+			expected: "d0c1e62-4d96-11ea-b174-c85b7644b6b5-5d0c1e62-4d96-11e-collector",
+			cap:      "instance + fixed within bounds",
+		},
+		{
+			format:   "%s-%s-collector",
+			max:      63,
+			values:   []interface{}{"d0c1e62", "4d96-11ea-b174-c85b7644b6b5-5d0c1e62-4d96-11ea-b174-c85b7644b6b5"},
+			expected: "-4d96-11ea-b174-c85b7644b6b5-5d0c1e62-4d96-11ea-b174--collector",
+			cap:      "first value gets dropped, second truncated",
+		},
+		{
+			format:   "%d-%s-collector",
+			max:      63,
+			values:   []interface{}{42, "d0c1e62-4d96-11ea-b174-c85b7644b6b5-5d0c1e62-4d96-11ea-b174-c85b7644b6b5"},
+			expected: "42-d0c1e62-4d96-11ea-b174-c85b7644b6b5-5d0c1e62-4d96--collector",
+			cap:      "first value gets passed, second truncated",
+		},
+	} {
+		assert.Equal(t, tt.expected, Truncate(tt.format, tt.max, tt.values...))
+	}
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -146,12 +146,17 @@ func AsOwner(jaeger *v1.Jaeger) metav1.OwnerReference {
 // Labels returns recommended labels
 func Labels(name, component string, jaeger v1.Jaeger) map[string]string {
 	return map[string]string{
-		"app":                          "jaeger",
-		"app.kubernetes.io/name":       name,
-		"app.kubernetes.io/instance":   jaeger.Name,
-		"app.kubernetes.io/component":  component,
+		"app":                          "jaeger", // kept for backwards compatibility, remove by version 2.0
+		"app.kubernetes.io/name":       Truncate(name, 63),
+		"app.kubernetes.io/instance":   Truncate(jaeger.Name, 63),
+		"app.kubernetes.io/component":  Truncate(component, 63),
 		"app.kubernetes.io/part-of":    "jaeger",
 		"app.kubernetes.io/managed-by": "jaeger-operator",
+
+		// the 'version' label is out for now for two reasons:
+		// 1. https://github.com/jaegertracing/jaeger-operator/issues/166
+		// 2. these labels are also used as selectors, and as such, need to be consistent... this
+		// might be a problem once we support updating the jaeger version
 	}
 }
 


### PR DESCRIPTION
Resolves #487 by limiting label values to 63 chars. Also included in this PR are similar manipulation for other objects, such as routes and batch jobs.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>