### PR TITLE
Add OTEL config to all-in-one

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,5 +3,6 @@ ignore:
   - "pkg/apis/jaegertracing/v1/zz_generated.deepcopy.go"
   - "pkg/apis/io/v1alpha1/zz_generated.defaults.go"
   - "pkg/apis/jaegertracing/v1/zz_generated.defaults.go"
+  - "pkg/apis/jaegertracing/v1/zz_generated.openapi.go"
   - "pkg/apis/kafka/v1beta1/zz_generated.deepcopy.go"
   - "pkg/apis/kafka/v1beta1/zz_generated.openapi.go"

--- a/deploy/crds/jaegertracing.io_jaegers_crd.yaml
+++ b/deploy/crds/jaegertracing.io_jaegers_crd.yaml
@@ -1542,6 +1542,8 @@ spec:
                     type: string
                   nullable: true
                   type: object
+                config:
+                  type: object
                 image:
                   type: string
                 labels:

--- a/deploy/examples/simplest.yaml
+++ b/deploy/examples/simplest.yaml
@@ -2,10 +2,3 @@ apiVersion: jaegertracing.io/v1
 kind: Jaeger
 metadata:
   name: simplest
-spec:
-  allInOne:
-    image: jaegertracing/opentelemetry-all-in-one:latest
-    config:
-      extensions:
-        health_check:
-          port: 14269

--- a/deploy/examples/simplest.yaml
+++ b/deploy/examples/simplest.yaml
@@ -2,3 +2,10 @@ apiVersion: jaegertracing.io/v1
 kind: Jaeger
 metadata:
   name: simplest
+spec:
+  allInOne:
+    image: jaegertracing/opentelemetry-all-in-one:latest
+    config:
+      extensions:
+        health_check:
+          port: 14269

--- a/pkg/apis/jaegertracing/v1/jaeger_types.go
+++ b/pkg/apis/jaegertracing/v1/jaeger_types.go
@@ -286,6 +286,9 @@ type JaegerAllInOneSpec struct {
 	Options Options `json:"options,omitempty"`
 
 	// +optional
+	Config FreeForm `json:"config,omitempty"`
+
+	// +optional
 	JaegerCommonSpec `json:",inline,omitempty"`
 }
 

--- a/pkg/apis/jaegertracing/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/jaegertracing/v1/zz_generated.deepcopy.go
@@ -145,6 +145,7 @@ func (in *JaegerAgentSpec) DeepCopy() *JaegerAgentSpec {
 func (in *JaegerAllInOneSpec) DeepCopyInto(out *JaegerAllInOneSpec) {
 	*out = *in
 	in.Options.DeepCopyInto(&out.Options)
+	in.Config.DeepCopyInto(&out.Config)
 	in.JaegerCommonSpec.DeepCopyInto(&out.JaegerCommonSpec)
 	return
 }

--- a/pkg/apis/jaegertracing/v1/zz_generated.openapi.go
+++ b/pkg/apis/jaegertracing/v1/zz_generated.openapi.go
@@ -327,6 +327,11 @@ func schema_pkg_apis_jaegertracing_v1_JaegerAllInOneSpec(ref common.ReferenceCal
 							Ref: ref("./pkg/apis/jaegertracing/v1.Options"),
 						},
 					},
+					"config": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("./pkg/apis/jaegertracing/v1.FreeForm"),
+						},
+					},
 					"volumes": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
@@ -431,7 +436,7 @@ func schema_pkg_apis_jaegertracing_v1_JaegerAllInOneSpec(ref common.ReferenceCal
 			},
 		},
 		Dependencies: []string{
-			"./pkg/apis/jaegertracing/v1.Options", "k8s.io/api/core/v1.Affinity", "k8s.io/api/core/v1.PodSecurityContext", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/api/core/v1.Toleration", "k8s.io/api/core/v1.Volume", "k8s.io/api/core/v1.VolumeMount"},
+			"./pkg/apis/jaegertracing/v1.FreeForm", "./pkg/apis/jaegertracing/v1.Options", "k8s.io/api/core/v1.Affinity", "k8s.io/api/core/v1.PodSecurityContext", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/api/core/v1.Toleration", "k8s.io/api/core/v1.Volume", "k8s.io/api/core/v1.VolumeMount"},
 	}
 }
 

--- a/pkg/config/otelconfig/otelconfig.go
+++ b/pkg/config/otelconfig/otelconfig.go
@@ -26,11 +26,7 @@ func ShouldCreate(jaeger *v1.Jaeger, opts v1.Options, otelCfg map[string]interfa
 		jaeger.Logger().Info("OpenTelemetry config will not be created. The config is explicitly provided in the options.")
 		return false
 	}
-	if len(otelCfg) == 0 {
-		return false
-	}
-	return true
-
+	return len(otelCfg) > 0
 }
 
 // Get returns a OTEL config maps for a Jaeger instance.
@@ -45,6 +41,10 @@ func Get(jaeger *v1.Jaeger) []corev1.ConfigMap {
 		cms = append(cms, *c)
 	}
 	c = createIfNeeded(jaeger, "ingester", jaeger.Spec.Ingester.Options, jaeger.Spec.Ingester.Config)
+	if c != nil {
+		cms = append(cms, *c)
+	}
+	c = createIfNeeded(jaeger, "all-in-one", jaeger.Spec.AllInOne.Options, jaeger.Spec.AllInOne.Config)
 	if c != nil {
 		cms = append(cms, *c)
 	}


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <ploffay@redhat.com>

Example CR

```yaml
apiVersion: jaegertracing.io/v1
kind: Jaeger
metadata:
  name: simplest
spec:
  allInOne:
    image: jaegertracing/opentelemetry-all-in-one:latest
    config:
      extensions:
        health_check:
          port: 14269
```