### PR TITLE
Use the correct OLM flag when determining if test should run

### DIFF
--- a/test/e2e/streaming_test.go
+++ b/test/e2e/streaming_test.go
@@ -86,7 +86,7 @@ func (suite *StreamingTestSuite) TestStreaming() {
 }
 
 func (suite *StreamingTestSuite) TestStreamingWithTLS() {
-	if !usingOLM {
+	if !usingJaegerViaOLM {
 		t.Skip("This test should only run when using OLM")
 	}
 	// Make sure ES and the kafka instance are available


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com>

Prior to #1140 we used a single environment variable, OLM, which would tell us whether all three of the Jaeger, ElasticSearch, and Kafka operators had been installed via operator hub.  As of that PR we split functionality into two, with OLM=true now meaning that the ES and Kafka operators had been installed via operator hub, and JAEGER_OLM saying Jaeger had been installed that way.

This test should have been corrected at that time, and should only be run when the Jaeger Operator is installed from operator hub.
