### PR TITLE
Remove unneeded dependency and increase timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ e2e-tests-examples1: prepare-e2e-tests es cassandra deploy-es-operator
 	@STORAGE_NAMESPACE=$(STORAGE_NAMESPACE) KAFKA_NAMESPACE=$(KAFKA_NAMESPACE) go test -tags=examples1 ./test/e2e/... $(TEST_OPTIONS)
 
 .PHONY: e2e-tests-examples2
-e2e-tests-examples2: prepare-e2e-tests es kafka deploy-es-operator
+e2e-tests-examples2: prepare-e2e-tests es kafka
 	@echo Running Example end-to-end tests part 2...
 	@STORAGE_NAMESPACE=$(STORAGE_NAMESPACE) KAFKA_NAMESPACE=$(KAFKA_NAMESPACE) go test -tags=examples2 ./test/e2e/... $(TEST_OPTIONS)
 

--- a/test/e2e/examples1_test.go
+++ b/test/e2e/examples1_test.go
@@ -106,7 +106,7 @@ func (suite *ExamplesTestSuite) TestBusinessApp() {
 	// First deploy a Jaeger instance
 	jaegerInstance := createJaegerInstanceFromFile("simplest", "../../deploy/examples/simplest.yaml")
 	defer undeployJaegerInstance(jaegerInstance)
-	err := WaitForDeployment(t, fw.KubeClient, namespace, "simplest", 1, retryInterval, timeout)
+	err := WaitForDeployment(t, fw.KubeClient, namespace, "simplest", 1, retryInterval, timeout+(1*time.Minute))
 	require.NoError(t, err)
 
 	// Now deploy deploy/examples/business-application-injected-sidecar.yaml

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -93,8 +93,9 @@ func prepare(t *testing.T) (*framework.TestCtx, error) {
 	t.Logf("debug mode: %v", debugMode)
 	ctx := framework.NewTestCtx(t)
 	// Install jaeger-operator unless we've installed it from OperatorHub
+	start := time.Now()
 	if !usingOLM {
-		err := ctx.InitializeClusterResources(&framework.CleanupOptions{TestContext: ctx, Timeout: timeout, RetryInterval: retryInterval})
+		err := ctx.InitializeClusterResources(&framework.CleanupOptions{TestContext: ctx, Timeout: 10 * time.Minute, RetryInterval: retryInterval})
 		if err != nil {
 			t.Errorf("failed to initialize cluster resources: %v", err)
 		}
@@ -103,6 +104,7 @@ func prepare(t *testing.T) (*framework.TestCtx, error) {
 	if err != nil {
 		t.Errorf("failed to get the operator's namespace: %v", err)
 	}
+	logrus.Infof("Using namespace %s", namespace)
 
 	ns, err := framework.Global.KubeClient.CoreV1().Namespaces().Get(namespace, metav1.GetOptions{})
 	if err != nil {
@@ -145,6 +147,7 @@ func prepare(t *testing.T) (*framework.TestCtx, error) {
 			return nil, err
 		}
 	}
+	logrus.Infof("Creation of Jaeger Operator in namespace %s took %v", namespace, time.Since(start))
 
 	return ctx, nil
 }


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com>

This should fix #947 by removing an unneeded dependency in the e2e-tests-examples2 target.  It also adds increases some timeouts to avoid some other intermittent failures we've seen, and adds logging to help better diagnose failures.
