### PR TITLE
Add http- prefix to collector service port names

### DIFF
--- a/pkg/service/collector.go
+++ b/pkg/service/collector.go
@@ -73,7 +73,7 @@ func collectorService(jaeger *v1.Jaeger, selector map[string]string) *corev1.Ser
 					Port: 14250,
 				},
 				{
-					Name: "http-c-tchan-trft",
+					Name: "c-tchan-trft",
 					Port: 14267,
 				},
 				{

--- a/pkg/service/collector.go
+++ b/pkg/service/collector.go
@@ -65,7 +65,7 @@ func collectorService(jaeger *v1.Jaeger, selector map[string]string) *corev1.Ser
 			ClusterIP: "",
 			Ports: []corev1.ServicePort{
 				{
-					Name: "zipkin",
+					Name: "http-zipkin",
 					Port: 9411,
 				},
 				{
@@ -73,11 +73,11 @@ func collectorService(jaeger *v1.Jaeger, selector map[string]string) *corev1.Ser
 					Port: 14250,
 				},
 				{
-					Name: "c-tchan-trft",
+					Name: "http-c-tchan-trft",
 					Port: 14267,
 				},
 				{
-					Name: "c-binary-trft",
+					Name: "http-c-binary-trft",
 					Port: 14268,
 				},
 			},


### PR DESCRIPTION
Also prefix the collector service http ports, as discussed in https://github.com/jaegertracing/jaeger-operator/pull/909#issuecomment-586237703.

Signed-off-by: Gary Brown <gary@brownuk.com>