### PR TITLE
Disabled service links

### DIFF
--- a/pkg/deployment/agent.go
+++ b/pkg/deployment/agent.go
@@ -65,6 +65,7 @@ func (a *Agent) Get() *appsv1.DaemonSet {
 	adminPort := util.GetPort("--admin-http-port=", args, 14271)
 
 	trueVar := true
+	falseVar := false
 	labels := util.Labels(a.name(), "agent", *a.jaeger)
 
 	baseCommonSpec := v1.JaegerCommonSpec{
@@ -184,6 +185,7 @@ func (a *Agent) Get() *appsv1.DaemonSet {
 					Tolerations:        commonSpec.Tolerations,
 					SecurityContext:    commonSpec.SecurityContext,
 					ServiceAccountName: account.JaegerServiceAccountFor(a.jaeger, account.AgentComponent),
+					EnableServiceLinks: &falseVar,
 				},
 			},
 		},

--- a/pkg/deployment/agent_test.go
+++ b/pkg/deployment/agent_test.go
@@ -242,3 +242,12 @@ func TestAgentOTELConfig(t *testing.T) {
 	assert.True(t, hasVolume("my-instance-agent-otel-config", d.Spec.Template.Spec.Volumes))
 	assert.True(t, hasVolumeMount("my-instance-agent-otel-config", d.Spec.Template.Spec.Containers[0].VolumeMounts))
 }
+
+func TestAgentServiceLinks(t *testing.T) {
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
+	jaeger.Spec.Agent.Strategy = "daemonset"
+	a := NewAgent(jaeger)
+	dep := a.Get()
+	falseVar := false
+	assert.Equal(t, &falseVar, dep.Spec.Template.Spec.EnableServiceLinks)
+}

--- a/pkg/deployment/all_in_one.go
+++ b/pkg/deployment/all_in_one.go
@@ -38,6 +38,7 @@ func NewAllInOne(jaeger *v1.Jaeger) *AllInOne {
 func (a *AllInOne) Get() *appsv1.Deployment {
 	a.jaeger.Logger().Debug("Assembling an all-in-one deployment")
 	trueVar := true
+	falseVar := false
 
 	args := append(a.jaeger.Spec.AllInOne.Options.ToArgs())
 
@@ -215,6 +216,7 @@ func (a *AllInOne) Get() *appsv1.Deployment {
 					Affinity:           commonSpec.Affinity,
 					Tolerations:        commonSpec.Tolerations,
 					SecurityContext:    commonSpec.SecurityContext,
+					EnableServiceLinks: &falseVar,
 				},
 			},
 		},

--- a/pkg/deployment/all_in_one_test.go
+++ b/pkg/deployment/all_in_one_test.go
@@ -345,3 +345,10 @@ func TestAllInOneOTELConfig_error(t *testing.T) {
 	assert.False(t, hasVolume("instance-all-in-one-otel-config", d.Spec.Template.Spec.Volumes))
 	assert.False(t, hasVolumeMount("instance-all-in-one-otel-config", d.Spec.Template.Spec.Containers[0].VolumeMounts))
 }
+
+func TestAllInOneServiceLinks(t *testing.T) {
+	a := NewAllInOne(v1.NewJaeger(types.NamespacedName{Name: "TestAllInOneServiceLinks"}))
+	dep := a.Get()
+	falseVar := false
+	assert.Equal(t, &falseVar, dep.Spec.Template.Spec.EnableServiceLinks)
+}

--- a/pkg/deployment/collector.go
+++ b/pkg/deployment/collector.go
@@ -39,6 +39,7 @@ func (c *Collector) Get() *appsv1.Deployment {
 
 	labels := c.labels()
 	trueVar := true
+	falseVar := false
 
 	args := append(c.jaeger.Spec.Collector.Options.ToArgs())
 
@@ -187,6 +188,7 @@ func (c *Collector) Get() *appsv1.Deployment {
 					Affinity:           commonSpec.Affinity,
 					Tolerations:        commonSpec.Tolerations,
 					SecurityContext:    commonSpec.SecurityContext,
+					EnableServiceLinks: &falseVar,
 				},
 			},
 		},

