### PR TITLE
Pass namespace when searching for insecure endpoint

### DIFF
--- a/test/e2e/smoketest.go
+++ b/test/e2e/smoketest.go
@@ -32,7 +32,7 @@ func AllInOneSmokeTest(jaegerInstanceName string) {
 
 	// Use ingress for k8s or on OpenShift if we have an insecure route
 	var apiTracesEndpoint string
-	insecureEndpoint := hasInsecureEndpoint(jaegerInstanceName)
+	insecureEndpoint := hasInsecureEndpoint(jaegerInstanceName, namespace)
 	if insecureEndpoint {
 		apiTracesEndpoint = getQueryURL(jaegerInstanceName, "%s/api/traces")
 	} else {
@@ -60,7 +60,7 @@ func productionSmokeTest(jaegerInstanceName, smokeTestNamespace string) {
 
 	// Use ingress for k8s or on OpenShift if we have an insecure route
 	var apiTracesEndpoint string
-	insecureEndpoint := hasInsecureEndpoint(jaegerInstanceName)
+	insecureEndpoint := hasInsecureEndpoint(jaegerInstanceName, smokeTestNamespace)
 	if insecureEndpoint {
 		apiTracesEndpoint = getQueryURL(jaegerInstanceName, "%s/api/traces")
 	} else {
@@ -86,12 +86,12 @@ func productionSmokeTest(jaegerInstanceName, smokeTestNamespace string) {
 	executeSmokeTest(apiTracesEndpoint, collectorEndpoint, insecureEndpoint)
 }
 
-func hasInsecureEndpoint(jaegerInstanceName string) bool {
+func hasInsecureEndpoint(jaegerInstanceName, jaegerInstanceNamespace string) bool {
 	if !isOpenShift(t) {
 		return true
 	}
 
-	jaeger := getJaegerInstance(jaegerInstanceName, namespace)
+	jaeger := getJaegerInstance(jaegerInstanceName, jaegerInstanceNamespace)
 	if jaeger.Spec.Ingress.Security == v1.IngressSecurityNoneExplicit || jaeger.Spec.Ingress.Security == v1.IngressSecurityNone {
 		return true
 	}

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -259,9 +259,9 @@ func undeployJaegerInstance(jaeger *v1.Jaeger) bool {
 	return true
 }
 
-func getJaegerInstance(name, jaegerInstanceNamespace string) *v1.Jaeger {
+func getJaegerInstance(name, namespace string) *v1.Jaeger {
 	jaegerInstance := &v1.Jaeger{}
-	key := types.NamespacedName{Name: name, Namespace: jaegerInstanceNamespace}
+	key := types.NamespacedName{Name: name, Namespace: namespace}
 	err := fw.Client.Get(goctx.Background(), key, jaegerInstance)
 	require.NoError(t, err)
 	return jaegerInstance

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -259,9 +259,9 @@ func undeployJaegerInstance(jaeger *v1.Jaeger) bool {
 	return true
 }
 
-func getJaegerInstance(name, namespace string) *v1.Jaeger {
+func getJaegerInstance(name, jaegerInstanceNamespace string) *v1.Jaeger {
 	jaegerInstance := &v1.Jaeger{}
-	key := types.NamespacedName{Name: name, Namespace: namespace}
+	key := types.NamespacedName{Name: name, Namespace: jaegerInstanceNamespace}
 	err := fw.Client.Get(goctx.Background(), key, jaegerInstance)
 	require.NoError(t, err)
 	return jaegerInstance


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com>

This is needed for the streaming_test/TestStreamingWithTLS test, as that deploys its jaeger instance to the kafka namespace rather than the test specific namespace.
