### PR TITLE
Support custom labels in Jaeger all-in-one deployments (#629)

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1431,6 +1431,7 @@ k8s.io/apimachinery v0.18.2 h1:44CmtbmkzVDAhCpRVSiP2R5PPrC2RtlIv/MoB8xpdRA=
 k8s.io/apimachinery v0.18.2/go.mod h1:9SnR/e11v5IbyPCGbvJViimtJ0SwHG4nfZFjU77ftcA=
 k8s.io/apimachinery v0.18.3 h1:pOGcbVAhxADgUYnjS08EFXs9QMl8qaH5U4fr5LGUrSk=
 k8s.io/apimachinery v0.18.3/go.mod h1:OaXp26zu/5J7p0f92ASynJa1pZo06YlV9fG7BoWbCko=
+k8s.io/apimachinery v0.18.6 h1:RtFHnfGNfd1N0LeSrKCUznz5xtUP1elRGvHJbL3Ntag=
 k8s.io/apiserver v0.0.0-20190918160949-bfa5e2e684ad/go.mod h1:XPCXEwhjaFN29a8NldXA901ElnKeKLrLtREO9ZhFyhg=
 k8s.io/apiserver v0.0.0-20191122221311-9d521947b1e1/go.mod h1:RbsZY5zzBIWnz4KbctZsTVjwIuOpTp4Z8oCgFHN4kZQ=
 k8s.io/apiserver v0.18.0/go.mod h1:3S2O6FeBBd6XTo0njUrLxiqk8GNy6wWOftjhJcXYnjw=

--- a/pkg/deployment/all_in_one.go
+++ b/pkg/deployment/all_in_one.go
@@ -37,7 +37,6 @@ func NewAllInOne(jaeger *v1.Jaeger) *AllInOne {
 // Get returns a pod for the current all-in-one configuration
 func (a *AllInOne) Get() *appsv1.Deployment {
 	a.jaeger.Logger().Debug("Assembling an all-in-one deployment")
-	labels := a.labels()
 	trueVar := true
 
 	args := append(a.jaeger.Spec.AllInOne.Options.ToArgs())
@@ -51,7 +50,7 @@ func (a *AllInOne) Get() *appsv1.Deployment {
 			"sidecar.istio.io/inject": "false",
 			"linkerd.io/inject":       "disabled",
 		},
-		Labels: labels,
+		Labels: a.labels(),
 	}
 
 	commonSpec := util.Merge([]v1.JaegerCommonSpec{a.jaeger.Spec.AllInOne.JaegerCommonSpec, a.jaeger.Spec.JaegerCommonSpec, baseCommonSpec})

--- a/pkg/deployment/all_in_one.go
+++ b/pkg/deployment/all_in_one.go
@@ -120,7 +120,7 @@ func (a *AllInOne) Get() *appsv1.Deployment {
 		},
 		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
-				MatchLabels: labels,
+				MatchLabels: commonSpec.Labels,
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/deployment/all_in_one_test.go
+++ b/pkg/deployment/all_in_one_test.go
@@ -83,6 +83,11 @@ func TestAllInOneLabels(t *testing.T) {
 	assert.Equal(t, "operator", dep.Spec.Template.Labels["name"])
 	assert.Equal(t, "world", dep.Spec.Template.Labels["hello"])
 	assert.Equal(t, "false", dep.Spec.Template.Labels["another"])
+
+	// Deployment selectors should be the same as the template labels.
+	assert.Equal(t, "operator", dep.Spec.Selector.MatchLabels["name"])
+	assert.Equal(t, "world", dep.Spec.Selector.MatchLabels["hello"])
+	assert.Equal(t, "false", dep.Spec.Selector.MatchLabels["another"])
 }
 
 func TestAllInOneHasOwner(t *testing.T) {

--- a/pkg/storage/elasticsearch_dependencies.go
+++ b/pkg/storage/elasticsearch_dependencies.go
@@ -7,10 +7,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/jaegertracing/jaeger-operator/pkg/account"
 	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/cronjob"
 	"github.com/jaegertracing/jaeger-operator/pkg/util"
-	"github.com/jaegertracing/jaeger-operator/pkg/account"
 )
 
 // EnableRollover returns true if rollover should be enabled
@@ -45,12 +45,12 @@ func elasticsearchDependencies(jaeger *v1.Jaeger) []batchv1.Job {
 					Labels:      commonSpec.Labels,
 				},
 				Spec: corev1.PodSpec{
-					RestartPolicy: corev1.RestartPolicyOnFailure,
+					RestartPolicy:      corev1.RestartPolicyOnFailure,
 					Affinity:           commonSpec.Affinity,
 					Tolerations:        commonSpec.Tolerations,
 					SecurityContext:    commonSpec.SecurityContext,
 					ServiceAccountName: account.JaegerServiceAccountFor(jaeger, account.EsRolloverComponent),
-					Volumes:       commonSpec.Volumes,
+					Volumes:            commonSpec.Volumes,
 					Containers: []corev1.Container{
 						{
 							Name:         name,


### PR DESCRIPTION
Proposed fix for Issue #629. Wrote test to fail where "name", "hello" and "another" custom labels have empty corresponding strings in the selectors, then update selector to use `commonSpec.Labels`, matching the template's labels. Tests pass after change.

Diff also contains a few gofmt and go.sum updates.