### PR TITLE
Prevent operator from overriding .Spec.Replicas

### DIFF
--- a/pkg/deployment/collector.go
+++ b/pkg/deployment/collector.go
@@ -88,12 +88,6 @@ func (c *Collector) Get() *appsv1.Deployment {
 	// see https://github.com/jaegertracing/jaeger-operator/issues/334
 	sort.Strings(options)
 
-	replicaSize := c.jaeger.Spec.Collector.Replicas
-	if replicaSize == nil || *replicaSize < 0 {
-		s := int32(1)
-		replicaSize = &s
-	}
-
 	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apps/v1",
@@ -115,7 +109,7 @@ func (c *Collector) Get() *appsv1.Deployment {
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: replicaSize,
+			Replicas: c.jaeger.Spec.Collector.Replicas,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: labels,
 			},

--- a/pkg/deployment/collector_test.go
+++ b/pkg/deployment/collector_test.go
@@ -27,7 +27,7 @@ func TestNegativeReplicas(t *testing.T) {
 
 	collector := NewCollector(jaeger)
 	dep := collector.Get()
-	assert.Equal(t, int32(1), *dep.Spec.Replicas)
+	assert.Equal(t, size, *dep.Spec.Replicas)
 }
 
 func TestDefaultSize(t *testing.T) {
@@ -35,7 +35,7 @@ func TestDefaultSize(t *testing.T) {
 
 	collector := NewCollector(jaeger)
 	dep := collector.Get()
-	assert.Equal(t, int32(1), *dep.Spec.Replicas)
+	assert.Nil(t, dep.Spec.Replicas) // we let Kubernetes define the default
 }
 
 func TestReplicaSize(t *testing.T) {
@@ -486,6 +486,21 @@ func TestAutoscalersDisabledByExplicitOption(t *testing.T) {
 
 	// verify
 	assert.Len(t, a, 0)
+}
+
+func TestAutoscalersSetMaxReplicas(t *testing.T) {
+	// prepare
+	maxReplicas := int32(2)
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
+	jaeger.Spec.Collector.MaxReplicas = &maxReplicas
+	c := NewCollector(jaeger)
+
+	// test
+	a := c.Autoscalers()
+
+	// verify
+	assert.Len(t, a, 1)
+	assert.Equal(t, maxReplicas, a[0].Spec.MaxReplicas)
 }
 
 func TestCollectoArgumentsOpenshiftTLS(t *testing.T) {

--- a/pkg/deployment/ingester.go
+++ b/pkg/deployment/ingester.go
@@ -71,12 +71,6 @@ func (i *Ingester) Get() *appsv1.Deployment {
 	// see https://github.com/jaegertracing/jaeger-operator/issues/334
 	sort.Strings(options)
 
-	replicaSize := i.jaeger.Spec.Ingester.Replicas
-	if replicaSize == nil || *replicaSize < 0 {
-		s := int32(1)
-		replicaSize = &s
-	}
-
 	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apps/v1",
@@ -97,7 +91,7 @@ func (i *Ingester) Get() *appsv1.Deployment {
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: replicaSize,
+			Replicas: i.jaeger.Spec.Ingester.Replicas,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: labels,
 			},

--- a/pkg/deployment/ingester_test.go
+++ b/pkg/deployment/ingester_test.go
@@ -33,7 +33,7 @@ func TestIngesterNegativeReplicas(t *testing.T) {
 
 	ingester := NewIngester(jaeger)
 	dep := ingester.Get()
-	assert.Equal(t, int32(1), *dep.Spec.Replicas)
+	assert.Equal(t, size, *dep.Spec.Replicas)
 }
 
 func TestIngesterDefaultSize(t *testing.T) {
@@ -41,7 +41,7 @@ func TestIngesterDefaultSize(t *testing.T) {
 
 	ingester := NewIngester(jaeger)
 	dep := ingester.Get()
-	assert.Equal(t, int32(1), *dep.Spec.Replicas)
+	assert.Nil(t, dep.Spec.Replicas) // we let Kubernetes define the default
 }
 
 func TestIngesterReplicaSize(t *testing.T) {

--- a/pkg/deployment/query.go
+++ b/pkg/deployment/query.go
@@ -76,12 +76,6 @@ func (q *Query) Get() *appsv1.Deployment {
 	// see https://github.com/jaegertracing/jaeger-operator/issues/334
 	sort.Strings(options)
 
-	replicaSize := q.jaeger.Spec.Query.Replicas
-	if replicaSize == nil || *replicaSize < 0 {
-		s := int32(1)
-		replicaSize = &s
-	}
-
 	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apps/v1",
@@ -103,7 +97,7 @@ func (q *Query) Get() *appsv1.Deployment {
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: replicaSize,
+			Replicas: q.jaeger.Spec.Query.Replicas,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: labels,
 			},

--- a/pkg/deployment/query_test.go
+++ b/pkg/deployment/query_test.go
@@ -25,7 +25,7 @@ func TestQueryNegativeReplicas(t *testing.T) {
 
 	query := NewQuery(jaeger)
 	dep := query.Get()
-	assert.Equal(t, int32(1), *dep.Spec.Replicas)
+	assert.Equal(t, size, *dep.Spec.Replicas)
 }
 
 func TestQueryDefaultSize(t *testing.T) {
@@ -33,7 +33,7 @@ func TestQueryDefaultSize(t *testing.T) {
 
 	query := NewQuery(jaeger)
 	dep := query.Get()
-	assert.Equal(t, int32(1), *dep.Spec.Replicas)
+	assert.Nil(t, dep.Spec.Replicas) // we let Kubernetes define the default
 }
 
 func TestQueryReplicaSize(t *testing.T) {

--- a/pkg/inventory/deployment.go
+++ b/pkg/inventory/deployment.go
@@ -27,6 +27,13 @@ func ForDeployments(existing []appsv1.Deployment, desired []appsv1.Deployment) D
 			tp := t.DeepCopy()
 			util.InitObjectMeta(tp)
 
+			// if we have a nil value for the replicas in the desired deployment
+			// but we have a specific value in the current deployment, we override the desired with the current
+			// as this might have been written by an HPA
+			if tp.Spec.Replicas != nil && v.Spec.Replicas == nil {
+				v.Spec.Replicas = tp.Spec.Replicas
+			}
+
 			// we can't blindly DeepCopyInto, so, we select what we bring from the new to the old object
 			tp.Spec = v.Spec
 			tp.Spec = inject.PropagateOAuthCookieSecret(t.Spec, v.Spec)

--- a/pkg/inventory/deployment_test.go
+++ b/pkg/inventory/deployment_test.go
@@ -106,3 +106,37 @@ func TestDeploymentInventoryNewWithSameNameAsExisting(t *testing.T) {
 
 	assert.Len(t, inv.Delete, 0)
 }
+
+func TestDeploymentKeepReplicasWhenDesiredIsNil(t *testing.T) {
+	replicas := int32(2)
+	existing := []appsv1.Deployment{{
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+		},
+	}}
+	desired := []appsv1.Deployment{{}}
+
+	inv := ForDeployments(existing, desired)
+	assert.Len(t, inv.Update, 1)
+	assert.Equal(t, replicas, *inv.Update[0].Spec.Replicas)
+}
+
+func TestDeploymentSetReplicasWhenDesiredIsNotNil(t *testing.T) {
+	replicas := int32(2)
+	existing := []appsv1.Deployment{{
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+		},
+	}}
+
+	desiredReplicas := int32(1)
+	desired := []appsv1.Deployment{{
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &desiredReplicas,
+		},
+	}}
+
+	inv := ForDeployments(existing, desired)
+	assert.Len(t, inv.Update, 1)
+	assert.Equal(t, desiredReplicas, *inv.Update[0].Spec.Replicas)
+}


### PR DESCRIPTION
Fixes #963 by using the current `.Spec.Replicas` from the `Deployment` if the desired number of replicas isn't explicitly set.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>