### PR TITLE
Changed the operator to gracefully degrade when not on cluster-wide scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,20 @@ The Jaeger Operator is an implementation of a [Kubernetes Operator](https://kube
 To install the operator, run:
 ```
 kubectl create namespace observability
-kubectl create -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/master/deploy/crds/jaegertracing.io_jaegers_crd.yaml
-kubectl create -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/master/deploy/service_account.yaml
-kubectl create -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/master/deploy/role.yaml
-kubectl create -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/master/deploy/role_binding.yaml
-kubectl create -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/master/deploy/operator.yaml
+kubectl create -n observability -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/master/deploy/crds/jaegertracing.io_jaegers_crd.yaml
+kubectl create -n observability -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/master/deploy/service_account.yaml
+kubectl create -n observability -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/master/deploy/role.yaml
+kubectl create -n observability -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/master/deploy/role_binding.yaml
+kubectl create -n observability -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/master/deploy/operator.yaml
 ```
+
+The operator will activate extra features if given cluster-wide permissions. To enable that, run:
+```
+kubectl create -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/master/deploy/cluster_role.yaml
+kubectl create -f https://raw.githubusercontent.com/jaegertracing/jaeger-operator/master/deploy/cluster_role_binding.yaml
+```
+
+Note that you'll need to download and customize the `cluster_role_binding.yaml` if you are using a namespace other than `observability`. You probably also want to download and customize the `operator.yaml`, setting the env var `WATCH_NAMESPACES` to have an empty value, so that it can watch for instances across all namespaces.
 
 Once the `jaeger-operator` deployment in the namespace `observability` is ready, create a Jaeger instance, like:
 

--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -1,0 +1,54 @@
+## this is an extra set of permissions that the Jaeger Operator might make use of if granted
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: jaeger-operator-cluster
+rules:
+
+## required for cluster-wide operators
+- apiGroups:
+  - jaegertracing.io
+  resources:
+  - '*'
+  verbs:
+  - 'get'
+  - 'list'
+  - 'create'
+  - 'update'
+  - 'delete'
+  - 'watch'
+
+## needed if support for injecting sidecars based on namespace annotation is required
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - 'get'
+  - 'list'
+  - 'watch'
+
+## needed if support for injecting sidecars based on deployment annotation is required, across all namespaces
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - 'get'
+  - 'list'
+  - 'create'
+  - 'update'
+  - 'watch'
+
+## needed only when .Spec.Ingress.Openshift.DelegateUrls is used
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  verbs:
+  - 'get'
+  - 'list'
+  - 'create'
+  - 'update'
+  - 'delete'
+  - 'watch'

--- a/deploy/cluster_role_binding.yaml
+++ b/deploy/cluster_role_binding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: jaeger-operator-cluster
+subjects:
+- kind: ServiceAccount
+  name: jaeger-operator
+  namespace: "observability" # change to point to the namespace you installed your operator
+roleRef:
+  kind: ClusterRole
+  name: jaeger-operator-cluster
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/examples/operator-with-tracing.yaml
+++ b/deploy/examples/operator-with-tracing.yaml
@@ -4,7 +4,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: jaeger-operator
-  namespace: observability
 spec:
   replicas: 1
   selector:
@@ -26,7 +25,9 @@ spec:
         imagePullPolicy: Always
         env:
         - name: WATCH_NAMESPACE
-          value: ""
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/deploy/olm-catalog/csv-config.yaml
+++ b/deploy/olm-catalog/csv-config.yaml
@@ -1,0 +1,6 @@
+crd-cr-paths:
+- deploy/crds
+operator-path: deploy/operator.yaml
+role-paths:
+- deploy/role.yaml
+- deploy/cluster_role.yaml

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: jaeger-operator
-  namespace: observability
 spec:
   replicas: 1
   selector:
@@ -24,7 +23,9 @@ spec:
         imagePullPolicy: Always
         env:
         - name: WATCH_NAMESPACE
-          value: ""
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         - name: POD_NAME
           valueFrom:
             fieldRef:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -1,30 +1,50 @@
+## this is a set of basic permissions the Jaeger Operator needs when restricted to work in specific namespaces
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
-  creationTimestamp: null
   name: jaeger-operator
 rules:
+
+## our own custom resources
 - apiGroups:
-  - ""
+  - jaegertracing.io
   resources:
-  - pods
-  - services
-  - services/finalizers
-  - endpoints
-  - persistentvolumeclaims
-  - events
-  - configmaps
-  - secrets
-  - serviceaccounts
-  verbs:
   - '*'
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
   verbs:
   - 'get'
   - 'list'
+  - 'create'
+  - 'update'
+  - 'delete'
+  - 'watch'
+
+## for the operator's own deployment
+- apiGroups:
+  - apps
+  resourceNames:
+  - jaeger-operator
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update
+
+## regular things the operator manages for an instance, as the result of processing CRs
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - persistentvolumeclaims
+  - pods
+  - secrets
+  - serviceaccounts
+  - services
+  - services/finalizers
+  verbs:
+  - 'get'
+  - 'list'
+  - 'create'
+  - 'update'
+  - 'delete'
   - 'watch'
 - apiGroups:
   - apps
@@ -34,74 +54,94 @@ rules:
   - replicasets
   - statefulsets
   verbs:
-  - '*'
-- apiGroups:
-  - monitoring.coreos.com
-  resources:
-  - servicemonitors
-  verbs:
-  - get
-  - create
+  - 'get'
+  - 'list'
+  - 'create'
+  - 'update'
+  - 'delete'
+  - 'watch'
 - apiGroups:
   - extensions
   resources:
-  - replicasets
-  - deployments
-  - daemonsets
-  - statefulsets
   - ingresses
   verbs:
-  - '*'
+  - 'get'
+  - 'list'
+  - 'create'
+  - 'update'
+  - 'delete'
+  - 'watch'
 - apiGroups:
   - batch
   resources:
   - jobs
   - cronjobs
   verbs:
-  - '*'
+  - 'get'
+  - 'list'
+  - 'create'
+  - 'update'
+  - 'delete'
+  - 'watch'
 - apiGroups:
   - route.openshift.io
   resources:
   - routes
   verbs:
-  - '*'
+  - 'get'
+  - 'list'
+  - 'create'
+  - 'update'
+  - 'delete'
+  - 'watch'
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - 'get'
+  - 'list'
+  - 'create'
+  - 'update'
+  - 'delete'
+  - 'watch'
+
+## needed if you want the operator to create service monitors for the Jaeger instances
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - 'get'
+  - 'list'
+  - 'create'
+  - 'update'
+  - 'delete'
+  - 'watch'
+
+## for the Elasticsearch auto-provisioning
 - apiGroups:
   - logging.openshift.io
   resources:
   - elasticsearches
   verbs:
-  - '*'
-- apiGroups:
-  - jaegertracing.io
-  resources:
-  - '*'
-  verbs:
-  - '*'
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
-  - clusterrolebindings
-  verbs:
-  - '*'
-- apiGroups:
-  - apps
-  - extensions
-  resourceNames:
-  - jaeger-operator
-  resources:
-  - deployments/finalizers
-  verbs:
-  - update
+  - 'get'
+  - 'list'
+  - 'create'
+  - 'update'
+  - 'delete'
+  - 'watch'
+
+## for the Kafka auto-provisioning
 - apiGroups:
   - kafka.strimzi.io
   resources:
   - kafkas
   - kafkausers
   verbs:
-  - '*'
-- apiGroups:
-  - autoscaling
-  resources:
-  - horizontalpodautoscalers
-  verbs:
-  - '*'
+  - 'get'
+  - 'list'
+  - 'create'
+  - 'update'
+  - 'delete'
+  - 'watch'

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -1,12 +1,11 @@
-kind: ClusterRoleBinding
+kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: jaeger-operator
 subjects:
 - kind: ServiceAccount
   name: jaeger-operator
-  namespace: observability
 roleRef:
-  kind: ClusterRole
+  kind: Role
   name: jaeger-operator
   apiGroup: rbac.authorization.k8s.io

--- a/deploy/service_account.yaml
+++ b/deploy/service_account.yaml
@@ -2,4 +2,3 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: jaeger-operator
-  namespace: observability

--- a/pkg/apis/jaegertracing/v1/const.go
+++ b/pkg/apis/jaegertracing/v1/const.go
@@ -7,6 +7,24 @@ const (
 	// ConfigIdentity is the key to the configuration map related to the operator's identity
 	ConfigIdentity string = "identity"
 
+	// ConfigWatchNamespace is the key to the configuration map related to the namespace the operator should watch
+	ConfigWatchNamespace string = "watch-namespace"
+
+	// ConfigEnableNamespaceController is the key to the configuration map related to the boolean, determining whether the namespace controller is enabled
+	ConfigEnableNamespaceController string = "enable-namespace-controller"
+
+	// ConfigOperatorScope is the configuration key holding the scope of the operator
+	ConfigOperatorScope string = "operator-scope"
+
+	// WatchAllNamespaces is the value that the ConfigWatchNamespace holds to represent "all namespaces".
+	WatchAllNamespaces string = ""
+
+	// OperatorScopeCluster signals that the operator's instance is installed cluster-wide
+	OperatorScopeCluster string = "cluster"
+
+	// OperatorScopeNamespace signals that the operator's instance is working on a single namespace
+	OperatorScopeNamespace string = "namespace"
+
 	// BootstrapTracer is the OpenTelemetry tracer name for the bootstrap procedure
 	BootstrapTracer string = "operator/bootstrap"
 

--- a/pkg/cmd/start/bootstrap.go
+++ b/pkg/cmd/start/bootstrap.go
@@ -21,6 +21,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
@@ -70,14 +71,61 @@ func bootstrap(ctx context.Context) manager.Manager {
 		log.Fatal(err)
 	}
 
+	watchNamespace, err := k8sutil.GetWatchNamespace()
+	if err != nil {
+		span.SetStatus(codes.Internal)
+		span.SetAttribute(key.String("error", err.Error()))
+		log.WithError(err).Fatal("failed to get watch namespace")
+	}
+
+	setOperatorScope(ctx, watchNamespace)
+
 	mgr := createManager(ctx, cfg)
 
+	detectNamespacePermissions(ctx, mgr)
 	performUpgrades(ctx, mgr)
 	setupControllers(ctx, mgr)
 	serveCRMetrics(ctx, cfg, namespace)
 	createMetricsService(ctx, cfg, namespace)
 
 	return mgr
+}
+
+func detectNamespacePermissions(ctx context.Context, mgr manager.Manager) {
+	tracer := global.TraceProvider().GetTracer(v1.BootstrapTracer)
+	ctx, span := tracer.Start(ctx, "detectNamespacePermissions")
+	defer span.End()
+
+	namespaces := &corev1.NamespaceList{}
+	opts := []client.ListOption{}
+	if err := mgr.GetAPIReader().List(ctx, namespaces, opts...); err != nil {
+		log.WithError(err).Trace("could not get a list of namespaces, disabling namespace controller")
+		tracing.HandleError(err, span)
+		span.SetAttribute(key.Bool(v1.ConfigEnableNamespaceController, false))
+		viper.Set(v1.ConfigEnableNamespaceController, false)
+	} else {
+		span.SetAttribute(key.Bool(v1.ConfigEnableNamespaceController, true))
+		viper.Set(v1.ConfigEnableNamespaceController, true)
+	}
+}
+
+func setOperatorScope(ctx context.Context, namespace string) {
+	tracer := global.TraceProvider().GetTracer(v1.BootstrapTracer)
+	ctx, span := tracer.Start(ctx, "setOperatorScope")
+	defer span.End()
+
+	// set what's the namespace to watch
+	viper.Set(v1.ConfigWatchNamespace, namespace)
+
+	// for now, the logic is simple: if we are watching all namespaces, then we are cluster-wide
+	if viper.GetString(v1.ConfigWatchNamespace) == v1.WatchAllNamespaces {
+		span.SetAttribute(key.String(v1.ConfigOperatorScope, v1.OperatorScopeCluster))
+		viper.Set(v1.ConfigOperatorScope, v1.OperatorScopeCluster)
+	} else {
+		log.Info("Consider running the operator in a cluster-wide scope for extra features")
+		span.SetAttribute(key.String(v1.ConfigOperatorScope, v1.OperatorScopeNamespace))
+		viper.Set(v1.ConfigOperatorScope, v1.OperatorScopeNamespace)
+	}
 }
 
 func setLogLevel(ctx context.Context) {
@@ -109,6 +157,8 @@ func buildIdentity(ctx context.Context, podNamespace string) {
 	} else {
 		identity = fmt.Sprintf("%s", operatorName)
 	}
+
+	span.SetAttribute(key.String(v1.ConfigIdentity, identity))
 	viper.Set(v1.ConfigIdentity, identity)
 }
 
@@ -144,15 +194,8 @@ func createManager(ctx context.Context, cfg *rest.Config) manager.Manager {
 	ctx, span := tracer.Start(ctx, "createManager")
 	defer span.End()
 
-	namespace, err := k8sutil.GetWatchNamespace()
-	if err != nil {
-		span.SetStatus(codes.Internal)
-		span.SetAttribute(key.String("error", err.Error()))
-		log.WithError(err).Fatal("failed to get watch namespace")
-	}
-
 	mgr, err := manager.New(cfg, manager.Options{
-		Namespace:          namespace,
+		Namespace:          viper.GetString(v1.ConfigWatchNamespace),
 		MapperProvider:     restmapper.NewDynamicRESTMapper,
 		MetricsBindAddress: fmt.Sprintf("%s:%d", viper.GetString("metrics-host"), viper.GetInt32("metrics-port")),
 	})

--- a/pkg/controller/deployment/deployment_controller.go
+++ b/pkg/controller/deployment/deployment_controller.go
@@ -3,13 +3,16 @@ package deployment
 import (
 	"context"
 
-	"k8s.io/apimachinery/pkg/types"
-
 	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+	"go.opentelemetry.io/otel/api/key"
+	"go.opentelemetry.io/otel/global"
+	"google.golang.org/grpc/codes"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -19,6 +22,7 @@ import (
 
 	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/inject"
+	"github.com/jaegertracing/jaeger-operator/pkg/tracing"
 )
 
 // Add creates a new Deployment Controller and adds it to the Manager. The Manager will set fields on the Controller
@@ -29,7 +33,7 @@ func Add(mgr manager.Manager) error {
 
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager) reconcile.Reconciler {
-	return &ReconcileDeployment{client: mgr.GetClient(), scheme: mgr.GetScheme()}
+	return &ReconcileDeployment{client: mgr.GetClient(), scheme: mgr.GetScheme(), rClient: mgr.GetAPIReader()}
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
@@ -56,6 +60,11 @@ type ReconcileDeployment struct {
 	// This client, initialized using mgr.Client() above, is a split client
 	// that reads objects from the cache and writes to the apiserver
 	client client.Client
+
+	// this avoid the cache, which we need to bypass because the default client will attempt to place
+	// a watch on Namespace at cluster scope, which isn't desirable to us...
+	rClient client.Reader
+
 	scheme *runtime.Scheme
 }
 
@@ -67,6 +76,11 @@ type ReconcileDeployment struct {
 func (r *ReconcileDeployment) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	ctx := context.Background()
 
+	tracer := global.TraceProvider().GetTracer(v1.ReconciliationTracer)
+	ctx, span := tracer.Start(ctx, "reconcileDeployment")
+	defer span.End()
+
+	span.SetAttributes(key.String("name", request.Name), key.String("namespace", request.Namespace))
 	log.WithFields(log.Fields{
 		"namespace": request.Namespace,
 		"name":      request.Name,
@@ -80,32 +94,32 @@ func (r *ReconcileDeployment) Reconcile(request reconcile.Request) (reconcile.Re
 			// Request object not found, could have been deleted after reconcile request.
 			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
 			// Return and don't requeue
+			span.SetStatus(codes.NotFound)
 			return reconcile.Result{}, nil
 		}
 		// Error reading the object - requeue the request.
-		return reconcile.Result{}, err
+		return reconcile.Result{}, tracing.HandleError(err, span)
 	}
 
 	ns := &corev1.Namespace{}
-	err = r.client.Get(ctx, types.NamespacedName{Name: request.Namespace}, ns)
+	err = r.rClient.Get(ctx, types.NamespacedName{Name: request.Namespace}, ns)
+	// we shouldn't fail if the namespace object can't be obtained
 	if err != nil {
-		if errors.IsNotFound(err) {
-			// Request object not found, could have been deleted after reconcile request.
-			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
-			// Return and don't requeue
-			return reconcile.Result{}, nil
-		}
-		// Error reading the object - requeue the request.
-		return reconcile.Result{}, nil
+		log.WithField("namespace", request.Namespace).WithError(err).Trace("failed to get the namespace for the deployment, skipping injection based on namespace annotation")
+		tracing.HandleError(err, span)
 	}
 
 	if inject.Needed(dep, ns) {
 		jaegers := &v1.JaegerList{}
 		opts := []client.ListOption{}
-		err := r.client.List(ctx, jaegers, opts...)
-		if err != nil {
+
+		if viper.GetString(v1.ConfigOperatorScope) == v1.OperatorScopeNamespace {
+			opts = append(opts, client.InNamespace(viper.GetString(v1.ConfigWatchNamespace)))
+		}
+
+		if err := r.client.List(ctx, jaegers, opts...); err != nil {
 			log.WithError(err).Error("failed to get the available Jaeger pods")
-			return reconcile.Result{}, err
+			return reconcile.Result{}, tracing.HandleError(err, span)
 		}
 
 		jaeger := inject.Select(dep, ns, jaegers)
@@ -121,7 +135,7 @@ func (r *ReconcileDeployment) Reconcile(request reconcile.Request) (reconcile.Re
 			dep = inject.Sidecar(jaeger, dep)
 			if err := r.client.Update(ctx, dep); err != nil {
 				log.WithField("deployment", dep).WithError(err).Error("failed to update")
-				return reconcile.Result{}, err
+				return reconcile.Result{}, tracing.HandleError(err, span)
 			}
 		} else {
 			log.WithField("deployment", dep.Name).Info("No suitable Jaeger instances found to inject a sidecar")

--- a/pkg/controller/namespace/namespace_controller.go
+++ b/pkg/controller/namespace/namespace_controller.go
@@ -4,6 +4,10 @@ import (
 	"context"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+	"go.opentelemetry.io/otel/api/key"
+	"go.opentelemetry.io/otel/global"
+	"google.golang.org/grpc/codes"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -17,6 +21,7 @@ import (
 
 	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/inject"
+	"github.com/jaegertracing/jaeger-operator/pkg/tracing"
 )
 
 // Add creates a new Namespace Controller and adds it to the Manager. The Manager will set fields on the Controller
@@ -27,11 +32,17 @@ func Add(mgr manager.Manager) error {
 
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager) reconcile.Reconciler {
-	return &ReconcileNamespace{client: mgr.GetClient(), scheme: mgr.GetScheme()}
+	return &ReconcileNamespace{client: mgr.GetClient(), scheme: mgr.GetScheme(), rClient: mgr.GetAPIReader()}
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
 func add(mgr manager.Manager, r reconcile.Reconciler) error {
+	// we only create this controller if we have cluster-scope, as watching namespaces is a cluster-wide operation
+	if !viper.GetBool(v1.ConfigEnableNamespaceController) {
+		log.Trace("skipping reconciliation for namespaces, do not have permissions to list and watch namespaces")
+		return nil
+	}
+
 	// Create a new controller
 	c, err := controller.New("namespace-controller", mgr, controller.Options{Reconciler: r})
 	if err != nil {
@@ -53,6 +64,11 @@ type ReconcileNamespace struct {
 	// This client, initialized using mgr.Client() above, is a split client
 	// that reads objects from the cache and writes to the apiserver
 	client client.Client
+
+	// this avoid the cache, which we need to bypass because the default client will attempt to place
+	// a watch on Namespace at cluster scope, which isn't desirable to us...
+	rClient client.Reader
+
 	scheme *runtime.Scheme
 }
 
@@ -64,22 +80,28 @@ type ReconcileNamespace struct {
 func (r *ReconcileNamespace) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	ctx := context.Background()
 
+	tracer := global.TraceProvider().GetTracer(v1.ReconciliationTracer)
+	ctx, span := tracer.Start(ctx, "reconcileNamespace")
+	defer span.End()
+
+	span.SetAttributes(key.String("name", request.Name), key.String("namespace", request.Namespace))
 	log.WithFields(log.Fields{
 		"namespace": request.Namespace,
 		"name":      request.Name,
 	}).Trace("Reconciling Namespace")
 
 	ns := &corev1.Namespace{}
-	err := r.client.Get(ctx, request.NamespacedName, ns)
+	err := r.rClient.Get(ctx, request.NamespacedName, ns)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
 			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
 			// Return and don't requeue
+			span.SetStatus(codes.NotFound)
 			return reconcile.Result{}, nil
 		}
 		// Error reading the object - requeue the request.
-		return reconcile.Result{}, nil
+		return reconcile.Result{}, tracing.HandleError(err, span)
 	}
 
 	opts := []client.ListOption{
@@ -97,7 +119,7 @@ func (r *ReconcileNamespace) Reconcile(request reconcile.Request) (reconcile.Res
 			return reconcile.Result{}, nil
 		}
 		// Error reading the object - requeue the request.
-		return reconcile.Result{}, err
+		return reconcile.Result{}, tracing.HandleError(err, span)
 	}
 
 	for i := 0; i < len(deps.Items); i++ {
@@ -105,10 +127,14 @@ func (r *ReconcileNamespace) Reconcile(request reconcile.Request) (reconcile.Res
 		if inject.Needed(dep, ns) {
 			jaegers := &v1.JaegerList{}
 			opts := []client.ListOption{}
-			err := r.client.List(ctx, jaegers, opts...)
-			if err != nil {
+
+			if viper.GetString(v1.ConfigOperatorScope) == v1.OperatorScopeNamespace {
+				opts = append(opts, client.InNamespace(viper.GetString(v1.ConfigWatchNamespace)))
+			}
+
+			if err := r.client.List(ctx, jaegers, opts...); err != nil {
 				log.WithError(err).Error("failed to get the available Jaeger pods")
-				return reconcile.Result{}, err
+				return reconcile.Result{}, tracing.HandleError(err, span)
 			}
 
 			jaeger := inject.Select(dep, ns, jaegers)
@@ -124,7 +150,7 @@ func (r *ReconcileNamespace) Reconcile(request reconcile.Request) (reconcile.Res
 				dep = inject.Sidecar(jaeger, dep)
 				if err := r.client.Update(ctx, dep); err != nil {
 					log.WithField("deployment", dep).WithError(err).Error("failed to update")
-					return reconcile.Result{}, err
+					return reconcile.Result{}, tracing.HandleError(err, span)
 				}
 			} else {
 				log.WithField("deployment", dep.Name).Info("No suitable Jaeger instances found to inject a sidecar")

--- a/test/service_account.yaml
+++ b/test/service_account.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: jaeger-operator


### PR DESCRIPTION
This is a first draft in getting the operator to work in a single namespace, without cluster roles. This supersedes #830 and fixes #791. It also fixes #905.

This PR also includes instrumentation of the reconciliation for deployments and namespaces, as I added them in order to better understand what needed fixing.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>