### PR TITLE
Change Ubuntu and Minikube versions to fix CI builds

### DIFF
--- a/.ci/start-minikube.sh
+++ b/.ci/start-minikube.sh
@@ -40,24 +40,12 @@ minikube update-context
 # waiting for node(s) to be ready
 JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
 
-# waiting for kube-addon-manager to be ready
-#JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl -n kube-system get pods -lcomponent=kube-addon-manager -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1;echo "waiting for kube-addon-manager to be available"; kubectl get pods --all-namespaces; done
-#kubectl wait --for=condition=Ready pod/kube-addon-manager-minikube  --namespace kube-system --timeout=60s || true
-
-kubectl get all --namespace kube-system
-
-# Get the log from one of the dns pods
-export ONEDNSPOD=$(kubectl --namespace kube-system get pods -lk8s-app=kube-dns | grep coredns | head -1 | awk '{print $1}')
-kubectl wait --for=condition=Ready pod/${ONEDNSPOD} --namespace kube-system --timeout=60s || true
-kubectl logs --namespace kube-system $ONEDNSPOD
-
 # waiting for kube-dns to be ready
-#JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl -n kube-system get pods -lk8s-app=kube-dns -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1;echo "waiting for kube-dns to be available"; kubectl get pods --all-namespaces; done
-
+export COREDNSPODS=$(kubectl --namespace kube-system get pods -lk8s-app=kube-dns | grep coredns | awk '{print $1}')
+for POD in ${COREDNSPODS}
+do
+    kubectl wait --for=condition=Ready pod/${POD}  --namespace kube-system --timeout=60s
+done
 sudo ${MINIKUBE} addons enable ingress
 
 eval $(minikube docker-env)
-
-kubectl get namespaces
-kubectl get all --namespace default
-kubectl get all --namespace kube-system

--- a/.ci/start-minikube.sh
+++ b/.ci/start-minikube.sh
@@ -15,8 +15,8 @@ set -x
 # socat is needed for port forwarding
 sudo apt-get update && sudo apt-get install socat
 
-export MINIKUBE_VERSION=v1.3.1
-export KUBERNETES_VERSION=v1.15.2
+export MINIKUBE_VERSION=v1.5.2
+export KUBERNETES_VERSION=v1.16.2
 
 MINIKUBE=$(which minikube) # it's outside of the regular PATH, so, need the full path when calling with sudo
 

--- a/.ci/start-minikube.sh
+++ b/.ci/start-minikube.sh
@@ -15,8 +15,8 @@ set -x
 # socat is needed for port forwarding
 sudo apt-get update && sudo apt-get install socat
 
-export MINIKUBE_VERSION=v1.0.0
-export KUBERNETES_VERSION=v1.14.0
+export MINIKUBE_VERSION=v1.3.1
+export KUBERNETES_VERSION=v1.15.2
 
 MINIKUBE=$(which minikube) # it's outside of the regular PATH, so, need the full path when calling with sudo
 
@@ -41,8 +41,8 @@ minikube update-context
 JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
 
 # waiting for kube-addon-manager to be ready
-JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl -n kube-system get pods -lcomponent=kube-addon-manager -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1;echo "waiting for kube-addon-manager to be available"; kubectl get pods --all-namespaces; done
-
+#JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl -n kube-system get pods -lcomponent=kube-addon-manager -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1;echo "waiting for kube-addon-manager to be available"; kubectl get pods --all-namespaces; done
+kubectl wait --for=condition=Ready pod/kube-addon-manager-minikube  --namespace kube-system --timeout=60s
 
 # Get the log from one of the dns pods
 export ONEDNSPOD=$(kubectl --namespace kube-system get pods -lk8s-app=kube-dns | grep coredns | head -1 | awk '{print $1}')

--- a/.ci/start-minikube.sh
+++ b/.ci/start-minikube.sh
@@ -15,8 +15,8 @@ set -x
 # socat is needed for port forwarding
 sudo apt-get update && sudo apt-get install socat
 
-export MINIKUBE_VERSION=v1.5.2
-export KUBERNETES_VERSION=v1.16.2
+export MINIKUBE_VERSION=v1.0.0
+export KUBERNETES_VERSION=v1.14.0
 
 MINIKUBE=$(which minikube) # it's outside of the regular PATH, so, need the full path when calling with sudo
 

--- a/.ci/start-minikube.sh
+++ b/.ci/start-minikube.sh
@@ -42,7 +42,9 @@ JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.ty
 
 # waiting for kube-addon-manager to be ready
 #JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl -n kube-system get pods -lcomponent=kube-addon-manager -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1;echo "waiting for kube-addon-manager to be available"; kubectl get pods --all-namespaces; done
-kubectl wait --for=condition=Ready pod/kube-addon-manager-minikube  --namespace kube-system --timeout=60s
+#kubectl wait --for=condition=Ready pod/kube-addon-manager-minikube  --namespace kube-system --timeout=60s || true
+
+kubectl get all --namespace kube-system
 
 # Get the log from one of the dns pods
 export ONEDNSPOD=$(kubectl --namespace kube-system get pods -lk8s-app=kube-dns | grep coredns | head -1 | awk '{print $1}')
