### PR TITLE
Disable Elasticsearch feature to monitor available disk space 

### DIFF
--- a/test/elasticsearch.yml
+++ b/test/elasticsearch.yml
@@ -26,6 +26,8 @@ spec:
               value: "0.0.0.0"
             - name: "transport.host"
               value: "127.0.0.1"
+            - name: "cluster.routing.allocation.disk.threshold_enabled"
+              value: "false"
           volumeMounts:
             - name: data
               mountPath: /usr/share/elasticsearch/data


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com>

This is to avoid test failures when disk usage goes above 95% on the images we are using for tests.