### PR TITLE
Make the generate-csv command generate the old-style manifests

### DIFF
--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -40,6 +40,7 @@ sed "s~${PREVIOUS_VERSION}~${OPERATOR_VERSION}~gi" -i versions.txt
 
 operator-sdk generate csv \
     --csv-channel=stable \
+    --make-manifests=false \
     --csv-version=${OPERATOR_VERSION} \
     --from-version=${PREVIOUS_VERSION}
 


### PR DESCRIPTION
Yet another operator-sdk breaking change, apparently. On Operator SDK 0.18.1, a new flag is needed to get the manifests in the older format, which updates the package.yaml. Without this update, CI builds with the operatorhub PRs will fail (see operator-framework/community-operators#2251 and operator-framework/community-operators#2250).

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>