### PR TITLE
Update downloaded SDK version and update deprecated struct name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ PROMETHEUS_OPERATOR_TAG ?= v0.39.0
 PROMETHEUS_RULES_CRD ?= https://raw.githubusercontent.com/coreos/prometheus-operator/${PROMETHEUS_OPERATOR_TAG}/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
 PROMETHEUS_SERVICE_MONITORS_CRD ?= https://raw.githubusercontent.com/coreos/prometheus-operator/${PROMETHEUS_OPERATOR_TAG}/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
 ES_OPERATOR_IMAGE ?= quay.io/openshift/origin-elasticsearch-operator:4.4
-SDK_VERSION=v0.15.1
+SDK_VERSION=v0.18.2
 GOPATH ?= "$(HOME)/go"
 
 LD_FLAGS ?= "-X $(VERSION_PKG).version=$(OPERATOR_VERSION) -X $(VERSION_PKG).buildDate=$(VERSION_DATE) -X $(VERSION_PKG).defaultJaeger=$(JAEGER_VERSION)"

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -103,9 +103,9 @@ func GetPod(namespace, namePrefix, containsImage string, kubeclient kubernetes.I
 	return *emptyPod
 }
 
-func prepare(t *testing.T) (*framework.TestCtx, error) {
+func prepare(t *testing.T) (*framework.Context, error) {
 	t.Logf("debug mode: %v", debugMode)
-	ctx := framework.NewTestCtx(t)
+	ctx := framework.NewContext(t)
 	// Install jaeger-operator unless we've installed it from OperatorHub
 	start := time.Now()
 	if !usingOLM {


### PR DESCRIPTION
SDK_VERSION in Makefile refered to an older version, and the struct
framework.TestCtx is now a deprecated alias for framework.Context.

Updates #1125