### PR TITLE
Comment out volume mount for trusted CA bundle in sidecar agent

### DIFF
--- a/pkg/inject/sidecar.go
+++ b/pkg/inject/sidecar.go
@@ -6,7 +6,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/config/ca"
+	// Commented out waiting for https://github.com/jaegertracing/jaeger-operator/issues/1092 fix
+	//"github.com/jaegertracing/jaeger-operator/pkg/config/ca"
 	"github.com/jaegertracing/jaeger-operator/pkg/config/otelconfig"
 
 	log "github.com/sirupsen/logrus"
@@ -203,7 +204,8 @@ func container(jaeger *v1.Jaeger, dep *appsv1.Deployment) corev1.Container {
 		otelconfig.Update(jaeger, "agent", volumesAndMountsSpec, &args)
 	}
 
-	ca.Update(jaeger, volumesAndMountsSpec)
+	// Commented out until https://github.com/jaegertracing/jaeger-operator/issues/1092 is fixed
+	//ca.Update(jaeger, volumesAndMountsSpec)
 
 	// ensure we have a consistent order of the arguments
 	// see https://github.com/jaegertracing/jaeger-operator/issues/334

--- a/pkg/inject/sidecar_test.go
+++ b/pkg/inject/sidecar_test.go
@@ -708,6 +708,7 @@ func hasArgument(arg string, args []string) bool {
 	return false
 }
 
+/* Commented out waiting for https://github.com/jaegertracing/jaeger-operator/issues/1092 fix
 func TestInjectSidecarOnOpenShift(t *testing.T) {
 	viper.Set("platform", v1.FlagPlatformOpenShift)
 	defer viper.Reset()
@@ -720,3 +721,4 @@ func TestInjectSidecarOnOpenShift(t *testing.T) {
 	assert.Len(t, dep.Spec.Template.Spec.Containers[1].VolumeMounts, 1)
 	assert.Len(t, dep.Spec.Template.Spec.Volumes, 1)
 }
+*/


### PR DESCRIPTION
Comment out volume/mount from sidecar agent until solution is found for https://github.com/jaegertracing/jaeger-operator/issues/1092.

Signed-off-by: Gary Brown <gary@brownuk.com>