### PR TITLE
Mount volumes from agent spec

### DIFF
--- a/pkg/inject/sidecar.go
+++ b/pkg/inject/sidecar.go
@@ -192,9 +192,9 @@ func container(jaeger *v1.Jaeger, dep *appsv1.Deployment) corev1.Container {
 
 	commonSpec := util.Merge([]v1.JaegerCommonSpec{jaeger.Spec.Agent.JaegerCommonSpec, jaeger.Spec.JaegerCommonSpec})
 
-	// Use a different common spec for volumes and mounts.
+	// Use only the agent common spec for volumes and mounts.
 	// We don't want to mount all Jaeger internal volumes into user's deployments
-	volumesAndMountsSpec := &v1.JaegerCommonSpec{}
+	volumesAndMountsSpec := &jaeger.Spec.Agent.JaegerCommonSpec
 	otelConf, err := jaeger.Spec.Agent.Config.GetMap()
 	if err != nil {
 		jaeger.Logger().WithField("error", err).


### PR DESCRIPTION
Context: https://github.com/jaegertracing/jaeger-operator/issues/1097

This PR uses any `volumes` or `volumeMounts` under the **agent** node in a Jaeger instance when creating an agent as a sidecar. This still doesn't use the common spec for volumes/mounts, as it seems, *"We don't want to mount all Jaeger internal volumes into user's deployments"*.

However, if someone were to specify a volume/mount under the agent node in the Jaeger instance, they would be mounted to the sidecar, since this would be very intentional.

This seems necessary if one needs to supply files to the agent (e.g. for TLS between the agent and collector with the arg `--reporter.grpc.tls.ca`).