### PR TITLE
Added TLS configuration for collector in all-in-one

### DIFF
--- a/pkg/config/tls/tls.go
+++ b/pkg/config/tls/tls.go
@@ -27,14 +27,14 @@ func Update(jaeger *v1.Jaeger, commonSpec *v1.JaegerCommonSpec, options *[]strin
 	}
 	volumeMount := corev1.VolumeMount{
 		Name:      configurationVolumeName(jaeger),
-		MountPath: "/etc/config",
+		MountPath: "/etc/tls-config",
 		ReadOnly:  true,
 	}
 	commonSpec.Volumes = append(commonSpec.Volumes, volume)
 	commonSpec.VolumeMounts = append(commonSpec.VolumeMounts, volumeMount)
 	*options = append(*options, "--collector.grpc.tls.enabled=true")
-	*options = append(*options, "--collector.grpc.tls.cert=/etc/config/tls.crt")
-	*options = append(*options, "--collector.grpc.tls.key=/etc/config/tls.key")
+	*options = append(*options, "--collector.grpc.tls.cert=/etc/tls-config/tls.crt")
+	*options = append(*options, "--collector.grpc.tls.key=/etc/tls-config/tls.key")
 }
 
 func configurationVolumeName(jaeger *v1.Jaeger) string {

--- a/pkg/config/tls/tls_test.go
+++ b/pkg/config/tls/tls_test.go
@@ -22,6 +22,6 @@ func TestUpdateWithTLSSecret(t *testing.T) {
 	assert.Len(t, commonSpec.VolumeMounts, 1)
 	assert.Len(t, options, 3)
 	assert.Equal(t, "--collector.grpc.tls.enabled=true", options[0])
-	assert.Equal(t, "--collector.grpc.tls.cert=/etc/config/tls.crt", options[1])
-	assert.Equal(t, "--collector.grpc.tls.key=/etc/config/tls.key", options[2])
+	assert.Equal(t, "--collector.grpc.tls.cert=/etc/tls-config/tls.crt", options[1])
+	assert.Equal(t, "--collector.grpc.tls.key=/etc/tls-config/tls.key", options[2])
 }

--- a/pkg/deployment/all_in_one.go
+++ b/pkg/deployment/all_in_one.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jaegertracing/jaeger-operator/pkg/account"
 	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/config/sampling"
+	"github.com/jaegertracing/jaeger-operator/pkg/config/tls"
 	configmap "github.com/jaegertracing/jaeger-operator/pkg/config/ui"
 	"github.com/jaegertracing/jaeger-operator/pkg/service"
 	"github.com/jaegertracing/jaeger-operator/pkg/storage"
@@ -55,6 +56,7 @@ func (a *AllInOne) Get() *appsv1.Deployment {
 
 	configmap.Update(a.jaeger, commonSpec, &options)
 	sampling.Update(a.jaeger, commonSpec, &options)
+	tls.Update(a.jaeger, commonSpec, &options)
 
 	// ensure we have a consistent order of the arguments
 	// see https://github.com/jaegertracing/jaeger-operator/issues/334

--- a/pkg/deployment/all_in_one.go
+++ b/pkg/deployment/all_in_one.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strconv"
 
+	"github.com/spf13/viper"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,7 +19,6 @@ import (
 	"github.com/jaegertracing/jaeger-operator/pkg/service"
 	"github.com/jaegertracing/jaeger-operator/pkg/storage"
 	"github.com/jaegertracing/jaeger-operator/pkg/util"
-	"github.com/spf13/viper"
 )
 
 // AllInOne builds pods for jaegertracing/all-in-one

--- a/pkg/deployment/all_in_one_test.go
+++ b/pkg/deployment/all_in_one_test.go
@@ -1,7 +1,6 @@
 package deployment
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/spf13/viper"
@@ -276,13 +275,14 @@ func TestAllInOneOrderOfArguments(t *testing.T) {
 	dep := a.Get()
 
 	assert.Len(t, dep.Spec.Template.Spec.Containers, 1)
-	assert.Len(t, dep.Spec.Template.Spec.Containers[0].Args, 4)
-	assert.True(t, strings.HasPrefix(dep.Spec.Template.Spec.Containers[0].Args[0], "--a-option"))
-	assert.True(t, strings.HasPrefix(dep.Spec.Template.Spec.Containers[0].Args[1], "--b-option"))
-	assert.True(t, strings.HasPrefix(dep.Spec.Template.Spec.Containers[0].Args[2], "--c-option"))
+	assert.Len(t, dep.Spec.Template.Spec.Containers[0].Args, 5)
+	assert.NotEmpty(t, util.FindItem("--a-option", dep.Spec.Template.Spec.Containers[0].Args))
+	assert.NotEmpty(t, util.FindItem("--b-option", dep.Spec.Template.Spec.Containers[0].Args))
+	assert.NotEmpty(t, util.FindItem("--c-option", dep.Spec.Template.Spec.Containers[0].Args))
 
 	// the following are added automatically
-	assert.True(t, strings.HasPrefix(dep.Spec.Template.Spec.Containers[0].Args[3], "--sampling.strategies-file"))
+	assert.NotEmpty(t, util.FindItem("--sampling.strategies-file", dep.Spec.Template.Spec.Containers[0].Args))
+	assert.NotEmpty(t, util.FindItem("--reporter.type=grpc", dep.Spec.Template.Spec.Containers[0].Args))
 }
 
 func TestAllInOneArgumentsOpenshiftTLS(t *testing.T) {
@@ -301,10 +301,15 @@ func TestAllInOneArgumentsOpenshiftTLS(t *testing.T) {
 
 	// verify
 	assert.Len(t, dep.Spec.Template.Spec.Containers, 1)
-	assert.Len(t, dep.Spec.Template.Spec.Containers[0].Args, 5)
-	assert.Greater(t, len(util.FindItem("--a-option=a-value", dep.Spec.Template.Spec.Containers[0].Args)), 0)
-	assert.Greater(t, len(util.FindItem("--collector.grpc.tls.enabled=true", dep.Spec.Template.Spec.Containers[0].Args)), 0)
-	assert.Greater(t, len(util.FindItem("--collector.grpc.tls.cert=/etc/tls-config/tls.crt", dep.Spec.Template.Spec.Containers[0].Args)), 0)
-	assert.Greater(t, len(util.FindItem("--collector.grpc.tls.key=/etc/tls-config/tls.key", dep.Spec.Template.Spec.Containers[0].Args)), 0)
-	assert.Greater(t, len(util.FindItem("--sampling.strategies-file", dep.Spec.Template.Spec.Containers[0].Args)), 0)
+	assert.Len(t, dep.Spec.Template.Spec.Containers[0].Args, 9)
+	assert.NotEmpty(t, util.FindItem("--a-option=a-value", dep.Spec.Template.Spec.Containers[0].Args))
+	assert.NotEmpty(t, util.FindItem("--collector.grpc.tls.enabled=true", dep.Spec.Template.Spec.Containers[0].Args))
+	assert.NotEmpty(t, util.FindItem("--collector.grpc.tls.cert=/etc/tls-config/tls.crt", dep.Spec.Template.Spec.Containers[0].Args))
+	assert.NotEmpty(t, util.FindItem("--collector.grpc.tls.key=/etc/tls-config/tls.key", dep.Spec.Template.Spec.Containers[0].Args))
+	assert.NotEmpty(t, util.FindItem("--sampling.strategies-file", dep.Spec.Template.Spec.Containers[0].Args))
+
+	assert.NotEmpty(t, util.FindItem("--reporter.grpc.tls.ca", dep.Spec.Template.Spec.Containers[0].Args))
+	assert.NotEmpty(t, util.FindItem("--reporter.grpc.tls.enabled", dep.Spec.Template.Spec.Containers[0].Args))
+	assert.NotEmpty(t, util.FindItem("--reporter.grpc.tls.server-name", dep.Spec.Template.Spec.Containers[0].Args))
+	assert.Equal(t, "--reporter.type=grpc", util.FindItem("--reporter.type", dep.Spec.Template.Spec.Containers[0].Args))
 }

--- a/pkg/deployment/collector_test.go
+++ b/pkg/deployment/collector_test.go
@@ -506,7 +506,7 @@ func TestCollectoArgumentsOpenshiftTLS(t *testing.T) {
 
 	// the following are added automatically
 	assert.Greater(t, len(util.FindItem("--collector.grpc.tls.enabled=true", dep.Spec.Template.Spec.Containers[0].Args)), 0)
-	assert.Greater(t, len(util.FindItem("--collector.grpc.tls.cert=/etc/config/tls.crt", dep.Spec.Template.Spec.Containers[0].Args)), 0)
-	assert.Greater(t, len(util.FindItem("--collector.grpc.tls.key=/etc/config/tls.key", dep.Spec.Template.Spec.Containers[0].Args)), 0)
+	assert.Greater(t, len(util.FindItem("--collector.grpc.tls.cert=/etc/tls-config/tls.crt", dep.Spec.Template.Spec.Containers[0].Args)), 0)
+	assert.Greater(t, len(util.FindItem("--collector.grpc.tls.key=/etc/tls-config/tls.key", dep.Spec.Template.Spec.Containers[0].Args)), 0)
 	assert.Greater(t, len(util.FindItem("--sampling.strategies-file", dep.Spec.Template.Spec.Containers[0].Args)), 0)
 }

--- a/pkg/inject/sidecar.go
+++ b/pkg/inject/sidecar.go
@@ -137,7 +137,7 @@ func container(jaeger *v1.Jaeger, dep *appsv1.Deployment) corev1.Container {
 
 	// Enable tls by default for openshift platform
 	if viper.GetString("platform") == v1.FlagPlatformOpenShift {
-		if len(util.FindItem("--reporter.type=grpc", args)) > 0 && len(util.FindItem("--reporter.grpc.tls=true", args)) == 0 {
+		if len(util.FindItem("--reporter.type=grpc", args)) > 0 && len(util.FindItem("--reporter.grpc.tls.enabled=true", args)) == 0 {
 			args = append(args, "--reporter.grpc.tls.enabled=true")
 			args = append(args, "--reporter.grpc.tls.ca=/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt")
 			args = append(args, fmt.Sprintf("--reporter.grpc.tls.server-name=%s.%s.svc.cluster.local", service.GetNameForHeadlessCollectorService(jaeger), jaeger.Namespace))

--- a/pkg/service/collector.go
+++ b/pkg/service/collector.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -20,7 +22,8 @@ func headlessCollectorService(jaeger *v1.Jaeger, selector map[string]string) *co
 	svc := collectorService(jaeger, selector)
 	svc.Name = GetNameForHeadlessCollectorService(jaeger)
 	svc.Annotations = map[string]string{
-		"prometheus.io/scrape": "false",
+		"prometheus.io/scrape":                               "false",
+		"service.beta.openshift.io/serving-cert-secret-name": fmt.Sprintf("%s-tls", svc.Name),
 	}
 	svc.Spec.ClusterIP = "None"
 	return svc

--- a/pkg/strategy/production.go
+++ b/pkg/strategy/production.go
@@ -2,13 +2,11 @@ package strategy
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/spf13/viper"
-	"go.opentelemetry.io/otel/api/core"
 	"go.opentelemetry.io/otel/api/key"
 	"go.opentelemetry.io/otel/global"
 	appsv1 "k8s.io/api/apps/v1"
@@ -24,7 +22,6 @@ import (
 	"github.com/jaegertracing/jaeger-operator/pkg/ingress"
 	"github.com/jaegertracing/jaeger-operator/pkg/inject"
 	"github.com/jaegertracing/jaeger-operator/pkg/route"
-	"github.com/jaegertracing/jaeger-operator/pkg/service"
 	"github.com/jaegertracing/jaeger-operator/pkg/storage"
 )
 
@@ -74,21 +71,6 @@ func newProductionStrategy(ctx context.Context, jaeger *v1.Jaeger) S {
 	if viper.GetString("platform") == v1.FlagPlatformOpenShift {
 		if q := route.NewQueryRoute(jaeger).Get(); nil != q {
 			c.routes = append(c.routes, *q)
-		}
-
-		// For openshift platform, we want the clusterIP service to be annotated
-		// with the cert secret-name tag
-		for k := range c.services {
-			span.AddEvent(ctx, "Checking service", core.KeyValue{Key: "Servicename", Value: core.String(c.services[k].Name)})
-			if c.services[k].Name == service.GetNameForHeadlessCollectorService(jaeger) {
-				if c.services[k].Annotations == nil {
-					c.services[k].Annotations = map[string]string{
-						"service.beta.openshift.io/serving-cert-secret-name": fmt.Sprintf("%s-tls", c.services[k].Name),
-					}
-				} else {
-					c.services[k].Annotations["service.beta.openshift.io/serving-cert-secret-name"] = fmt.Sprintf("%s-tls", c.services[k].Name)
-				}
-			}
 		}
 	} else {
 		span.SetAttribute(key.String("Platform", v1.FlagPlatformKubernetes))


### PR DESCRIPTION
Fixes #959 by adding `tls.Update` in the all-in-one strategy as well. As the volume `/etc/config` conflicts with the `ui` configuration, the path has been changed to `/etc/tls-config` as well.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>