### PR TITLE
Added configuration for the agent's securityContext

### DIFF
--- a/deploy/crds/jaegertracing.io_jaegers_crd.yaml
+++ b/deploy/crds/jaegertracing.io_jaegers_crd.yaml
@@ -662,6 +662,56 @@ spec:
                   type: object
                 serviceAccount:
                   type: string
+                sidecarSecurityContext:
+                  properties:
+                    allowPrivilegeEscalation:
+                      type: boolean
+                    capabilities:
+                      properties:
+                        add:
+                          items:
+                            type: string
+                          type: array
+                        drop:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    privileged:
+                      type: boolean
+                    procMount:
+                      type: string
+                    readOnlyRootFilesystem:
+                      type: boolean
+                    runAsGroup:
+                      format: int64
+                      type: integer
+                    runAsNonRoot:
+                      type: boolean
+                    runAsUser:
+                      format: int64
+                      type: integer
+                    seLinuxOptions:
+                      properties:
+                        level:
+                          type: string
+                        role:
+                          type: string
+                        type:
+                          type: string
+                        user:
+                          type: string
+                      type: object
+                    windowsOptions:
+                      properties:
+                        gmsaCredentialSpec:
+                          type: string
+                        gmsaCredentialSpecName:
+                          type: string
+                        runAsUserName:
+                          type: string
+                      type: object
+                  type: object
                 strategy:
                   type: string
                 tolerations:

--- a/pkg/apis/jaegertracing/v1/jaeger_types.go
+++ b/pkg/apis/jaegertracing/v1/jaeger_types.go
@@ -383,6 +383,9 @@ type JaegerAgentSpec struct {
 
 	// +optional
 	Config FreeForm `json:"config,omitempty"`
+
+	// +optional
+	SidecarSecurityContext *v1.SecurityContext `json:"sidecarSecurityContext,omitempty"`
 }
 
 // JaegerStorageSpec defines the common storage options to be used for the query and collector

--- a/pkg/apis/jaegertracing/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/jaegertracing/v1/zz_generated.deepcopy.go
@@ -133,6 +133,11 @@ func (in *JaegerAgentSpec) DeepCopyInto(out *JaegerAgentSpec) {
 	in.Options.DeepCopyInto(&out.Options)
 	in.JaegerCommonSpec.DeepCopyInto(&out.JaegerCommonSpec)
 	in.Config.DeepCopyInto(&out.Config)
+	if in.SidecarSecurityContext != nil {
+		in, out := &in.SidecarSecurityContext, &out.SidecarSecurityContext
+		*out = new(corev1.SecurityContext)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/apis/jaegertracing/v1/zz_generated.openapi.go
+++ b/pkg/apis/jaegertracing/v1/zz_generated.openapi.go
@@ -318,11 +318,16 @@ func schema_pkg_apis_jaegertracing_v1_JaegerAgentSpec(ref common.ReferenceCallba
 							Ref: ref("./pkg/apis/jaegertracing/v1.FreeForm"),
 						},
 					},
+					"sidecarSecurityContext": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("k8s.io/api/core/v1.SecurityContext"),
+						},
+					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"./pkg/apis/jaegertracing/v1.FreeForm", "./pkg/apis/jaegertracing/v1.Options", "k8s.io/api/core/v1.Affinity", "k8s.io/api/core/v1.LocalObjectReference", "k8s.io/api/core/v1.PodSecurityContext", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/api/core/v1.Toleration", "k8s.io/api/core/v1.Volume", "k8s.io/api/core/v1.VolumeMount"},
+			"./pkg/apis/jaegertracing/v1.FreeForm", "./pkg/apis/jaegertracing/v1.Options", "k8s.io/api/core/v1.Affinity", "k8s.io/api/core/v1.LocalObjectReference", "k8s.io/api/core/v1.PodSecurityContext", "k8s.io/api/core/v1.ResourceRequirements", "k8s.io/api/core/v1.SecurityContext", "k8s.io/api/core/v1.Toleration", "k8s.io/api/core/v1.Volume", "k8s.io/api/core/v1.VolumeMount"},
 	}
 }
 

--- a/pkg/inject/sidecar.go
+++ b/pkg/inject/sidecar.go
@@ -274,8 +274,9 @@ func container(jaeger *v1.Jaeger, dep *appsv1.Deployment) corev1.Container {
 				Name:          "admin-http",
 			},
 		},
-		Resources:    commonSpec.Resources,
-		VolumeMounts: volumesAndMountsSpec.VolumeMounts,
+		Resources:       commonSpec.Resources,
+		SecurityContext: jaeger.Spec.Agent.SidecarSecurityContext,
+		VolumeMounts:    volumesAndMountsSpec.VolumeMounts,
 	}
 }
 

--- a/pkg/inject/sidecar_test.go
+++ b/pkg/inject/sidecar_test.go
@@ -850,3 +850,16 @@ func TestInjectSidecarOnOpenShift(t *testing.T) {
 	assert.Len(t, dep.Spec.Template.Spec.Containers[1].VolumeMounts, 2)
 	assert.Len(t, dep.Spec.Template.Spec.Volumes, 2)
 }
+
+func TestSidecarWithSecurityContext(t *testing.T) {
+	var user, group int64 = 111, 222
+	expectedSecurityContext := &corev1.SecurityContext{RunAsUser: &user, RunAsGroup: &group}
+
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestSidecarWithSecurityContext"})
+	jaeger.Spec.Agent.SidecarSecurityContext = expectedSecurityContext
+
+	dep := dep(map[string]string{}, map[string]string{})
+	dep = Sidecar(jaeger, dep)
+	assert.Len(t, dep.Spec.Template.Spec.Containers, 2)
+	assert.Equal(t, dep.Spec.Template.Spec.Containers[1].SecurityContext, expectedSecurityContext)
+}


### PR DESCRIPTION
Unfortunately, I can't just use the Jaeger CommonSpec's securityContext as that is a `PodSecurityContext` whereas the sidecar can only have a `SecurityContext`. This required me to add an additional config option `containerSecurityContext`. This does add some redundancy as the `Jaeger.Spec.SecurityContext` is not reused.

Is `sidecarContainerSecurityContext` a better name for this config option as the other agent deployments do use the default pod security context?

Resolves #1186 