### PR TITLE
Fixed the generate CSV command

### DIFF
--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -38,7 +38,7 @@ sed "s~image: jaegertracing/jaeger-operator.*~image: ${BUILD_IMAGE}~gi" -i test/
 # change the versions.txt
 sed "s~${PREVIOUS_VERSION}~${OPERATOR_VERSION}~gi" -i versions.txt
 
-operator-sdk olm-catalog gen-csv \
+operator-sdk generate csv \
     --csv-channel=stable \
     --csv-version=${OPERATOR_VERSION} \
     --from-version=${PREVIOUS_VERSION}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,7 @@ Starting from operator-sdk v0.5.0, one can generate and update CSVs based on the
 The Jaeger CSV can be updated to version 1.9.0 with the following command:
 
 ```
-$ operator-sdk olm-catalog gen-csv --csv-version 1.9.0
+$ operator-sdk generate csv --csv-version 1.9.0
 INFO[0000] Generating CSV manifest version 1.9.0
 INFO[0000] Create deploy/olm-catalog/jaeger-operator.csv.yaml 
 INFO[0000] Create deploy/olm-catalog/_generated.concat_crd.yaml 


### PR DESCRIPTION
The `olm-catalog gen-csv` command has been moved as part of Operator SDK 0.15.x.
Reference: https://github.com/operator-framework/operator-sdk/blob/master/doc/user/olm-catalog/generating-a-csv.md#generating-a-cluster-service-version-csv-with-operator-sdk

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>