### PR TITLE
Add support for JAEGER_OLM EV

### DIFF
--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -42,6 +42,7 @@ var (
 	kafkaNamespace       = os.Getenv("KAFKA_NAMESPACE")
 	debugMode            = getBoolEnv("DEBUG_MODE", false)
 	usingOLM             = getBoolEnv("OLM", false)
+	usingJaegerViaOLM    = getBoolEnv("JAEGER_OLM", false)
 	saveLogs             = getBoolEnv("SAVE_LOGS", false)
 	skipCassandraTests   = getBoolEnv("SKIP_CASSANDRA_TESTS", false)
 	testOtelCollector    = getBoolEnv("USE_OTEL_COLLECTOR", false)
@@ -108,7 +109,7 @@ func prepare(t *testing.T) (*framework.TestCtx, error) {
 	ctx := framework.NewTestCtx(t)
 	// Install jaeger-operator unless we've installed it from OperatorHub
 	start := time.Now()
-	if !usingOLM {
+	if !usingJaegerViaOLM {
 		err := ctx.InitializeClusterResources(&framework.CleanupOptions{TestContext: ctx, Timeout: 10 * time.Minute, RetryInterval: retryInterval})
 		if err != nil {
 			t.Errorf("failed to initialize cluster resources: %v", err)
@@ -157,7 +158,7 @@ func prepare(t *testing.T) (*framework.TestCtx, error) {
 	// get global framework variables
 	f := framework.Global
 	// wait for the operator to be ready
-	if !usingOLM {
+	if !usingJaegerViaOLM {
 		err := e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "jaeger-operator", 1, retryInterval, timeout)
 		if err != nil {
 			logrus.Errorf("WaitForDeployment returned error %v", err)
@@ -195,7 +196,7 @@ func getJaegerOperatorImages(kubeclient kubernetes.Interface, namespace string) 
 }
 
 func getJaegerOperatorNamespace() string {
-	if !usingOLM {
+	if !usingJaegerViaOLM {
 		return namespace
 	}
 
@@ -367,7 +368,7 @@ func WaitAndPollForHTTPResponse(targetURL string, condition ValidateHTTPResponse
 
 func handleSuiteTearDown() {
 	logrus.Info("Entering TearDownSuite()")
-	if saveLogs && !usingOLM {
+	if saveLogs && !usingJaegerViaOLM {
 		var logFileNameBase string
 		// Sometimes t.Name() returns just the suite name, other times it returns suite/lastTestRun.
 		// Here we just want the suite name


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com>

Add a separate EV to indicate whether the Jaeger Operator has been installed via OLM so we can run tests where the ElasticSearch and Kafka operators have been installed via OLM but the Jaeger Operator has not.