@@ -55,3 +57,7 @@ kubectl logs --namespace kube-system $ONEDNSPOD
 sudo ${MINIKUBE} addons enable ingress
 
 eval $(minikube docker-env)
+
+kubectl get namespaces
+kubectl get all --namespace default
+kubectl get all --namespace kube-system

--- a/.github/workflows/e2e-kubernetes.yaml
+++ b/.github/workflows/e2e-kubernetes.yaml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   end-to-end:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-xenial
     strategy:
       matrix:
         TEST_GROUP: [es]
@@ -12,8 +12,8 @@ jobs:
       with:
         go-version: '1.13.5'
     - uses: jpkrohling/setup-minikube@v1-release
-      with:
-        minikube-version: v1.5.2
+      #with:
+      #  minikube-version: v1.5.2
     - uses: jpkrohling/setup-kubectl@v1-release
     - uses: jpkrohling/setup-operator-sdk@v1-release
       with:

--- a/.github/workflows/e2e-kubernetes.yaml
+++ b/.github/workflows/e2e-kubernetes.yaml
@@ -10,10 +10,10 @@ jobs:
     steps:
     - uses: actions/setup-go@v1
       with:
-        go-version: '1.13.3'
+        go-version: '1.13.5'
     - uses: jpkrohling/setup-minikube@v1-release
       with:
-        minikube-version: v1.6.2
+        minikube-version: v1.3.1
     - uses: jpkrohling/setup-kubectl@v1-release
     - uses: jpkrohling/setup-operator-sdk@v1-release
       with:

--- a/.github/workflows/e2e-kubernetes.yaml
+++ b/.github/workflows/e2e-kubernetes.yaml
@@ -13,7 +13,7 @@ jobs:
         go-version: '1.13.5'
     - uses: jpkrohling/setup-minikube@v1-release
       with:
-        minikube-version: v1.3.1
+        minikube-version: v1.5.2
     - uses: jpkrohling/setup-kubectl@v1-release
     - uses: jpkrohling/setup-operator-sdk@v1-release
       with:

--- a/.github/workflows/e2e-kubernetes.yaml
+++ b/.github/workflows/e2e-kubernetes.yaml
@@ -6,12 +6,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        TEST_GROUP: [smoke, es, cassandra, streaming, examples1, examples2]
+        TEST_GROUP: [es]
     steps:
     - uses: actions/setup-go@v1
       with:
         go-version: '1.13.3'
     - uses: jpkrohling/setup-minikube@v1-release
+      with:
+        minikube-version: v1.6.2
     - uses: jpkrohling/setup-kubectl@v1-release
     - uses: jpkrohling/setup-operator-sdk@v1-release
       with:

--- a/.github/workflows/e2e-kubernetes.yaml
+++ b/.github/workflows/e2e-kubernetes.yaml
@@ -3,9 +3,9 @@ on: [push, pull_request]
 
 jobs:
   end-to-end:
-    runs-on: ubuntu-xenial
+    runs-on: ubuntu-16.04
     strategy:
-      matrix:
+      matrix: 
         TEST_GROUP: [es]
     steps:
     - uses: actions/setup-go@v1

--- a/.github/workflows/e2e-kubernetes.yaml
+++ b/.github/workflows/e2e-kubernetes.yaml
@@ -5,15 +5,15 @@ jobs:
   end-to-end:
     runs-on: ubuntu-16.04
     strategy:
-      matrix: 
+      matrix:
         TEST_GROUP: [es]
     steps:
     - uses: actions/setup-go@v1
       with:
         go-version: '1.13.5'
     - uses: jpkrohling/setup-minikube@v1-release
-      #with:
-      #  minikube-version: v1.5.2
+      with:
+        minikube-version: v1.3.1
     - uses: jpkrohling/setup-kubectl@v1-release
     - uses: jpkrohling/setup-operator-sdk@v1-release
       with:

--- a/.github/workflows/e2e-kubernetes.yaml
+++ b/.github/workflows/e2e-kubernetes.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-16.04
     strategy:
       matrix:
-        TEST_GROUP: [es]
+        TEST_GROUP: [smoke, es, cassandra, streaming, examples1, examples2]
     steps:
     - uses: actions/setup-go@v1
       with:


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com>

I have downgraded the CI builds to use Ubuntu version 16.04 instead of 18.04 because of https://github.com/kubernetes/kubernetes/issues/66067.  (Getting minikube to work on 18.04 will require some DNS configuration changes which I don't yet understand.)  

I have also taken this opportunity to update to the most recent version of minikube that I can get to run on Ubuntu 16.04, as we were previously using 1.3.1, which is quite old.

When possible we should got back to using ubuntu-latest and a newer version of minikube.  I have opened issue #1021 to track this.

