### PR TITLE
Verify namespace when finding routes

### DIFF
--- a/test/e2e/elasticsearch_token_propagation_test.go
+++ b/test/e2e/elasticsearch_token_propagation_test.go
@@ -202,7 +202,7 @@ func (suite *TokenTestSuite) deployJaegerWithPropagationEnabled() {
 	err = e2eutil.WaitForDeployment(t, fw.KubeClient, namespace, queryName, 1, retryInterval, timeout)
 	require.NoError(t, err, "Error waiting for query deployment")
 
-	route := findRoute(t, fw, name)
+	route := findRoute(t, fw, name, namespace)
 
 	suite.host = route.Spec.Host
 	suite.queryServiceEndPoint = fmt.Sprintf("https://%s/api/traces?service=%s", suite.host, testServiceName)

--- a/test/e2e/misc_test.go
+++ b/test/e2e/misc_test.go
@@ -14,8 +14,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/util"
-
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
 	log "github.com/sirupsen/logrus"
@@ -26,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	"github.com/jaegertracing/jaeger-operator/pkg/util"
 )
 
 type MiscTestSuite struct {


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com>

This is needed to run tests in parallel, as it can return the wrong route if there are multiple jaeger instances with the same name.  (For instance "simple-prod", which is used by multiple tests"
