### PR TITLE
Use routes instead of port-forwarding where possible to improve test …

### DIFF
--- a/.ci/run-e2e-tests.sh
+++ b/.ci/run-e2e-tests.sh
@@ -5,7 +5,8 @@ set -x
 
 ## Since we're running MiniKube with --vm-driver none, change imagePullPolicy to get the image locally
 sed -i 's/imagePullPolicy: Always/imagePullPolicy: Never/g' test/operator.yaml
-
+## remove this once #947 is fixed
+export VERBOSE='-v -timeout 20m'
 if [ "${TEST_GROUP}" = "es" ]; then
     echo "Running elasticsearch tests"
     make es

--- a/test/e2e/cassandra_test.go
+++ b/test/e2e/cassandra_test.go
@@ -86,6 +86,7 @@ func (suite *CassandraTestSuite) TestCassandraSparkDependencies() {
 }
 
 func getJaegerWithCassandra(s string) *v1.Jaeger {
+	ingressEnabled := true
 	j := &v1.Jaeger{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Jaeger",
@@ -96,6 +97,10 @@ func getJaegerWithCassandra(s string) *v1.Jaeger {
 			Namespace: namespace,
 		},
 		Spec: v1.JaegerSpec{
+			Ingress: v1.JaegerIngressSpec{
+				Enabled:  &ingressEnabled,
+				Security: v1.IngressSecurityNoneExplicit,
+			},
 			Strategy: v1.DeploymentStrategyAllInOne,
 			Storage: v1.JaegerStorageSpec{
 				Type:    "cassandra",

--- a/test/e2e/elasticsearch_test.go
+++ b/test/e2e/elasticsearch_test.go
@@ -155,6 +155,7 @@ func (suite *ElasticSearchTestSuite) TestEsIndexCleaner() {
 }
 
 func getJaegerSimpleProdWithServerUrls() *v1.Jaeger {
+	ingressEnabled := true
 	exampleJaeger := &v1.Jaeger{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Jaeger",
@@ -165,6 +166,10 @@ func getJaegerSimpleProdWithServerUrls() *v1.Jaeger {
 			Namespace: namespace,
 		},
 		Spec: v1.JaegerSpec{
+			Ingress: v1.JaegerIngressSpec{
+				Enabled:  &ingressEnabled,
+				Security: v1.IngressSecurityNoneExplicit,
+			},
 			Strategy: v1.DeploymentStrategyProduction,
 			Storage: v1.JaegerStorageSpec{
 				Type: "elasticsearch",
@@ -179,6 +184,7 @@ func getJaegerSimpleProdWithServerUrls() *v1.Jaeger {
 
 func getJaegerAllInOne(name string) *v1.Jaeger {
 	numberOfDays := 0
+	ingressEnabled := true
 	j := &v1.Jaeger{
 		TypeMeta: v12.TypeMeta{
 			Kind:       "Jaeger",
@@ -189,6 +195,10 @@ func getJaegerAllInOne(name string) *v1.Jaeger {
 			Namespace: namespace,
 		},
 		Spec: v1.JaegerSpec{
+			Ingress: v1.JaegerIngressSpec{
+				Enabled:  &ingressEnabled,
+				Security: v1.IngressSecurityNoneExplicit,
+			},
 			Strategy: v1.DeploymentStrategyAllInOne,
 			Storage: v1.JaegerStorageSpec{
 				Type: "elasticsearch",

--- a/test/e2e/self_provisioned_elasticsearch_kafka_test.go
+++ b/test/e2e/self_provisioned_elasticsearch_kafka_test.go
@@ -51,6 +51,7 @@ func (suite *SelfProvisionedTestSuite) SetupSuite() {
 			APIVersion: "kafka.strimzi.io/v1beta1",
 		},
 	}))
+	addToFrameworkSchemeForSmokeTests(t)
 
 	var err error
 	ctx, err = prepare(t)
@@ -112,6 +113,7 @@ func (suite *SelfProvisionedTestSuite) TestSelfProvisionedESAndKafkaSmokeTest() 
 }
 
 func getJaegerSelfProvisionedESAndKafka(instanceName string) *v1.Jaeger {
+	ingressEnabled := true
 	return &v1.Jaeger{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Jaeger",
@@ -122,6 +124,10 @@ func getJaegerSelfProvisionedESAndKafka(instanceName string) *v1.Jaeger {
 			Namespace: namespace,
 		},
 		Spec: v1.JaegerSpec{
+			Ingress: v1.JaegerIngressSpec{
+				Enabled:  &ingressEnabled,
+				Security: v1.IngressSecurityNoneExplicit,
+			},
 			Strategy: v1.DeploymentStrategyStreaming,
 			Storage: v1.JaegerStorageSpec{
 				Type: "elasticsearch",

--- a/test/e2e/self_provisioned_elasticsearch_test.go
+++ b/test/e2e/self_provisioned_elasticsearch_test.go
@@ -48,6 +48,7 @@ func (suite *SelfProvisionedTestSuite) SetupSuite() {
 			APIVersion: "logging.openshift.io/v1",
 		},
 	}))
+	addToFrameworkSchemeForSmokeTests(t)
 
 	var err error
 	ctx, err = prepare(t)
@@ -199,6 +200,7 @@ func (suite *SelfProvisionedTestSuite) TestValidateEsOperatorImage() {
 }
 
 func getJaegerSimpleProd(instanceName string) *v1.Jaeger {
+	ingressEnabled := true
 	exampleJaeger := &v1.Jaeger{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Jaeger",
@@ -209,6 +211,10 @@ func getJaegerSimpleProd(instanceName string) *v1.Jaeger {
 			Namespace: namespace,
 		},
 		Spec: v1.JaegerSpec{
+			Ingress: v1.JaegerIngressSpec{
+				Enabled:  &ingressEnabled,
+				Security: v1.IngressSecurityNoneExplicit,
+			},
 			Strategy: v1.DeploymentStrategyProduction,
 			Storage: v1.JaegerStorageSpec{
 				Type: "elasticsearch",

--- a/test/e2e/smoketest.go
+++ b/test/e2e/smoketest.go
@@ -121,6 +121,7 @@ func executeSmokeTest(apiTracesEndpoint, collectorEndpoint string, hasInsecureRo
 	transport := &http.Transport{}
 	if hasInsecureRoute {
 		insecure := true
+		// #nosec  G402: TLS InsecureSkipVerify set true
 		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: insecure}
 	}
 	err = wait.Poll(retryInterval, timeout, func() (done bool, err error) {

--- a/test/e2e/smoketest.go
+++ b/test/e2e/smoketest.go
@@ -89,14 +89,13 @@ func productionSmokeTest(jaegerInstanceName, smokeTestNamespace string) {
 func hasInsecureEndpoint(jaegerInstanceName string) bool {
 	if !isOpenShift(t) {
 		return true
-	} else {
-		jaeger := getJaegerInstance(jaegerInstanceName, namespace)
-		if jaeger.Spec.Ingress.Security == v1.IngressSecurityNoneExplicit || jaeger.Spec.Ingress.Security == v1.IngressSecurityNone {
-			return true
-		} else {
-			return false
-		}
 	}
+
+	jaeger := getJaegerInstance(jaegerInstanceName, namespace)
+	if jaeger.Spec.Ingress.Security == v1.IngressSecurityNoneExplicit || jaeger.Spec.Ingress.Security == v1.IngressSecurityNone {
+		return true
+	}
+	return false
 }
 
 func executeSmokeTest(apiTracesEndpoint, collectorEndpoint string, hasInsecureEndpoint bool) {

--- a/test/e2e/smoketest.go
+++ b/test/e2e/smoketest.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -8,16 +9,21 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
+	osv1 "github.com/openshift/api/route/v1"
 	"github.com/stretchr/testify/require"
 	"github.com/uber/jaeger-client-go/config"
 	"k8s.io/apimachinery/pkg/util/wait"
+
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 )
 
 // AllInOneSmokeTest is for the all-in-one image, where query and collector use the same pod
-func AllInOneSmokeTest(resourceName string) {
+func AllInOneSmokeTest(jaegerInstanceName string) {
 	allInOneImageName := "all-in-one"
 	ports := []string{"0:16686", "0:14268"}
-	portForw, closeChan := CreatePortForward(namespace, resourceName, allInOneImageName, ports, fw.KubeConfig)
+	portForw, closeChan := CreatePortForward(namespace, jaegerInstanceName, allInOneImageName, ports, fw.KubeConfig)
 	defer portForw.Close()
 	defer close(closeChan)
 	forwardedPorts, err := portForw.GetPorts()
@@ -25,9 +31,15 @@ func AllInOneSmokeTest(resourceName string) {
 	queryPort := forwardedPorts[0].Local
 	collectorPort := forwardedPorts[1].Local
 
-	apiTracesEndpoint := fmt.Sprintf("http://localhost:%d/api/traces", queryPort)
+	var apiTracesEndpoint string
+	route, hasInsecureRoute := getInsecureRoute(jaegerInstanceName)
+	if hasInsecureRoute {
+		apiTracesEndpoint = fmt.Sprintf("https://%s/api/traces", route.Spec.Host)
+	} else {
+		apiTracesEndpoint = fmt.Sprintf("http://localhost:%d/api/traces", queryPort)
+	}
 	collectorEndpoint := fmt.Sprintf("http://localhost:%d/api/traces", collectorPort)
-	executeSmokeTest(apiTracesEndpoint, collectorEndpoint)
+	executeSmokeTest(apiTracesEndpoint, collectorEndpoint, hasInsecureRoute)
 }
 
 // ProductionSmokeTest should be used if query and collector are in separate pods
@@ -40,19 +52,26 @@ func ProductionSmokeTestWithNamespace(resourceName, smokeTestNamespace string) {
 	productionSmokeTest(resourceName, smokeTestNamespace)
 }
 
-func productionSmokeTest(resourceName, smokeTestNamespace string) {
+func productionSmokeTest(jaegerInstanceName, smokeTestNamespace string) {
 	queryPodImageName := "jaeger-query"
 	collectorPodImageName := "jaeger-collector"
-	queryPodPrefix := resourceName + "-query"
-	collectorPodPrefix := resourceName + "-collector"
+	queryPodPrefix := jaegerInstanceName + "-query"
+	collectorPodPrefix := jaegerInstanceName + "-collector"
 
-	queryPorts := []string{"0:16686"}
-	portForw, closeChan := CreatePortForward(smokeTestNamespace, queryPodPrefix, queryPodImageName, queryPorts, fw.KubeConfig)
-	defer portForw.Close()
-	defer close(closeChan)
-	forwardedQueryPorts, err := portForw.GetPorts()
-	require.NoError(t, err)
-	queryPort := forwardedQueryPorts[0].Local
+	var apiTracesEndpoint string
+	route, hasInsecureRoute := getInsecureRoute(jaegerInstanceName)
+	if hasInsecureRoute {
+		apiTracesEndpoint = fmt.Sprintf("https://%s/api/traces", route.Spec.Host)
+	} else {
+		queryPorts := []string{"0:16686"}
+		portForw, closeChan := CreatePortForward(smokeTestNamespace, queryPodPrefix, queryPodImageName, queryPorts, fw.KubeConfig)
+		defer portForw.Close()
+		defer close(closeChan)
+		forwardedQueryPorts, err := portForw.GetPorts()
+		require.NoError(t, err)
+		queryPort := forwardedQueryPorts[0].Local
+		apiTracesEndpoint = fmt.Sprintf("http://localhost:%d/api/traces", queryPort)
+	}
 
 	collectorPorts := []string{"0:14268"}
 	portForwColl, closeChanColl := CreatePortForward(smokeTestNamespace, collectorPodPrefix, collectorPodImageName, collectorPorts, fw.KubeConfig)
@@ -62,12 +81,28 @@ func productionSmokeTest(resourceName, smokeTestNamespace string) {
 	require.NoError(t, err)
 	collectorPort := forwardedCollectorPorts[0].Local
 
-	apiTracesEndpoint := fmt.Sprintf("http://localhost:%d/api/traces", queryPort)
 	collectorEndpoint := fmt.Sprintf("http://localhost:%d/api/traces", collectorPort)
-	executeSmokeTest(apiTracesEndpoint, collectorEndpoint)
+	executeSmokeTest(apiTracesEndpoint, collectorEndpoint, hasInsecureRoute)
 }
 
-func executeSmokeTest(apiTracesEndpoint, collectorEndpoint string) {
+func getInsecureRoute(jaegerInstanceName string) (*osv1.Route, bool) {
+	var route *osv1.Route
+	hasInsecureRoute := false
+	if isOpenShift(t) {
+		route = findRoute(t, fw, jaegerInstanceName)
+		if route != nil {
+			jaeger := getJaegerInstance(jaegerInstanceName, namespace)
+			if jaeger.Spec.Ingress.Security == v1.IngressSecurityNoneExplicit || jaeger.Spec.Ingress.Security == v1.IngressSecurityNone {
+				hasInsecureRoute = true
+			}
+		}
+	}
+
+	return route, hasInsecureRoute
+}
+
+func executeSmokeTest(apiTracesEndpoint, collectorEndpoint string, hasInsecureRoute bool) {
+	logrus.Infof("Using Query endpoint %s", apiTracesEndpoint)
 	serviceName := "smoketest"
 	cfg := config.Configuration{
 		Reporter:    &config.ReporterConfig{CollectorEndpoint: collectorEndpoint},
@@ -83,8 +118,13 @@ func executeSmokeTest(apiTracesEndpoint, collectorEndpoint string) {
 		Finish()
 	closer.Close()
 
+	transport := &http.Transport{}
+	if hasInsecureRoute {
+		insecure := true
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: insecure}
+	}
 	err = wait.Poll(retryInterval, timeout, func() (done bool, err error) {
-		c := http.Client{Timeout: 3 * time.Second}
+		c := http.Client{Timeout: 3 * time.Second, Transport: transport}
 		req, err := http.NewRequest(http.MethodGet, apiTracesEndpoint+"?service="+serviceName, nil)
 		require.NoError(t, err)
 

--- a/test/e2e/streaming_test.go
+++ b/test/e2e/streaming_test.go
@@ -151,6 +151,7 @@ func (suite *StreamingTestSuite) TestStreamingWithAutoProvisioning() {
 
 func jaegerStreamingDefinition(namespace string, name string) *v1.Jaeger {
 	kafkaClusterURL := fmt.Sprintf("my-cluster-kafka-brokers.%s:9092", kafkaNamespace)
+	ingressEnabled := true
 	j := &v1.Jaeger{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Jaeger",
@@ -161,6 +162,10 @@ func jaegerStreamingDefinition(namespace string, name string) *v1.Jaeger {
 			Namespace: namespace,
 		},
 		Spec: v1.JaegerSpec{
+			Ingress: v1.JaegerIngressSpec{
+				Enabled:  &ingressEnabled,
+				Security: v1.IngressSecurityNoneExplicit,
+			},
 			Strategy: v1.DeploymentStrategyStreaming,
 			Collector: v1.JaegerCollectorSpec{
 				Options: v1.NewOptions(map[string]interface{}{
@@ -192,6 +197,7 @@ func jaegerStreamingDefinition(namespace string, name string) *v1.Jaeger {
 func jaegerStreamingDefinitionWithTLS(namespace string, name, kafkaUserName string) *v1.Jaeger {
 	volumes := getTLSVolumes(kafkaUserName)
 	volumeMounts := getTLSVolumeMounts()
+	ingressEnabled := true
 
 	kafkaClusterURL := fmt.Sprintf("my-cluster-kafka-bootstrap.%s.svc.cluster.local:9093", kafkaNamespace)
 	j := &v1.Jaeger{
@@ -204,6 +210,10 @@ func jaegerStreamingDefinitionWithTLS(namespace string, name, kafkaUserName stri
 			Namespace: namespace,
 		},
 		Spec: v1.JaegerSpec{
+			Ingress: v1.JaegerIngressSpec{
+				Enabled:  &ingressEnabled,
+				Security: v1.IngressSecurityNoneExplicit,
+			},
 			Strategy: v1.DeploymentStrategyStreaming,
 			Collector: v1.JaegerCollectorSpec{
 				Options: v1.NewOptions(map[string]interface{}{
@@ -242,6 +252,7 @@ func jaegerStreamingDefinitionWithTLS(namespace string, name, kafkaUserName stri
 }
 
 func jaegerAutoProvisionedDefinition(namespace string, name string) *v1.Jaeger {
+	ingressEnabled := true
 	jaegerInstance := &v1.Jaeger{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Jaeger",
@@ -252,6 +263,10 @@ func jaegerAutoProvisionedDefinition(namespace string, name string) *v1.Jaeger {
 			Namespace: namespace,
 		},
 		Spec: v1.JaegerSpec{
+			Ingress: v1.JaegerIngressSpec{
+				Enabled:  &ingressEnabled,
+				Security: v1.IngressSecurityNoneExplicit,
+			},
 			Strategy: v1.DeploymentStrategyStreaming,
 			Storage: v1.JaegerStorageSpec{
 				Type: "elasticsearch",

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -374,20 +374,11 @@ func findRoute(t *testing.T, f *framework.Framework, name string) *osv1.Route {
 	return nil
 }
 
-func getQueryURLAndHTTPClient(jaegerInstanceName, urlPattern string, insecure bool) (string, http.Client) {
-	var url string
-	var httpClient http.Client
-
+func getQueryURL(jaegerInstanceName, urlPattern string) (url string) {
 	if isOpenShift(t) {
 		route := findRoute(t, fw, jaegerInstanceName)
 		require.Len(t, route.Status.Ingress, 1, "Wrong number of ingresses.")
-
 		url = fmt.Sprintf("https://"+urlPattern, route.Spec.Host)
-		// #nosec
-		transport := &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: insecure},
-		}
-		httpClient = http.Client{Timeout: 30 * time.Second, Transport: transport}
 	} else {
 		ingress, err := WaitForIngress(t, fw.KubeClient, namespace, jaegerInstanceName+"-query", retryInterval, timeout)
 		require.NoError(t, err, "Failed waiting for ingress")
@@ -395,9 +386,28 @@ func getQueryURLAndHTTPClient(jaegerInstanceName, urlPattern string, insecure bo
 
 		address := ingress.Status.LoadBalancer.Ingress[0].IP
 		url = fmt.Sprintf("http://"+urlPattern, address)
+	}
+
+	return url
+}
+
+func getHTTPCLient(insecure bool) (httpClient http.Client) {
+	if isOpenShift(t) {
+		transport := &http.Transport{
+			// #nosec  G402: TLS InsecureSkipVerify set true
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: insecure},
+		}
+		httpClient = http.Client{Timeout: 30 * time.Second, Transport: transport}
+	} else {
 		httpClient = http.Client{Timeout: time.Second}
 	}
-	logrus.Infof("Using Query URL [%v]\n", url)
+
+	return httpClient
+}
+
+func getQueryURLAndHTTPClient(jaegerInstanceName, urlPattern string, insecure bool) (string, http.Client) {
+	url := getQueryURL(jaegerInstanceName, urlPattern)
+	httpClient := getHTTPCLient(insecure)
 
 	return url, httpClient
 }

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -139,7 +139,8 @@ func prepare(t *testing.T) (*framework.TestCtx, error) {
 	f := framework.Global
 	// wait for the operator to be ready
 	if !usingOLM {
-		err := e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "jaeger-operator", 1, retryInterval, timeout)
+		// TODO replace 10*time.minute with timeout once #947 is fixed
+		err := e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "jaeger-operator", 1, retryInterval, 10*time.Minute)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
…reliability

Signed-off-by: Kevin Earls <kearls@redhat.com>

We get port forwarding failures regularly when running CI on OpenShift.  This updates some tests to use routes where available instead in order to improve test reliability.