### PR TITLE
Update tests to work properly when using OLM installed Jaeger Operator

### DIFF
--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -113,6 +113,10 @@ func prepare(t *testing.T) (*framework.TestCtx, error) {
 		if err != nil {
 			t.Errorf("failed to initialize cluster resources: %v", err)
 		}
+	} else {
+		// Hacky - as of Operator SDK 0.18.2 calling getOperatorNamespace is required to actually create the namespace
+		_, err := ctx.GetOperatorNamespace()
+		require.NoError(t, err)
 	}
 
 	namespace := ctx.GetID()


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com>

Because of the upgrade to operator-sdk 0.18.2 tests started failing when run using an OLM installed Jaeger Operator.  As noted below, if we skip the normal cluster initialization, the namespace for the test doesn't actually get created.