### PR TITLE
Added kafka-provisioning-minimal flag

### DIFF
--- a/pkg/cmd/start/main.go
+++ b/pkg/cmd/start/main.go
@@ -86,6 +86,9 @@ func NewStartCommand() *cobra.Command {
 	cmd.Flags().Bool("tracing-enabled", false, "Whether the Operator should report its own spans to a Jaeger instance")
 	viper.BindPFlag("tracing-enabled", cmd.Flags().Lookup("tracing-enabled"))
 
+	cmd.Flags().Bool("kafka-provisioning-minimal", false, "(unsupported) Whether to provision Kafka clusters with minimal requirements, suitable for demos and tests.")
+	viper.BindPFlag("kafka-provisioning-minimal", cmd.Flags().Lookup("kafka-provisioning-minimal"))
+
 	return cmd
 }
 

--- a/test/operator.yaml
+++ b/test/operator.yaml
@@ -19,7 +19,7 @@ spec:
           ports:
           - containerPort: 60000
             name: metrics
-          args: ["start", "--log-level=debug", "--tracing-enabled=false"]
+          args: ["start", "--log-level=debug", "--tracing-enabled=false", "--kafka-provisioning-minimal=true"]
           imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE


### PR DESCRIPTION
Closes #957.

This flag is used to tell the operator to provision a smaller Kafka cluster, with 1 replica instead of 3, and with 10Gi instead of 100Gi.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>