### PR TITLE
Sidecar injection: Include the admin-http port

### DIFF
--- a/pkg/inject/sidecar.go
+++ b/pkg/inject/sidecar.go
@@ -25,7 +25,7 @@ var (
 	// PrometheusDefaultAnnotations is a map containing annotations for prometheus to be inserted at sidecar in case it doesn't have any
 	PrometheusDefaultAnnotations = map[string]string{
 		"prometheus.io/scrape": "true",
-		"prometheus.io/port":   "5778",
+		"prometheus.io/port":   "14271",
 	}
 )
 
@@ -138,6 +138,7 @@ func container(jaeger *v1.Jaeger, dep *appsv1.Deployment) corev1.Container {
 	configRest := util.GetPort("--http-server.host-port=", args, 5778)
 	jgCompactTrft := util.GetPort("--processor.jaeger-compact.server-host-port=", args, 6831)
 	jgBinaryTrft := util.GetPort("--processor.jaeger-binary.server-host-port=", args, 6832)
+	adminPort := util.GetPort("--admin-http-port=", args, 14271)
 
 	if len(util.FindItem("--jaeger.tags=", args)) == 0 {
 		agentTags := fmt.Sprintf("%s=%s,%s=%s,%s=%s,%s=%s,%s=%s",
@@ -204,6 +205,10 @@ func container(jaeger *v1.Jaeger, dep *appsv1.Deployment) corev1.Container {
 				ContainerPort: jgBinaryTrft,
 				Name:          "jg-binary-trft",
 				Protocol:      corev1.ProtocolUDP,
+			},
+			{
+				ContainerPort: adminPort,
+				Name:          "admin-http",
 			},
 		},
 		Resources: commonSpec.Resources,

--- a/pkg/inject/sidecar_test.go
+++ b/pkg/inject/sidecar_test.go
@@ -176,11 +176,12 @@ func TestSidecarDefaultPorts(t *testing.T) {
 	assert.Len(t, dep.Spec.Template.Spec.Containers, 2)
 	assert.Contains(t, dep.Spec.Template.Spec.Containers[1].Image, "jaeger-agent")
 
-	assert.Len(t, dep.Spec.Template.Spec.Containers[1].Ports, 4)
+	assert.Len(t, dep.Spec.Template.Spec.Containers[1].Ports, 5)
 	assert.Contains(t, dep.Spec.Template.Spec.Containers[1].Ports, corev1.ContainerPort{ContainerPort: 5775, Name: "zk-compact-trft", Protocol: corev1.ProtocolUDP})
 	assert.Contains(t, dep.Spec.Template.Spec.Containers[1].Ports, corev1.ContainerPort{ContainerPort: 5778, Name: "config-rest"})
 	assert.Contains(t, dep.Spec.Template.Spec.Containers[1].Ports, corev1.ContainerPort{ContainerPort: 6831, Name: "jg-compact-trft", Protocol: corev1.ProtocolUDP})
 	assert.Contains(t, dep.Spec.Template.Spec.Containers[1].Ports, corev1.ContainerPort{ContainerPort: 6832, Name: "jg-binary-trft", Protocol: corev1.ProtocolUDP})
+	assert.Contains(t, dep.Spec.Template.Spec.Containers[1].Ports, corev1.ContainerPort{ContainerPort: 14271, Name: "admin-http"})
 }
 
 func TestSkipInjectSidecar(t *testing.T) {


### PR DESCRIPTION
Judging from the code, at some point the jaeger-agent accepted metrics scrapes on the other HTTP port (config-rest), but that is no longer the case.  So this change exposes the admin-http port, which does accept metric scrapes.

(It appears that the 1.12.0 release changed this port, see https://github.com/jaegertracing/jaeger/pull/1442 )

I am actually confused as to why any of the other ports are exposed; the idea of the sidecar is that these ports only show up to other containers in the pod on 127.0.0.1 and it would be somewhat harmful if other applications started sending traces to the pod address.  But they're there, so I didn't touch them.