--- a/pkg/deployment/collector_test.go
+++ b/pkg/deployment/collector_test.go
@@ -539,6 +539,13 @@ func TestCollectorOTELConfig(t *testing.T) {
 	assert.True(t, hasVolumeMount("instance-collector-otel-config", d.Spec.Template.Spec.Containers[0].VolumeMounts))
 }
 
+func TestCollectorServiceLinks(t *testing.T) {
+	c := NewCollector(v1.NewJaeger(types.NamespacedName{Name: "my-instance"}))
+	dep := c.Get()
+	falseVar := false
+	assert.Equal(t, &falseVar, dep.Spec.Template.Spec.EnableServiceLinks)
+}
+
 func hasVolume(name string, volumes []corev1.Volume) bool {
 	for _, v := range volumes {
 		if v.Name == name {

--- a/pkg/deployment/ingester.go
+++ b/pkg/deployment/ingester.go
@@ -45,6 +45,7 @@ func (i *Ingester) Get() *appsv1.Deployment {
 
 	labels := i.labels()
 	trueVar := true
+	falseVar := false
 
 	args := append(i.jaeger.Spec.Ingester.Options.ToArgs())
 
@@ -162,6 +163,7 @@ func (i *Ingester) Get() *appsv1.Deployment {
 					Affinity:           commonSpec.Affinity,
 					Tolerations:        commonSpec.Tolerations,
 					SecurityContext:    commonSpec.SecurityContext,
+					EnableServiceLinks: &falseVar,
 				},
 			},
 		},

--- a/pkg/deployment/ingester_test.go
+++ b/pkg/deployment/ingester_test.go
@@ -453,3 +453,10 @@ func TestIngesterOTELConfig(t *testing.T) {
 	assert.True(t, hasVolume("instance-ingester-otel-config", d.Spec.Template.Spec.Volumes))
 	assert.True(t, hasVolumeMount("instance-ingester-otel-config", d.Spec.Template.Spec.Containers[0].VolumeMounts))
 }
+
+func TestIngesterServiceLinks(t *testing.T) {
+	ingester := NewIngester(newIngesterJaeger("TestIngesterServiceLinks"))
+	dep := ingester.Get()
+	falseVar := false
+	assert.Equal(t, &falseVar, dep.Spec.Template.Spec.EnableServiceLinks)
+}

--- a/pkg/deployment/query.go
+++ b/pkg/deployment/query.go
@@ -34,6 +34,7 @@ func (q *Query) Get() *appsv1.Deployment {
 	q.jaeger.Logger().Debug("Assembling a query deployment")
 	labels := q.labels()
 	trueVar := true
+	falseVar := false
 
 	args := append(q.jaeger.Spec.Query.Options.ToArgs())
 
@@ -155,6 +156,7 @@ func (q *Query) Get() *appsv1.Deployment {
 					Affinity:           commonSpec.Affinity,
 					Tolerations:        commonSpec.Tolerations,
 					SecurityContext:    commonSpec.SecurityContext,
+					EnableServiceLinks: &falseVar,
 				},
 			},
 		},

--- a/pkg/deployment/query_test.go
+++ b/pkg/deployment/query_test.go
@@ -315,3 +315,10 @@ func TestQueryOrderOfArguments(t *testing.T) {
 	assert.True(t, strings.HasPrefix(dep.Spec.Template.Spec.Containers[0].Args[1], "--b-option"))
 	assert.True(t, strings.HasPrefix(dep.Spec.Template.Spec.Containers[0].Args[2], "--c-option"))
 }
+
+func TestQueryServiceLinks(t *testing.T) {
+	query := NewQuery(v1.NewJaeger(types.NamespacedName{Name: "TestQueryServiceLinks"}))
+	dep := query.Get()
+	falseVar := false
+	assert.Equal(t, &falseVar, dep.Spec.Template.Spec.EnableServiceLinks)
+}


### PR DESCRIPTION
Disabled information about services being injected into pod's environment variables.

This prevents service links environmental variables from conflicting with internal Jaeger environmental variables. 

Image has been verified to work as expected. For verification purposes the image is available at:
fairfaxmedia/jaeger-operator:latest

Thanks to @dackroyd for assistance in these creating this fix.

Fixes #1158 
Relates to jaegertracing/jaeger#1986
