### PR TITLE
Added missing metrics port to operator's deployment

### DIFF
--- a/deploy/examples/operator-with-tracing.yaml
+++ b/deploy/examples/operator-with-tracing.yaml
@@ -17,10 +17,12 @@ spec:
       serviceAccountName: jaeger-operator
       containers:
       - name: jaeger-operator
-        image: jaegertracing/jaeger-operator:1.16.0 # operator tracing is available since 1.16.0
+        image: jaegertracing/jaeger-operator:1.18.1
         ports:
         - containerPort: 8383
-          name: metrics
+          name: http-metrics
+        - containerPort: 8686
+          name: cr-metrics
         args: ["start", "--tracing-enabled=true"]
         imagePullPolicy: Always
         env:
@@ -39,7 +41,7 @@ spec:
         - name: OPERATOR_NAME
           value: "jaeger-operator"
       - name: jaeger-agent
-        image: jaegertracing/jaeger-agent:1.16.0
+        image: jaegertracing/jaeger-agent:1.18
         env:
         - name: POD_NAMESPACE
           valueFrom:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -18,7 +18,9 @@ spec:
         image: jaegertracing/jaeger-operator:1.18.1
         ports:
         - containerPort: 8383
-          name: metrics
+          name: http-metrics
+        - containerPort: 8686
+          name: cr-metrics
         args: ["start"]
         imagePullPolicy: Always
         env:


### PR DESCRIPTION
While testing #1114, I found a small problem in the operator's deployment descriptor, where it's missing one port that is referenced by the service created to back the service monitor.

Also added a target to install the Prometheus Operator.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>