### PR TITLE
Change 'make generate' to write only a single CRD

### DIFF
--- a/.ci/generate.sh
+++ b/.ci/generate.sh
@@ -35,6 +35,15 @@ fi
 # move the generated CRD to the same location the operator-sdk places
 mv deploy/crds/jaegertracing.io_jaegers.yaml deploy/crds/jaegertracing.io_jaegers_crd.yaml
 
+# the controller-gen will generate a list of CRDs, but the operator-sdk tooling expects
+# a single item
+# the proper solutions are, in order:
+# 1) find a controller-gen switch that makes it write only one CRD. Such a switch doesn't exist yet: https://git.io/JvX5D
+# 2) use a YAML command line tool to get the first item from the file
+# 3) chop off the first two lines of the file
+# the last option is the easiest to implement for now, also because `tail` is found everywhere
+echo "$(tail -n +3 deploy/crds/jaegertracing.io_jaegers_crd.yaml)" > deploy/crds/jaegertracing.io_jaegers_crd.yaml
+
 # generate the schema validation (openapi) stubs
 ${OPENAPIGEN} --logtostderr=true -o "" -i ./pkg/apis/jaegertracing/v1 -O zz_generated.openapi -p ./pkg/apis/jaegertracing/v1 -h /dev/null -r "-"
 RT=$?

--- a/.ci/generate.sh
+++ b/.ci/generate.sh
@@ -44,6 +44,11 @@ mv deploy/crds/jaegertracing.io_jaegers.yaml deploy/crds/jaegertracing.io_jaeger
 # the last option is the easiest to implement for now, also because `tail` is found everywhere
 echo "$(tail -n +3 deploy/crds/jaegertracing.io_jaegers_crd.yaml)" > deploy/crds/jaegertracing.io_jaegers_crd.yaml
 
+if ! [[ "$(head -n 1 deploy/crds/jaegertracing.io_jaegers_crd.yaml)" == "apiVersion"* ]]; then
+    echo "The generated CRD doesn't seem valid. Make sure the controller-gen is generating the CRD in the expected format. Aborting."
+    exit 1
+fi
+
 # generate the schema validation (openapi) stubs
 ${OPENAPIGEN} --logtostderr=true -o "" -i ./pkg/apis/jaegertracing/v1 -O zz_generated.openapi -p ./pkg/apis/jaegertracing/v1 -h /dev/null -r "-"
 RT=$?

--- a/deploy/crds/jaegertracing.io_jaegers_crd.yaml
+++ b/deploy/crds/jaegertracing.io_jaegers_crd.yaml
@@ -1,5 +1,3 @@
-
----
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:


### PR DESCRIPTION
Fixes #977 by using `tail` to chop off the first two lines of the CRD file.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>