### PR TITLE
Restore two minute timeout

### DIFF
--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -38,7 +38,7 @@ import (
 
 var (
 	retryInterval        = time.Second * 5
-	timeout              = time.Minute * 5
+	timeout              = time.Minute * 2
 	storageNamespace     = os.Getenv("STORAGE_NAMESPACE")
 	kafkaNamespace       = os.Getenv("KAFKA_NAMESPACE")
 	debugMode            = getBoolEnv("DEBUG_MODE", false)

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -38,7 +38,7 @@ import (
 
 var (
 	retryInterval        = time.Second * 5
-	timeout              = time.Minute * 2
+	timeout              = time.Duration(getIntEnv("TEST_TIMEOUT", 2)) * time.Minute
 	storageNamespace     = os.Getenv("STORAGE_NAMESPACE")
 	kafkaNamespace       = os.Getenv("KAFKA_NAMESPACE")
 	debugMode            = getBoolEnv("DEBUG_MODE", false)
@@ -60,6 +60,18 @@ func getBoolEnv(key string, defaultValue bool) bool {
 			logrus.Warnf("Error [%v] received converting environment variable [%s] using [%v]", err, key, boolValue)
 		}
 		return boolValue
+	}
+	return defaultValue
+}
+
+func getIntEnv(key string, defaultValue int) int {
+	if value, ok := os.LookupEnv(key); ok {
+		intValue, err := strconv.Atoi(value)
+		if err != nil {
+			logrus.Warnf("Error [%v] received converting environment variable [%s] using [%v]", err, key, value)
+		}
+		logrus.Infof("Using test timeout of %d minute(s)", intValue)
+		return intValue
 	}
 	return defaultValue
 }

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -70,7 +70,6 @@ func getIntEnv(key string, defaultValue int) int {
 		if err != nil {
 			logrus.Warnf("Error [%v] received converting environment variable [%s] using [%v]", err, key, value)
 		}
-		logrus.Infof("Using test timeout of %d minute(s)", intValue)
 		return intValue
 	}
 	return defaultValue


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com>

Five minutes is not needed for timeouts.  If two minutes is not adequate for something we should override the default for that test only.  