### PR TITLE
Do not set the default index cleaner, rollover and dependencies image in CR

### DIFF
--- a/pkg/cronjob/es_index_cleaner.go
+++ b/pkg/cronjob/es_index_cleaner.go
@@ -70,7 +70,7 @@ func CreateEsIndexCleaner(jaeger *v1.Jaeger) *batchv1beta1.CronJob {
 							Containers: []corev1.Container{
 								{
 									Name:         util.Truncate(name, 63),
-									Image:        jaeger.Spec.Storage.EsIndexCleaner.Image,
+									Image:        util.ImageName(jaeger.Spec.Storage.EsIndexCleaner.Image, "jaeger-es-index-cleaner-image"),
 									Args:         []string{strconv.Itoa(*jaeger.Spec.Storage.EsIndexCleaner.NumberOfDays), esUrls},
 									Env:          util.RemoveEmptyVars(envs),
 									EnvFrom:      envFromSource,

--- a/pkg/cronjob/es_index_cleaner_test.go
+++ b/pkg/cronjob/es_index_cleaner_test.go
@@ -3,6 +3,7 @@ package cronjob
 import (
 	"testing"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -188,4 +189,31 @@ func TestEsIndexCleanerResources(t *testing.T) {
 		assert.Equal(t, test.expected, cjob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Resources)
 
 	}
+}
+
+func TestDefaultEsIndexCleanerImage(t *testing.T) {
+	viper.SetDefault("jaeger-es-index-cleaner-image", "jaegertracing/jaeger-es-index-cleaner")
+
+	days := 0
+
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestDefaultEsIndexCleanerImage"})
+	jaeger.Spec.Storage.EsIndexCleaner.NumberOfDays = &days
+
+	cjob := CreateEsIndexCleaner(jaeger)
+	assert.Empty(t, jaeger.Spec.Storage.EsIndexCleaner.Image)
+	assert.Equal(t, "jaegertracing/jaeger-es-index-cleaner:0.0.0", cjob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Image)
+}
+
+func TestCustomEsIndexCleanerImage(t *testing.T) {
+	viper.Set("jaeger-es-index-cleaner-image", "org/custom-es-index-cleaner-image")
+	defer viper.Reset()
+
+	days := 0
+
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestDefaultEsIndexCleanerImage"})
+	jaeger.Spec.Storage.EsIndexCleaner.NumberOfDays = &days
+
+	cjob := CreateEsIndexCleaner(jaeger)
+	assert.Empty(t, jaeger.Spec.Storage.EsIndexCleaner.Image)
+	assert.Equal(t, "org/custom-es-index-cleaner-image:0.0.0", cjob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Image)
 }

--- a/pkg/cronjob/es_rollover.go
+++ b/pkg/cronjob/es_rollover.go
@@ -85,7 +85,7 @@ func createTemplate(name, action string, jaeger *v1.Jaeger, envs []corev1.EnvVar
 			Containers: []corev1.Container{
 				{
 					Name:         name,
-					Image:        jaeger.Spec.Storage.EsRollover.Image,
+					Image:        util.ImageName(jaeger.Spec.Storage.EsRollover.Image, "jaeger-es-rollover-image"),
 					Args:         []string{action, util.GetEsHostname(jaeger.Spec.Storage.Options.Map())},
 					Env:          util.RemoveEmptyVars(envs),
 					EnvFrom:      envFromSource,

--- a/pkg/cronjob/es_rollover_test.go
+++ b/pkg/cronjob/es_rollover_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -323,4 +324,25 @@ func TestEsRolloverLookbackResources(t *testing.T) {
 		assert.Equal(t, test.expected, cjob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Resources)
 
 	}
+}
+
+func TestDefaultEsRolloverImage(t *testing.T) {
+	viper.SetDefault("jaeger-es-rollover-image", "jaegertracing/jaeger-es-rollover")
+
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestDefaultEsRolloverImage"})
+
+	cjob := lookback(jaeger)
+	assert.Empty(t, jaeger.Spec.Storage.EsRollover.Image)
+	assert.Equal(t, "jaegertracing/jaeger-es-rollover:0.0.0", cjob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Image)
+}
+
+func TestCustomEsRolloverImage(t *testing.T) {
+	viper.Set("jaeger-es-rollover-image", "org/custom-es-rollover-image")
+	defer viper.Reset()
+
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestDefaultEsRolloverImage"})
+
+	cjob := lookback(jaeger)
+	assert.Empty(t, jaeger.Spec.Storage.EsRollover.Image)
+	assert.Equal(t, "org/custom-es-rollover-image:0.0.0", cjob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Image)
 }

--- a/pkg/cronjob/spark_dependencies.go
+++ b/pkg/cronjob/spark_dependencies.go
@@ -52,6 +52,9 @@ func CreateSparkDependencies(jaeger *v1.Jaeger) *batchv1beta1.CronJob {
 
 	commonSpec := util.Merge([]v1.JaegerCommonSpec{jaeger.Spec.Storage.Dependencies.JaegerCommonSpec, jaeger.Spec.JaegerCommonSpec, baseCommonSpec})
 
+	// Cannot use util.ImageName to obtain the correct image, as the spark-dependencies
+	// image does not get tagged with the jaeger version, so the latest image must
+	// be used instead.
 	image := jaeger.Spec.Storage.Dependencies.Image
 	if image == "" {
 		// the version is not included, there is only one version - latest

--- a/pkg/cronjob/spark_dependencies_test.go
+++ b/pkg/cronjob/spark_dependencies_test.go
@@ -3,6 +3,7 @@ package cronjob
 import (
 	"testing"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -201,4 +202,25 @@ func TestSparkDependenciesResources(t *testing.T) {
 		assert.Equal(t, test.expected, cjob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Resources)
 
 	}
+}
+
+func TestDefaultSparkDependenciesImage(t *testing.T) {
+	viper.SetDefault("jaeger-spark-dependencies-image", "jaegertracing/spark-dependencies")
+
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestDefaultSparkDependenciesImage"})
+
+	cjob := CreateSparkDependencies(jaeger)
+	assert.Empty(t, jaeger.Spec.Storage.Dependencies.Image)
+	assert.Equal(t, "jaegertracing/spark-dependencies", cjob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Image)
+}
+
+func TestCustomSparkDependenciesImage(t *testing.T) {
+	viper.Set("jaeger-spark-dependencies-image", "org/custom-spark-dependencies-image")
+	defer viper.Reset()
+
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestDefaultSparkDependenciesImage"})
+
+	cjob := CreateSparkDependencies(jaeger)
+	assert.Empty(t, jaeger.Spec.Storage.Dependencies.Image)
+	assert.Equal(t, "org/custom-spark-dependencies-image", cjob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Image)
 }

--- a/pkg/storage/elasticsearch_dependencies.go
+++ b/pkg/storage/elasticsearch_dependencies.go
@@ -7,6 +7,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/spf13/viper"
+
 	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/cronjob"
 	"github.com/jaegertracing/jaeger-operator/pkg/util"
@@ -30,6 +32,11 @@ func elasticsearchDependencies(jaeger *v1.Jaeger) []batchv1.Job {
 		Labels: util.Labels(name, "job-es-rollover-create-mapping", *jaeger),
 	}
 	commonSpec = util.Merge([]v1.JaegerCommonSpec{jaeger.Spec.Storage.EsRollover.JaegerCommonSpec, jaeger.Spec.JaegerCommonSpec, *commonSpec})
+	image := jaeger.Spec.Storage.Dependencies.Image
+	if image == "" {
+		// the version is not included, there is only one version - latest
+		image = viper.GetString("jaeger-spark-dependencies-image")
+	}
 	job := batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            name,
@@ -49,7 +56,7 @@ func elasticsearchDependencies(jaeger *v1.Jaeger) []batchv1.Job {
 					Containers: []corev1.Container{
 						{
 							Name:         name,
-							Image:        jaeger.Spec.Storage.EsRollover.Image,
+							Image:        image,
 							Args:         []string{"init", util.GetEsHostname(jaeger.Spec.Storage.Options.Map())},
 							Env:          util.RemoveEmptyVars(envVars(jaeger.Spec.Storage.Options)),
 							EnvFrom:      envFromSource,

--- a/pkg/storage/elasticsearch_dependencies_test.go
+++ b/pkg/storage/elasticsearch_dependencies_test.go
@@ -51,7 +51,7 @@ func TestEnableRollover(t *testing.T) {
 func TestElasticsearchDependencies(t *testing.T) {
 	j := v1.NewJaeger(types.NamespacedName{Name: "eevee"})
 	j.Namespace = "kitchen"
-	j.Spec.Storage.Dependencies.Image = "wohooo"
+	j.Spec.Storage.EsRollover.Image = "wohooo"
 	j.Spec.Storage.Options = v1.NewOptions(map[string]interface{}{"es.server-urls": "foo,bar", "es.index-prefix": "shortone"})
 
 	deps := elasticsearchDependencies(j)
@@ -62,7 +62,7 @@ func TestElasticsearchDependencies(t *testing.T) {
 	assert.Equal(t, []metav1.OwnerReference{util.AsOwner(j)}, job.OwnerReferences)
 	assert.Equal(t, util.Labels("eevee-es-rollover-create-mapping", "job-es-rollover-create-mapping", *j), job.Labels)
 	assert.Equal(t, 1, len(job.Spec.Template.Spec.Containers))
-	assert.Equal(t, j.Spec.Storage.Dependencies.Image, job.Spec.Template.Spec.Containers[0].Image)
+	assert.Equal(t, j.Spec.Storage.EsRollover.Image, job.Spec.Template.Spec.Containers[0].Image)
 	assert.Equal(t, []string{"init", "foo"}, job.Spec.Template.Spec.Containers[0].Args)
 	assert.Equal(t, []corev1.EnvVar{{Name: "INDEX_PREFIX", Value: "shortone"}}, job.Spec.Template.Spec.Containers[0].Env)
 }

--- a/pkg/storage/elasticsearch_dependencies_test.go
+++ b/pkg/storage/elasticsearch_dependencies_test.go
@@ -51,7 +51,7 @@ func TestEnableRollover(t *testing.T) {
 func TestElasticsearchDependencies(t *testing.T) {
 	j := v1.NewJaeger(types.NamespacedName{Name: "eevee"})
 	j.Namespace = "kitchen"
-	j.Spec.Storage.EsRollover.Image = "wohooo"
+	j.Spec.Storage.Dependencies.Image = "wohooo"
 	j.Spec.Storage.Options = v1.NewOptions(map[string]interface{}{"es.server-urls": "foo,bar", "es.index-prefix": "shortone"})
 
 	deps := elasticsearchDependencies(j)
@@ -62,7 +62,7 @@ func TestElasticsearchDependencies(t *testing.T) {
 	assert.Equal(t, []metav1.OwnerReference{util.AsOwner(j)}, job.OwnerReferences)
 	assert.Equal(t, util.Labels("eevee-es-rollover-create-mapping", "job-es-rollover-create-mapping", *j), job.Labels)
 	assert.Equal(t, 1, len(job.Spec.Template.Spec.Containers))
-	assert.Equal(t, j.Spec.Storage.EsRollover.Image, job.Spec.Template.Spec.Containers[0].Image)
+	assert.Equal(t, j.Spec.Storage.Dependencies.Image, job.Spec.Template.Spec.Containers[0].Image)
 	assert.Equal(t, []string{"init", "foo"}, job.Spec.Template.Spec.Containers[0].Args)
 	assert.Equal(t, []corev1.EnvVar{{Name: "INDEX_PREFIX", Value: "shortone"}}, job.Spec.Template.Spec.Containers[0].Env)
 }

--- a/pkg/strategy/controller.go
+++ b/pkg/strategy/controller.go
@@ -15,7 +15,6 @@ import (
 	"github.com/jaegertracing/jaeger-operator/pkg/cronjob"
 	"github.com/jaegertracing/jaeger-operator/pkg/storage"
 	esv1 "github.com/jaegertracing/jaeger-operator/pkg/storage/elasticsearch/v1"
-	"github.com/jaegertracing/jaeger-operator/pkg/util"
 )
 
 const (
@@ -129,10 +128,6 @@ func normalizeSparkDependencies(spec *v1.JaegerStorageSpec) {
 		trueVar := true
 		spec.Dependencies.Enabled = &trueVar
 	}
-	if spec.Dependencies.Image == "" {
-		// the version is not included, there is only one version - latest
-		spec.Dependencies.Image = viper.GetString("jaeger-spark-dependencies-image")
-	}
 	if spec.Dependencies.Schedule == "" {
 		spec.Dependencies.Schedule = "55 23 * * *"
 	}
@@ -144,7 +139,6 @@ func normalizeIndexCleaner(spec *v1.JaegerEsIndexCleanerSpec, storage string) {
 		trueVar := true
 		spec.Enabled = &trueVar
 	}
-	spec.Image = util.ImageName(spec.Image, "jaeger-es-index-cleaner-image")
 	if spec.Schedule == "" {
 		spec.Schedule = "55 23 * * *"
 	}
@@ -179,7 +173,6 @@ func normalizeElasticsearch(spec *v1.ElasticsearchSpec) {
 }
 
 func normalizeRollover(spec *v1.JaegerEsRolloverSpec) {
-	spec.Image = util.ImageName(spec.Image, "jaeger-es-rollover-image")
 	if spec.Schedule == "" {
 		spec.Schedule = "0 0 * * *"
 	}

--- a/pkg/strategy/controller_test.go
+++ b/pkg/strategy/controller_test.go
@@ -179,8 +179,6 @@ func TestAcceptExplicitValueFromSecurityWhenOnOpenShift(t *testing.T) {
 }
 
 func TestNormalizeIndexCleaner(t *testing.T) {
-	viper.Set("jaeger-es-index-cleaner-image", "foo")
-	defer viper.Reset()
 	trueVar := true
 	falseVar := false
 	days7 := 7
@@ -190,7 +188,7 @@ func TestNormalizeIndexCleaner(t *testing.T) {
 		expected  v1.JaegerEsIndexCleanerSpec
 	}{
 		{underTest: v1.JaegerEsIndexCleanerSpec{},
-			expected: v1.JaegerEsIndexCleanerSpec{Image: "foo:0.0.0", Schedule: "55 23 * * *", NumberOfDays: &days7, Enabled: &trueVar}},
+			expected: v1.JaegerEsIndexCleanerSpec{Schedule: "55 23 * * *", NumberOfDays: &days7, Enabled: &trueVar}},
 		{underTest: v1.JaegerEsIndexCleanerSpec{Image: "bla", Schedule: "lol", NumberOfDays: &days55, Enabled: &falseVar},
 			expected: v1.JaegerEsIndexCleanerSpec{Image: "bla", Schedule: "lol", NumberOfDays: &days55, Enabled: &falseVar}},
 	}
@@ -201,14 +199,12 @@ func TestNormalizeIndexCleaner(t *testing.T) {
 }
 
 func TestNormalizeRollover(t *testing.T) {
-	viper.Set("jaeger-es-rollover-image", "hoo")
-	defer viper.Reset()
 	tests := []struct {
 		underTest v1.JaegerEsRolloverSpec
 		expected  v1.JaegerEsRolloverSpec
 	}{
 		{underTest: v1.JaegerEsRolloverSpec{},
-			expected: v1.JaegerEsRolloverSpec{Image: "hoo:0.0.0", Schedule: "0 0 * * *"}},
+			expected: v1.JaegerEsRolloverSpec{Schedule: "0 0 * * *"}},
 		{underTest: v1.JaegerEsRolloverSpec{Image: "bla", Schedule: "lol"},
 			expected: v1.JaegerEsRolloverSpec{Image: "bla", Schedule: "lol"}},
 	}
@@ -219,8 +215,6 @@ func TestNormalizeRollover(t *testing.T) {
 }
 
 func TestNormalizeSparkDependencies(t *testing.T) {
-	viper.Set("jaeger-spark-dependencies-image", "foo")
-	defer viper.Reset()
 	trueVar := true
 	falseVar := false
 	tests := []struct {
@@ -230,30 +224,30 @@ func TestNormalizeSparkDependencies(t *testing.T) {
 		{
 			underTest: v1.JaegerStorageSpec{Type: "elasticsearch", Options: v1.NewOptions(map[string]interface{}{"es.server-urls": "foo"})},
 			expected: v1.JaegerStorageSpec{Type: "elasticsearch", Options: v1.NewOptions(map[string]interface{}{"es.server-urls": "foo"}),
-				Dependencies: v1.JaegerDependenciesSpec{Schedule: "55 23 * * *", Image: "foo", Enabled: &trueVar}},
+				Dependencies: v1.JaegerDependenciesSpec{Schedule: "55 23 * * *", Enabled: &trueVar}},
 		},
 		{
 			underTest: v1.JaegerStorageSpec{Type: "elasticsearch"},
-			expected:  v1.JaegerStorageSpec{Type: "elasticsearch", Dependencies: v1.JaegerDependenciesSpec{Schedule: "55 23 * * *", Image: "foo"}},
+			expected:  v1.JaegerStorageSpec{Type: "elasticsearch", Dependencies: v1.JaegerDependenciesSpec{Schedule: "55 23 * * *"}},
 		},
 		{
 			underTest: v1.JaegerStorageSpec{Type: "elasticsearch", Dependencies: v1.JaegerDependenciesSpec{},
 				Options: v1.NewOptions(map[string]interface{}{"es.server-urls": "local", "es.tls": true})},
-			expected: v1.JaegerStorageSpec{Type: "elasticsearch", Dependencies: v1.JaegerDependenciesSpec{Image: "foo", Schedule: "55 23 * * *", Enabled: nil},
+			expected: v1.JaegerStorageSpec{Type: "elasticsearch", Dependencies: v1.JaegerDependenciesSpec{Schedule: "55 23 * * *", Enabled: nil},
 				Options: v1.NewOptions(map[string]interface{}{"es.server-urls": "local", "es.tls": true}),
 			},
 		},
 		{
 			underTest: v1.JaegerStorageSpec{Type: "elasticsearch", Dependencies: v1.JaegerDependenciesSpec{},
 				Options: v1.NewOptions(map[string]interface{}{"es.server-urls": "local", "es.skip-host-verify": false})},
-			expected: v1.JaegerStorageSpec{Type: "elasticsearch", Dependencies: v1.JaegerDependenciesSpec{Image: "foo", Schedule: "55 23 * * *", Enabled: &trueVar},
+			expected: v1.JaegerStorageSpec{Type: "elasticsearch", Dependencies: v1.JaegerDependenciesSpec{Schedule: "55 23 * * *", Enabled: &trueVar},
 				Options: v1.NewOptions(map[string]interface{}{"es.server-urls": "local", "es.skip-host-verify": false}),
 			},
 		},
 		{
 			underTest: v1.JaegerStorageSpec{Type: "elasticsearch", Dependencies: v1.JaegerDependenciesSpec{},
 				Options: v1.NewOptions(map[string]interface{}{"es.server-urls": "local", "es.skip-host-verify": false, "es.tls.ca": "rr"})},
-			expected: v1.JaegerStorageSpec{Type: "elasticsearch", Dependencies: v1.JaegerDependenciesSpec{Image: "foo", Schedule: "55 23 * * *", Enabled: nil},
+			expected: v1.JaegerStorageSpec{Type: "elasticsearch", Dependencies: v1.JaegerDependenciesSpec{Schedule: "55 23 * * *", Enabled: nil},
 				Options: v1.NewOptions(map[string]interface{}{"es.server-urls": "local", "es.skip-host-verify": false, "es.tls.ca": "rr"}),
 			},
 		},


### PR DESCRIPTION
Signed-off-by: Gary Brown <gary@brownuk.com>

Previously the persisted CR for simplest,yaml included:
```
    Es Index Cleaner:
      Image:           jaegertracing/jaeger-es-index-cleaner:1.17.1
      Number Of Days:  7
      Resources:
      Schedule:  55 23 * * *
    Es Rollover:
      Image:  jaegertracing/jaeger-es-rollover:1.17.1
      Resources:
      Schedule:  0 0 * * *
```
Now
```
    Es Index Cleaner:
      Number Of Days:  7
      Resources:
      Schedule:  55 23 * * *
    Es Rollover:
      Resources:
      Schedule:  0 0 * * *
```