### PR TITLE
Differentiate simple-prod-with-volumes from simple-prod in e2e-tests-examples2

### DIFF
--- a/deploy/examples/simple-prod-with-volumes.yaml
+++ b/deploy/examples/simple-prod-with-volumes.yaml
@@ -2,7 +2,7 @@
 apiVersion: jaegertracing.io/v1
 kind: Jaeger
 metadata:
-  name: simple-prod
+  name: simple-prod-with-volumes
 spec:
   strategy: production
   storage:

--- a/test/e2e/examples2_test.go
+++ b/test/e2e/examples2_test.go
@@ -62,7 +62,7 @@ func (suite *ExamplesTestSuite2) TestWithBadgerAndVolumeExample() {
 
 func (suite *ExamplesTestSuite2) TestSimpleProdWithVolumes() {
 	yamlFileName := "../../deploy/examples/simple-prod-with-volumes.yaml"
-	smokeTestProductionExample("simple-prod", yamlFileName)
+	smokeTestProductionExample("simple-prod-with-volumes", yamlFileName)
 }
 
 func (suite *ExamplesTestSuite2) TestSimpleProdExample() {


### PR DESCRIPTION
Signed-off-by: Eric Wohltman <eric.wohltman@gmail.com>

This PR is to test if differentiating `simple-prod-with-volumes` from `simple-prod` helps when running smoke tests.

This is related to Issue https://github.com/jaegertracing/jaeger-operator/issues/947.