### PR TITLE
Add note on ingress-controller and include namespace in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ The Jaeger Operator is an implementation of a [Kubernetes Operator](https://kube
 
 ## Getting started
 
+Firstly, ensure an [ingress-controller is deployed](https://kubernetes.github.io/ingress-nginx/deploy/).
+
 To install the operator, run:
 ```
 kubectl create namespace observability
@@ -39,7 +41,7 @@ EOF
 This will create a Jaeger instance named `simplest`. The Jaeger UI is served via the `Ingress`, like:
 
 ```console
-$ kubectl get ingress
+$ kubectl get -n observability ingress
 NAME             HOSTS     ADDRESS          PORTS     AGE
 simplest-query   *         192.168.122.34   80        3m
 ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The Jaeger Operator is an implementation of a [Kubernetes Operator](https://kube
 
 ## Getting started
 
-Firstly, ensure an [ingress-controller is deployed](https://kubernetes.github.io/ingress-nginx/deploy/).
+Firstly, ensure an [ingress-controller is deployed](https://kubernetes.github.io/ingress-nginx/deploy/). When using `minikube`, you can use the `ingress` add-on: `minikube start --addons=ingress`
 
 To install the operator, run:
 ```


### PR DESCRIPTION
This PR reminds the Kubernetes novice to ensure an ingress-controller is deployed otherwise an ingress address won't be assigned.

Ingress is also deployed in the namespace `observability`, so I've added this in the `kubectl` command.

Please let me know if this is meant to be assumed knowledge and doesn't require explicit documentation. :)