### PR TITLE
Remove ES error shards toleration from smoke test

### DIFF
--- a/test/e2e/smoketest.go
+++ b/test/e2e/smoketest.go
@@ -138,7 +138,7 @@ func executeSmokeTest(apiTracesEndpoint, collectorEndpoint string, hasInsecureEn
 		bodyString := string(bodyBytes)
 
 		// The first requests to newly created ES might fail
-		if !strings.Contains(bodyString, "errors\":null") && !strings.Contains(bodyString, "all shards failed") {
+		if !strings.Contains(bodyString, "errors\":null") {
 			return false, fmt.Errorf("query service returns errors: %s", bodyString)
 		}
 		return strings.Contains(bodyString, tStr), nil


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <ploffay@redhat.com>

```
NAMESPACE=pavolloffay make e2e-tests-self-provisioned-es                                 5:56 
Formatting code...
Building...
Sending build context to Docker daemon  177.8MB
Step 1/7 : FROM registry.access.redhat.com/ubi8/ubi
 ---> a523835cfc89
Step 2/7 : ENV OPERATOR=/usr/local/bin/jaeger-operator     USER_UID=1001     USER_NAME=jaeger-operator
 ---> Using cache
 ---> cdacbb7a92b2
Step 3/7 : RUN INSTALL_PKGS="       openssl       " &&     yum install -y $INSTALL_PKGS &&     rpm -V $INSTALL_PKGS &&     yum clean all &&     mkdir /tmp/_working_dir &&     chmod og+w /tmp/_working_dir
 ---> Using cache
 ---> b25f1d9d044c
Step 4/7 : COPY scripts/* /scripts/
 ---> Using cache
 ---> 399f83a7d70b
Step 5/7 : COPY build/_output/bin/jaeger-operator ${OPERATOR}
 ---> 91b847a531b8
Step 6/7 : ENTRYPOINT ["/usr/local/bin/jaeger-operator"]
 ---> Running in 575ac58eccdb
Removing intermediate container 575ac58eccdb
 ---> deb4bd6cbfcd
Step 7/7 : USER ${USER_UID}
 ---> Running in 1a3cab21f46c
Removing intermediate container 1a3cab21f46c
 ---> ecfa8597ad68
Successfully built ecfa8597ad68
Successfully tagged pavolloffay/jaeger-operator:latest
Pushing image pavolloffay/jaeger-operator:latest...
# Elasticsearch requires labeled nodes. These labels are by default present in OCP 4.2
node/ip-10-0-144-5.us-east-2.compute.internal not labeled
node/ip-10-0-162-83.us-east-2.compute.internal not labeled
node/ip-10-0-163-132.us-east-2.compute.internal not labeled
node/ip-10-0-168-222.us-east-2.compute.internal not labeled
node/ip-10-0-210-190.us-east-2.compute.internal not labeled
node/ip-10-0-234-252.us-east-2.compute.internal not labeled
# This is not required in OCP 4.1. The node tuning operator configures the property automatically
# when label tuned.openshift.io/elasticsearch=true label is present on the ES pod. The label
# is configured by ES operator.
namespace/openshift-logging created
customresourcedefinition.apiextensions.k8s.io/prometheusrules.monitoring.coreos.com created
customresourcedefinition.apiextensions.k8s.io/servicemonitors.monitoring.coreos.com created
serviceaccount/elasticsearch-operator created
clusterrole.rbac.authorization.k8s.io/elasticsearch-operator created
clusterrolebinding.rbac.authorization.k8s.io/elasticsearch-operator-rolebinding created
customresourcedefinition.apiextensions.k8s.io/elasticsearches.logging.openshift.io created
deployment.apps/elasticsearch-operator created
deployment.apps/elasticsearch-operator image updated
Running Self provisioned Elasticsearch end-to-end tests...
ok  	github.com/jaegertracing/jaeger-operator/test/e2e	288.175s

```