### PR TITLE
Reduced logging verbosity when debug is enabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ prepare-e2e-tests: build docker push
 
 	@cat test/operator.yaml | sed "s~image: jaegertracing\/jaeger-operator\:.*~image: $(BUILD_IMAGE)~gi" >> deploy/test/namespace-manifests.yaml
 
-	# ClusterRoleBinding is created in test codebase because we don't know service account namespace
+	@# ClusterRoleBinding is created in test codebase because we don't know service account namespace
 	@cp deploy/role.yaml deploy/test/global-manifests.yaml
 	@echo "---" >> deploy/test/global-manifests.yaml
 

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -25,6 +25,7 @@ rules:
   verbs:
   - 'get'
   - 'list'
+  - 'watch'
 - apiGroups:
   - apps
   resources:

--- a/pkg/controller/jaeger/jaeger_controller.go
+++ b/pkg/controller/jaeger/jaeger_controller.go
@@ -114,7 +114,7 @@ func (r *ReconcileJaeger) Reconcile(request reconcile.Request) (reconcile.Result
 	logFields := instance.Logger().WithField("execution", execution)
 
 	if err := validate(instance); err != nil {
-		instance.Logger().WithError(err).Error("Failed to validate")
+		instance.Logger().WithError(err).Error("failed to validate")
 		span.SetAttribute(key.String("error", err.Error()))
 		span.SetStatus(codes.InvalidArgument)
 		return reconcile.Result{}, err
@@ -129,7 +129,7 @@ func (r *ReconcileJaeger) Reconcile(request reconcile.Request) (reconcile.Result
 			log.WithFields(log.Fields{
 				"our-identity":   identity,
 				"owner-identity": val,
-			}).Debug("skipping CR as we are not owners")
+			}).Trace("skipping CR as we are not owners")
 			return reconcile.Result{}, nil
 		}
 	} else {

--- a/pkg/inject/sidecar.go
+++ b/pkg/inject/sidecar.go
@@ -43,13 +43,12 @@ func Sidecar(jaeger *v1.Jaeger, dep *appsv1.Deployment) *appsv1.Deployment {
 	logFields := jaeger.Logger().WithField("deployment", dep.Name)
 
 	if jaeger == nil || (dep.Annotations[Annotation] != jaeger.Name && dep.Annotations[AnnotationLegacy] != jaeger.Name) {
-		logFields.Debug("skipping sidecar injection")
+		logFields.Trace("skipping sidecar injection")
 	} else {
 		decorate(dep)
+
 		logFields.Debug("injecting sidecar")
 		dep.Spec.Template.Spec.Containers = append(dep.Spec.Template.Spec.Containers, container(jaeger, dep))
-		// Add label to deployment
-		logFields.Debug("adding label to deployment")
 
 		if dep.Labels == nil {
 			dep.Labels = map[string]string{Label: jaeger.Name}
@@ -69,7 +68,7 @@ func Needed(dep *appsv1.Deployment, ns *corev1.Namespace) bool {
 		log.WithFields(log.Fields{
 			"namespace":  dep.Namespace,
 			"deployment": dep.Name,
-		}).Debug("annotation not present, not injecting")
+		}).Trace("annotation not present, not injecting")
 		return false
 	}
 	return !HasJaegerAgent(dep)


### PR DESCRIPTION
While debugging a problem with #904, I noticed that the logs are too verbose to be useful. This PR reduces it drastically, by:

* Changing the "waiting for..." messages to be shown only once
* Setting the levels for background process to "trace" for messages that are repeated
* Fixing the role.yaml to include the ability to 'watch' namespaces

Unrelated change included in this PR: the reconciliation for namespaces and deployments had three different contexts each. This PR creates one context and reuses it across the reconciliation. It should make it easier when we decide to instrument those routines.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>