### PR TITLE
Fix route name for OCP

### DIFF
--- a/pkg/route/query.go
+++ b/pkg/route/query.go
@@ -43,7 +43,7 @@ func (r *QueryRoute) Get() *corev1.Route {
 		// -namespace is added to the host by OpenShift
 		name = util.Truncate(r.jaeger.Name, 62-len(r.jaeger.Namespace))
 	}
-
+	name = util.DNSName(name)
 	return &corev1.Route{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Route",

--- a/pkg/strategy/all_in_one_test.go
+++ b/pkg/strategy/all_in_one_test.go
@@ -12,6 +12,7 @@ import (
 
 	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/storage"
+	"github.com/jaegertracing/jaeger-operator/pkg/util"
 )
 
 func init() {
@@ -110,7 +111,7 @@ func assertDeploymentsAndServicesForAllInOne(t *testing.T, name string, s S, has
 	ingresses := map[string]bool{}
 	routes := map[string]bool{}
 	if viper.GetString("platform") == v1.FlagPlatformOpenShift {
-		routes[fmt.Sprintf("%s", name)] = false
+		routes[fmt.Sprintf("%s", util.DNSName(name))] = false
 	} else {
 		ingresses[fmt.Sprintf("%s-query", name)] = false
 	}

--- a/pkg/strategy/production_test.go
+++ b/pkg/strategy/production_test.go
@@ -14,6 +14,7 @@ import (
 
 	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/storage"
+	"github.com/jaegertracing/jaeger-operator/pkg/util"
 )
 
 func init() {
@@ -151,7 +152,7 @@ func assertDeploymentsAndServicesForProduction(t *testing.T, name string, s S, h
 	ingresses := map[string]bool{}
 	routes := map[string]bool{}
 	if viper.GetString("platform") == v1.FlagPlatformOpenShift {
-		routes[name] = false
+		routes[util.DNSName(name)] = false
 	} else {
 		ingresses[fmt.Sprintf("%s-query", name)] = false
 	}

--- a/pkg/util/dns_name.go
+++ b/pkg/util/dns_name.go
@@ -9,28 +9,22 @@ import (
 var regex = regexp.MustCompile(`[a-z0-9]`)
 
 // DNSName returns a dns-safe string for the given name.
-// Any char that is not [a-z0-9] is replaced by "-".
-// If the final name starts with "-", "a" is added as prefix. Similarly, if it ends with "-", "z" is added.
+// Any char that is not [a-z0-9] is replaced by "-" or "a".
+// Replacement character "a" is used only at the beginning or at the end of the name.
+// The function does not change length of the string.
 func DNSName(name string) string {
 	var d []rune
 
-	first := true
-	for _, x := range strings.ToLower(name) {
+	for i, x := range strings.ToLower(name) {
 		if regex.Match([]byte(string(x))) {
 			d = append(d, x)
 		} else {
-			if first {
+			if i == 0 || i == utf8.RuneCountInString(name)-1 {
 				d = append(d, 'a')
-			}
-			d = append(d, '-')
-
-			if len(d) == utf8.RuneCountInString(name) {
-				// we had to replace the last char, so, it's "-". DNS names can't end with dash.
-				d = append(d, 'z')
+			} else {
+				d = append(d, '-')
 			}
 		}
-
-		first = false
 	}
 
 	return string(d)

--- a/pkg/util/dns_name_test.go
+++ b/pkg/util/dns_name_test.go
@@ -15,8 +15,12 @@ func TestDnsName(t *testing.T) {
 		{"simplest", "simplest"},
 		{"instance.with.dots-collector-headless", "instance-with-dots-collector-headless"},
 		{"TestQueryDottedServiceName.With.Dots", "testquerydottedservicename-with-dots"},
-		{"Service🦄", "service-z"},
-		{"📈Stock-Tracker", "a-stock-tracker"},
+		{"Service🦄", "servicea"},
+		{"📈Stock-Tracker", "astock-tracker"},
+		{"-📈Stock-Tracker", "a-stock-tracker"},
+		{"📈", "a"},
+		{"foo-", "fooa"},
+		{"-foo", "afoo"},
 	}
 
 	for _, tt := range tests {

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -363,7 +363,7 @@ func findRoute(t *testing.T, f *framework.Framework, name string) *osv1.Route {
 	}
 
 	// Truncate the namespace name and use that to find the route
-	target := util.Truncate(name, 62-len(namespace))
+	target := util.DNSName(util.Truncate(name, 62-len(namespace)))
 	for _, r := range routeList.Items {
 		if strings.HasPrefix(r.Spec.Host, target) {
 			return &r


### PR DESCRIPTION
Resolves https://issues.redhat.com/browse/TRACING-965

Fixes smoke test failures on OCP `make e2e-tests-smoke` caused probably by https://github.com/jaegertracing/jaeger-operator/pull/891. Other related fixes https://github.com/jaegertracing/jaeger-operator/pull/904 and https://github.com/jaegertracing/jaeger-operator/pull/915

Signed-off-by: Pavol Loffay <ploffay@redhat.com>