### PR TITLE
Updated CI to use latest versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,14 @@ jobs:
       - checkout
       - run:
           command: >-
+            curl -L https://golang.org/dl/go1.14.6.linux-amd64.tar.gz | tar xzf - &&
+            sudo mv go/bin/go /usr/local/bin/ &&
+            sudo mv go/bin/gofmt /usr/local/bin/ && 
+            go version
+          name: Install recent go
+
+      - run:
+          command: >-
             curl -Lo minikube https://github.com/kubernetes/minikube/releases/download/v1.12.1/minikube-linux-amd64 &&
               chmod +x minikube &&
               sudo mv minikube /usr/local/bin/
@@ -25,6 +33,6 @@ jobs:
             sudo -E minikube start --vm-driver=none --kubernetes-version=v1.17.9
           name: Start minikube
 
-      - run: make install-sdk
+      - run: SDK_VERSION=0.18.2 make install-sdk
       - run: make install-tools
       - run: TEST_GROUP=smoke ./.ci/run-e2e-tests.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
       - checkout
       - run:
           command: >-
-            curl -L https://golang.org/dl/go1.14.6.linux-amd64.tar.gz | sudo tar -xz -C /usr/local/ &&
+            curl -L https://golang.org/dl/go1.14.3.linux-amd64.tar.gz | sudo tar -xz -C /usr/local/ &&
             sudo chown -R $(whoami): /usr/local/go &&
             echo "export PATH=$PATH:/usr/local/go/bin" >> $BASH_ENV &&
             go version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,9 +7,9 @@ jobs:
       - checkout
       - run:
           command: >-
-            curl -L https://golang.org/dl/go1.14.6.linux-amd64.tar.gz | tar xzf - &&
-            sudo mv go/bin/go /usr/local/bin/ &&
-            sudo mv go/bin/gofmt /usr/local/bin/ && 
+            curl -L https://golang.org/dl/go1.14.6.linux-amd64.tar.gz | sudo tar -xz -C /usr/local/ &&
+            sudo chown -R $(whoami): /usr/local/go &&
+            echo "export PATH=$PATH:/usr/local/go/bin" >> $BASH_ENV &&
             go version
           name: Install recent go
 
@@ -33,6 +33,6 @@ jobs:
             sudo -E minikube start --vm-driver=none --kubernetes-version=v1.17.9
           name: Start minikube
 
-      - run: SDK_VERSION=0.18.2 make install-sdk
+      - run: make install-sdk SDK_VERSION=0.18.2 
       - run: make install-tools
-      - run: TEST_GROUP=smoke ./.ci/run-e2e-tests.sh
+      - run: ./.ci/run-e2e-tests.sh TEST_GROUP=smoke 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,30 @@
+version: 2.1
+jobs:
+  build:
+    machine:
+      image: circleci/classic:201808-01
+    steps:
+      - checkout
+      - run:
+          command: >-
+            curl -Lo minikube https://github.com/kubernetes/minikube/releases/download/v1.12.1/minikube-linux-amd64 &&
+              chmod +x minikube &&
+              sudo mv minikube /usr/local/bin/
+          name: Install minikube
+
+      - run:
+          command: >-
+            curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.18.3/bin/linux/amd64/kubectl &&
+              chmod +x kubectl &&
+              sudo mv kubectl /usr/local/bin/ &&
+              mkdir -p ${HOME}/.kube && touch ${HOME}/.kube/config
+          name: Install kubectl
+
+      - run:
+          command: >-
+            sudo -E minikube start --vm-driver=none --kubernetes-version=v1.17.9
+          name: Start minikube
+
+      - run: make install-sdk
+      - run: make install-tools
+      - run: TEST_GROUP=smoke ./.ci/run-e2e-tests.sh


### PR DESCRIPTION
1. Changed the CI to use the latest Ubuntu from GitHub Actions (20.04).
1. Changed the CI to use podman instead of docker.
1. Simplified the start-minikube.sh a bit

Fixes #1137

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>