### PR TITLE
Remove explicitly setting agent's reporter type

### DIFF
--- a/deploy/examples/statefulset-manual-sidecar.yaml
+++ b/deploy/examples/statefulset-manual-sidecar.yaml
@@ -43,4 +43,3 @@ spec:
               protocol: TCP
           args:
             - --reporter.grpc.host-port=dns:///jaeger-collector-headless.example-ns:14250
-            - --reporter.type=grpc

--- a/deploy/examples/tracegen.yaml
+++ b/deploy/examples/tracegen.yaml
@@ -28,7 +28,6 @@ spec:
         image: jaegertracing/jaeger-agent:1.17
         args:
         - --reporter.grpc.host-port=dns:///simple-prod-collector-headless.default:14250
-        - --reporter.type=grpc
         env:
         - name: POD_NAME
           valueFrom:

--- a/pkg/deployment/agent.go
+++ b/pkg/deployment/agent.go
@@ -40,18 +40,14 @@ func (a *Agent) Get() *appsv1.DaemonSet {
 
 	args := append(a.jaeger.Spec.Agent.Options.ToArgs())
 
-	if len(util.FindItem("--reporter.type=", args)) == 0 {
-		args = append(args, "--reporter.type=grpc")
-
-		// we only add the grpc host if we are adding the reporter type and there's no explicit value yet
-		if len(util.FindItem("--reporter.grpc.host-port=", args)) == 0 {
-			args = append(args, fmt.Sprintf("--reporter.grpc.host-port=dns:///%s.%s:14250", service.GetNameForHeadlessCollectorService(a.jaeger), a.jaeger.Namespace))
-		}
+	// we only add the grpc host if we are adding the reporter type and there's no explicit value yet
+	if len(util.FindItem("--reporter.grpc.host-port=", args)) == 0 {
+		args = append(args, fmt.Sprintf("--reporter.grpc.host-port=dns:///%s.%s:14250", service.GetNameForHeadlessCollectorService(a.jaeger), a.jaeger.Namespace))
 	}
 
 	// Enable tls by default for openshift platform
 	if viper.GetString("platform") == v1.FlagPlatformOpenShift {
-		if len(util.FindItem("--reporter.type=grpc", args)) > 0 && len(util.FindItem("--reporter.grpc.tls=true", args)) == 0 {
+		if len(util.FindItem("--reporter.grpc.tls=true", args)) == 0 {
 			args = append(args, "--reporter.grpc.tls.enabled=true")
 			args = append(args, fmt.Sprintf("--reporter.grpc.tls.ca=%s", ca.ServiceCAPath))
 			args = append(args, fmt.Sprintf("--reporter.grpc.tls.server-name=%s.%s.svc.cluster.local", service.GetNameForHeadlessCollectorService(a.jaeger), a.jaeger.Namespace))

--- a/pkg/inject/sidecar.go
+++ b/pkg/inject/sidecar.go
@@ -167,18 +167,14 @@ func getJaeger(name string, jaegers *v1.JaegerList) *v1.Jaeger {
 func container(jaeger *v1.Jaeger, dep *appsv1.Deployment) corev1.Container {
 	args := append(jaeger.Spec.Agent.Options.ToArgs())
 
-	if len(util.FindItem("--reporter.type=", args)) == 0 {
-		args = append(args, "--reporter.type=grpc")
-
-		// we only add the grpc host if we are adding the reporter type and there's no explicit value yet
-		if len(util.FindItem("--reporter.grpc.host-port=", args)) == 0 {
-			args = append(args, fmt.Sprintf("--reporter.grpc.host-port=dns:///%s.%s.svc:14250", service.GetNameForHeadlessCollectorService(jaeger), jaeger.Namespace))
-		}
+	// we only add the grpc host if we are adding the reporter type and there's no explicit value yet
+	if len(util.FindItem("--reporter.grpc.host-port=", args)) == 0 {
+		args = append(args, fmt.Sprintf("--reporter.grpc.host-port=dns:///%s.%s.svc:14250", service.GetNameForHeadlessCollectorService(jaeger), jaeger.Namespace))
 	}
 
 	// Enable tls by default for openshift platform
 	if viper.GetString("platform") == v1.FlagPlatformOpenShift {
-		if len(util.FindItem("--reporter.type=grpc", args)) > 0 && len(util.FindItem("--reporter.grpc.tls.enabled=true", args)) == 0 {
+		if len(util.FindItem("--reporter.grpc.tls.enabled=true", args)) == 0 {
 			args = append(args, "--reporter.grpc.tls.enabled=true")
 			args = append(args, fmt.Sprintf("--reporter.grpc.tls.ca=%s", ca.ServiceCAPath))
 		}


### PR DESCRIPTION
Tchannel reporter has been removed in 1.18.0
The GRPC reporter was set as default in 1.11.0


This also helps with using OTEL based images since they do not expose `--reporter.type` flag.