### PR TITLE
Add common field to  jaeger-es-rollover-create-mapping

### DIFF
--- a/pkg/storage/elasticsearch_dependencies.go
+++ b/pkg/storage/elasticsearch_dependencies.go
@@ -1,7 +1,6 @@
 package storage
 
 import (
-	"github.com/jaegertracing/jaeger-operator/pkg/account"
 	"strings"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -11,6 +10,7 @@ import (
 	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/cronjob"
 	"github.com/jaegertracing/jaeger-operator/pkg/util"
+	"github.com/jaegertracing/jaeger-operator/pkg/account"
 )
 
 // EnableRollover returns true if rollover should be enabled

--- a/pkg/storage/elasticsearch_dependencies.go
+++ b/pkg/storage/elasticsearch_dependencies.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"github.com/jaegertracing/jaeger-operator/pkg/account"
 	"strings"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -45,6 +46,10 @@ func elasticsearchDependencies(jaeger *v1.Jaeger) []batchv1.Job {
 				},
 				Spec: corev1.PodSpec{
 					RestartPolicy: corev1.RestartPolicyOnFailure,
+					Affinity:           commonSpec.Affinity,
+					Tolerations:        commonSpec.Tolerations,
+					SecurityContext:    commonSpec.SecurityContext,
+					ServiceAccountName: account.JaegerServiceAccountFor(jaeger, account.EsRolloverComponent),
 					Volumes:       commonSpec.Volumes,
 					Containers: []corev1.Container{
 						{


### PR DESCRIPTION
Happen to see the job `jaeger-es-rollover-create-mapping` can't be like other components,`cronjob.batch/jaeger-es-index-cleaner, cronjob.batch/jaeger-es-lookback, cronjob.batch/jaeger-es-rollover` to have Affinity, Tolerations, SecurityContext and ServiceAccountName
