### PR TITLE
Use ubi as base image

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos
+FROM registry.access.redhat.com/ubi8/ubi
 
 ENV OPERATOR=/usr/local/bin/jaeger-operator \
     USER_UID=1001 \

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi8/ubi
+FROM registry.access.redhat.com/ubi8/ubi
 
 ENV OPERATOR=/usr/local/bin/jaeger-operator \
     USER_UID=1001 \

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi
+FROM registry.redhat.io/ubi8/ubi
 
 ENV OPERATOR=/usr/local/bin/jaeger-operator \
     USER_UID=1001 \


### PR DESCRIPTION
Resolves #767

- set docker base image to registry.access.redhat.com/ubi8/ubi