### PR TITLE
Temporary workaround for intermittent daemonset test failures

### DIFF
--- a/test/e2e/daemonset_test.go
+++ b/test/e2e/daemonset_test.go
@@ -228,6 +228,7 @@ func jaegerAgentAsDaemonsetDefinition(namespace string, name string) *v1.Jaeger 
 			Strategy: v1.DeploymentStrategyAllInOne,
 			AllInOne: v1.JaegerAllInOneSpec{},
 			Agent: v1.JaegerAgentSpec{
+				Image:    "quay.io/jpkroehling/jaeger-agent:pr1176", // Remove once https://github.com/jaegertracing/jaeger-operator/issues/1175 is fixed
 				Strategy: "DaemonSet",
 				Options: v1.NewOptions(map[string]interface{}{
 					"log-level": "debug",


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com>

This is a temporary workaround for https://github.com/jaegertracing/jaeger-operator/issues/1175 which depends on this fix: https://github.com/jaegertracing/jaeger/issues/2443 becoming available.



