### PR TITLE
Restored the displayName in the CSV

### DIFF
--- a/deploy/olm-catalog/jaeger-operator/1.17.1/jaeger-operator.v1.17.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/jaeger-operator/1.17.1/jaeger-operator.v1.17.1.clusterserviceversion.yaml
@@ -77,6 +77,7 @@ spec:
   customresourcedefinitions:
     owned:
     - description: Jaeger is the Schema for the jaegers API
+      displayName: Jaeger
       kind: Jaeger
       name: jaegers.jaegertracing.io
       version: v1


### PR DESCRIPTION
For some reason, the generated CSV for 1.17.1 is missing the `displayName`. When installing a bundle from the current master, the operator fails to install because of the missing field.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>