### PR TITLE
Adjusted gRPC options for OpenShift when TLS is enabled

### DIFF
--- a/pkg/inject/sidecar.go
+++ b/pkg/inject/sidecar.go
@@ -152,7 +152,7 @@ func container(jaeger *v1.Jaeger, dep *appsv1.Deployment) corev1.Container {
 
 		// we only add the grpc host if we are adding the reporter type and there's no explicit value yet
 		if len(util.FindItem("--reporter.grpc.host-port=", args)) == 0 {
-			args = append(args, fmt.Sprintf("--reporter.grpc.host-port=dns:///%s.%s:14250", service.GetNameForHeadlessCollectorService(jaeger), jaeger.Namespace))
+			args = append(args, fmt.Sprintf("--reporter.grpc.host-port=dns:///%s.%s.svc:14250", service.GetNameForHeadlessCollectorService(jaeger), jaeger.Namespace))
 		}
 	}
 
@@ -161,7 +161,6 @@ func container(jaeger *v1.Jaeger, dep *appsv1.Deployment) corev1.Container {
 		if len(util.FindItem("--reporter.type=grpc", args)) > 0 && len(util.FindItem("--reporter.grpc.tls.enabled=true", args)) == 0 {
 			args = append(args, "--reporter.grpc.tls.enabled=true")
 			args = append(args, "--reporter.grpc.tls.ca=/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt")
-			args = append(args, fmt.Sprintf("--reporter.grpc.tls.server-name=%s.%s.svc.cluster.local", service.GetNameForHeadlessCollectorService(jaeger), jaeger.Namespace))
 		}
 	}
 

--- a/pkg/inject/sidecar_test.go
+++ b/pkg/inject/sidecar_test.go
@@ -712,14 +712,13 @@ func TestSidecarArgumentsOpenshiftTLS(t *testing.T) {
 	dep = Sidecar(jaeger, dep)
 
 	assert.Len(t, dep.Spec.Template.Spec.Containers, 2)
-	assert.Len(t, dep.Spec.Template.Spec.Containers[1].Args, 7)
+	assert.Len(t, dep.Spec.Template.Spec.Containers[1].Args, 6)
 	assert.Greater(t, len(util.FindItem("--a-option=a-value", dep.Spec.Template.Spec.Containers[1].Args)), 0)
 	assert.Greater(t, len(util.FindItem("--jaeger.tags", dep.Spec.Template.Spec.Containers[1].Args)), 0)
 	assert.Greater(t, len(util.FindItem("--reporter.type=grpc", dep.Spec.Template.Spec.Containers[1].Args)), 0)
-	assert.Greater(t, len(util.FindItem("--reporter.grpc.host-port=dns:///testqueryorderofarguments-collector-headless.test:14250", dep.Spec.Template.Spec.Containers[1].Args)), 0)
+	assert.Greater(t, len(util.FindItem("--reporter.grpc.host-port=dns:///testqueryorderofarguments-collector-headless.test.svc:14250", dep.Spec.Template.Spec.Containers[1].Args)), 0)
 	assert.Greater(t, len(util.FindItem("--reporter.grpc.tls.enabled=true", dep.Spec.Template.Spec.Containers[1].Args)), 0)
 	assert.Greater(t, len(util.FindItem("--reporter.grpc.tls.ca=/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt", dep.Spec.Template.Spec.Containers[1].Args)), 0)
-	assert.Greater(t, len(util.FindItem("--reporter.grpc.tls.server-name=testqueryorderofarguments-collector-headless.test.svc.cluster.local", dep.Spec.Template.Spec.Containers[1].Args)), 0)
 	agentTags := agentTags(dep.Spec.Template.Spec.Containers[1].Args)
 	assert.Contains(t, agentTags, "container.name=only_container")
 }


### PR DESCRIPTION
Fixes #1118 by changing the collector's hostname to connect, and removing the 'service name' flag. With this PR, this is how the logs for the sidecar agent looks like:

