### PR TITLE
Use non-cached CR on reconciliation

### DIFF
--- a/pkg/controller/jaeger/jaeger_controller.go
+++ b/pkg/controller/jaeger/jaeger_controller.go
@@ -99,7 +99,7 @@ func (r *ReconcileJaeger) Reconcile(request reconcile.Request) (reconcile.Result
 
 	// Fetch the Jaeger instance
 	instance := &v1.Jaeger{}
-	err := r.client.Get(ctx, request.NamespacedName, instance)
+	err := r.rClient.Get(ctx, request.NamespacedName, instance)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.

--- a/pkg/controller/jaeger/jaeger_controller_test.go
+++ b/pkg/controller/jaeger/jaeger_controller_test.go
@@ -71,7 +71,7 @@ func TestDeletedInstance(t *testing.T) {
 	// no known objects
 	cl := fake.NewFakeClient()
 
-	r := &ReconcileJaeger{client: cl, scheme: s}
+	r := &ReconcileJaeger{client: cl, scheme: s, rClient: cl}
 
 	req := reconcile.Request{
 		NamespacedName: types.NamespacedName{
@@ -132,7 +132,7 @@ func TestSkipOnNonOwnedCR(t *testing.T) {
 	s := scheme.Scheme
 	s.AddKnownTypes(v1.SchemeGroupVersion, jaeger)
 	cl := fake.NewFakeClient(jaeger)
-	r := &ReconcileJaeger{client: cl, scheme: s}
+	r := &ReconcileJaeger{client: cl, scheme: s, rClient: cl}
 	req := reconcile.Request{NamespacedName: nsn}
 
 	// test


### PR DESCRIPTION
When receiving a reconciliation request, we try to obtain the CR that triggered the event from Kubernetes repository. When using the regular client, we might end up retrieving a cached version that isn't up to date, meaning that we might see errors like the following from time to time:

```
ERRO[0350] failed to store back the current CustomResource  error="Operation cannot be fulfilled on jaegers.jaegertracing.io \"simple-prod\": the object has been modified; please apply your changes to the latest version and try again" execution="2020-03-02 13:55:31.292270472 +0000 UTC" instance=simple-prod namespace=observability
```

This error isn't a big problem, as it will trigger another reconciliation loop and things will eventually stabilize, but given that we might have a couple of reconciliation loops for the same object when it is first created, we want to bypass the cache and reduce the risk of facing this error.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>