### PR TITLE
Log warning events on failed tests to help debug PVC and other issues

### DIFF
--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -588,7 +588,7 @@ func logWarningEvents() {
 	eventList, err := fw.KubeClient.CoreV1().Events(namespace).List(metav1.ListOptions{})
 	require.NoError(t, err)
 	if len(eventList.Items) > 0 {
-		logrus.Infof("Events for test %s", t.Name())
+		logrus.Infof("Warning events for test %s", t.Name())
 	}
 	for _, event := range eventList.Items {
 		if event.Type != "Normal" {

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -592,7 +592,7 @@ func logWarningEvents() {
 	}
 	for _, event := range eventList.Items {
 		if event.Type != "Normal" {
-			logrus.Warnf("Type: %s Reason: %s Message: %s", event.Type, event.Reason, event.Message)
+			logrus.Warnf("Event Warning: Reason: %s Message: %s", event.Reason, event.Message)
 		}
 	}
 }

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -587,11 +587,13 @@ func getOtelCollectorOptions() map[string]interface{} {
 func logWarningEvents() {
 	eventList, err := fw.KubeClient.CoreV1().Events(namespace).List(metav1.ListOptions{})
 	require.NoError(t, err)
-	if len(eventList.Items) > 0 {
-		logrus.Infof("Warning events for test %s", t.Name())
-	}
+	firstWarning := true
 	for _, event := range eventList.Items {
 		if event.Type != "Normal" {
+			if firstWarning {
+				logrus.Infof("Warning events for test %s", t.Name())
+				firstWarning = false
+			}
 			logrus.Warnf("Event Warning: Reason: %s Message: %s", event.Reason, event.Message)
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com>  We have recurring problems when testing on OpenShift with failures of tests which use PVCs.  This change will log Warning events when a test fails, and hopefully will help resolve this and other problems.