```
$ kubectl logs myapp-6f7cc99b66-ckxx9 -c jaeger-agent -f
2020/07/06 13:24:16 maxprocs: Leaving GOMAXPROCS=2: CPU quota undefined
{"level":"info","ts":1594041857.0278215,"caller":"flags/service.go:116","msg":"Mounting metrics handler on admin server","route":"/metrics"}
{"level":"info","ts":1594041857.02812,"caller":"flags/admin.go:120","msg":"Mounting health check on admin server","route":"/"}
{"level":"info","ts":1594041857.0281951,"caller":"flags/admin.go:126","msg":"Starting admin HTTP server","http-addr":":14271"}
{"level":"info","ts":1594041857.028216,"caller":"flags/admin.go:112","msg":"Admin server started","http.host-port":"[::]:14271","health-status":"unavailable"}
{"level":"warn","ts":1594041857.0282385,"caller":"reporter/flags.go:61","msg":"Using deprecated configuration","option":"jaeger.tags"}
{"level":"info","ts":1594041857.0291817,"caller":"grpc/builder.go:57","msg":"Agent requested secure grpc connection to collector(s)"}
{"level":"info","ts":1594041857.0305443,"caller":"grpc@v1.27.1/clientconn.go:106","msg":"parsed scheme: \"dns\"","system":"grpc","grpc_log":true}
{"level":"info","ts":1594041857.042985,"caller":"command-line-arguments/main.go:78","msg":"Starting agent"}
{"level":"info","ts":1594041857.043091,"caller":"healthcheck/handler.go:128","msg":"Health Check state change","status":"ready"}
{"level":"info","ts":1594041857.043513,"caller":"app/agent.go:69","msg":"Starting jaeger-agent HTTP server","http-port":5778}
{"level":"info","ts":1594041857.0844226,"caller":"dns/dns_resolver.go:212","msg":"ccResolverWrapper: sending update to cc: {[{10.129.2.32:14250  <nil> 0 <nil>}] <nil> <nil>}","system":"grpc","grpc_log":true}
{"level":"info","ts":1594041857.0845058,"caller":"grpc@v1.27.1/clientconn.go:948","msg":"ClientConn switching balancer to \"round_robin\"","system":"grpc","grpc_log":true}
{"level":"warn","ts":1594041857.084815,"caller":"grpc@v1.27.1/clientconn.go:1223","msg":"grpc: addrConn.createTransport failed to connect to {10.129.2.32:14250  <nil> 0 <nil>}. Err :connection error: desc = \"transport: Error while dialing dial tcp 10.129.2.32:14250: connect: connection refused\". Reconnecting...","system":"grpc","grpc_log":true}
{"level":"info","ts":1594041858.0855982,"caller":"base/balancer.go:196","msg":"roundrobinPicker: newPicker called with info: {map[]}","system":"grpc","grpc_log":true}
{"level":"warn","ts":1594041858.087407,"caller":"grpc@v1.27.1/clientconn.go:1223","msg":"grpc: addrConn.createTransport failed to connect to {10.129.2.32:14250  <nil> 0 <nil>}. Err :connection error: desc = \"transport: Error while dialing dial tcp 10.129.2.32:14250: connect: connection refused\". Reconnecting...","system":"grpc","grpc_log":true}
{"level":"info","ts":1594041859.9060602,"caller":"base/balancer.go:196","msg":"roundrobinPicker: newPicker called with info: {map[]}","system":"grpc","grpc_log":true}
{"level":"info","ts":1594041859.9167461,"caller":"base/balancer.go:196","msg":"roundrobinPicker: newPicker called with info: {map[0xc00003e290:{{10.129.2.32:14250  <nil> 0 <nil>}}]}","system":"grpc","grpc_log":true}
{"level":"info","ts":1594041887.0981283,"caller":"dns/dns_resolver.go:212","msg":"ccResolverWrapper: sending update to cc: {[{10.129.2.32:14250  <nil> 0 <nil>}] <nil> <nil>}","system":"grpc","grpc_log":true}
```

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>