### PR TITLE
Reorganized cluster roles, added rules to watch all namespaces

### DIFF
--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -1,11 +1,15 @@
-## this is an extra set of permissions that the Jaeger Operator might make use of if granted
+## When using the operator in cluster-wide mode, this ClusterRole has to be created and bound to the jaeger-operator service account,
+## so that the operator can watch and create resources in every namespace in the cluster.
+## An alternative to this cluster role is to create one role binding for each namespace that the operator should watch
+## in that case, don't forget to add a comma-separated list of namespaces as WATCH_NAMESPACE in the operator's deployment.
+## Further down in this file there's another set of rules, with extra optional permissions
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: jaeger-operator-cluster
+  name: jaeger-operator
 rules:
 
-## required for cluster-wide operators
+## our own custom resources
 - apiGroups:
   - jaegertracing.io
   resources:
@@ -17,6 +21,137 @@ rules:
   - 'update'
   - 'delete'
   - 'watch'
+
+## for the operator's own deployment
+- apiGroups:
+  - apps
+  resourceNames:
+  - jaeger-operator
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update
+
+## regular things the operator manages for an instance, as the result of processing CRs
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - persistentvolumeclaims
+  - pods
+  - secrets
+  - serviceaccounts
+  - services
+  - services/finalizers
+  verbs:
+  - 'get'
+  - 'list'
+  - 'create'
+  - 'update'
+  - 'delete'
+  - 'watch'
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - 'get'
+  - 'list'
+  - 'create'
+  - 'update'
+  - 'delete'
+  - 'watch'
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - 'get'
+  - 'list'
+  - 'create'
+  - 'update'
+  - 'delete'
+  - 'watch'
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  - cronjobs
+  verbs:
+  - 'get'
+  - 'list'
+  - 'create'
+  - 'update'
+  - 'delete'
+  - 'watch'
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - 'get'
+  - 'list'
+  - 'create'
+  - 'update'
+  - 'delete'
+  - 'watch'
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - 'get'
+  - 'list'
+  - 'create'
+  - 'update'
+  - 'delete'
+  - 'watch'
+
+## needed if you want the operator to create service monitors for the Jaeger instances
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - 'get'
+  - 'list'
+  - 'create'
+  - 'update'
+  - 'delete'
+  - 'watch'
+
+## for the Elasticsearch auto-provisioning
+- apiGroups:
+  - logging.openshift.io
+  resources:
+  - elasticsearches
+  verbs:
+  - 'get'
+  - 'list'
+  - 'create'
+  - 'update'
+  - 'delete'
+  - 'watch'
+
+## for the Kafka auto-provisioning
+- apiGroups:
+  - kafka.strimzi.io
+  resources:
+  - kafkas
+  - kafkausers
+  verbs:
+  - 'get'
+  - 'list'
+  - 'create'
+  - 'update'
+  - 'delete'
+  - 'watch'
+
+## Extra permissions
+## This is an extra set of permissions that the Jaeger Operator might make use of if granted
 
 ## needed if support for injecting sidecars based on namespace annotation is required
 - apiGroups:

--- a/deploy/cluster_role_binding.yaml
+++ b/deploy/cluster_role_binding.yaml
@@ -1,12 +1,12 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jaeger-operator-cluster
+  name: jaeger-operator
 subjects:
 - kind: ServiceAccount
   name: jaeger-operator
   namespace: "observability" # change to point to the namespace you installed your operator
 roleRef:
   kind: ClusterRole
-  name: jaeger-operator-cluster
+  name: jaeger-operator
   apiGroup: rbac.authorization.k8s.io

--- a/deploy/olm-catalog/jaeger-operator/1.17.0/jaeger-operator.v1.17.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/jaeger-operator/1.17.0/jaeger-operator.v1.17.0.clusterserviceversion.yaml
@@ -76,7 +76,8 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - description: Jaeger is the Schema for the jaegers API
+    - description: A configuration file for a Jaeger custom resource.
+      displayName: Jaeger
       kind: Jaeger
       name: jaegers.jaegertracing.io
       version: v1
@@ -135,6 +136,124 @@ spec:
           - delete
           - watch
         - apiGroups:
+          - apps
+          resourceNames:
+          - jaeger-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - persistentvolumeclaims
+          - pods
+          - secrets
+          - serviceaccounts
+          - services
+          - services/finalizers
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - watch
+        - apiGroups:
+          - extensions
+          resources:
+          - ingresses
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - watch
+        - apiGroups:
+          - batch
+          resources:
+          - jobs
+          - cronjobs
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - watch
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - watch
+        - apiGroups:
+          - autoscaling
+          resources:
+          - horizontalpodautoscalers
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - watch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - watch
+        - apiGroups:
+          - logging.openshift.io
+          resources:
+          - elasticsearches
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - watch
+        - apiGroups:
+          - kafka.strimzi.io
+          resources:
+          - kafkas
+          - kafkausers
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - watch
+        - apiGroups:
           - ""
           resources:
           - namespaces
@@ -163,7 +282,7 @@ spec:
           - update
           - delete
           - watch
-        serviceAccountName: jaeger-operator-cluster
+        serviceAccountName: jaeger-operator
       deployments:
       - name: jaeger-operator
         spec:

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -111,7 +111,7 @@ func prepare(t *testing.T) (*framework.TestCtx, error) {
 
 	crb := &rbac.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: namespace + "jaeger-operator-cluster",
+			Name: namespace + "jaeger-operator",
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					Name:       ns.Name,
@@ -126,7 +126,7 @@ func prepare(t *testing.T) (*framework.TestCtx, error) {
 			Name:      "jaeger-operator",
 			Namespace: namespace,
 		}},
-		RoleRef: rbac.RoleRef{Kind: "ClusterRole", Name: "jaeger-operator-cluster"},
+		RoleRef: rbac.RoleRef{Kind: "ClusterRole", Name: "jaeger-operator"},
 	}
 
 	if _, err := framework.Global.KubeClient.RbacV1().ClusterRoleBindings().Create(crb); err != nil {


### PR DESCRIPTION
This PR changes the cluster role to include all the rules from the regular role. Unfortunately, we can't compose roles, as the operator-sdk will *either* bind a service account for the cluster role, *or* to a role. It cannot bind a service account to both a role and a cluster role (!!). 

Related to the finding above, this PR also fixes a problem that went unnoticed with the CSV, which listed a different service account under `clusterPermissions`.

Fixes #931.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>