### PR TITLE
Create service accounts before storage dependencies/init schemas

### DIFF
--- a/pkg/controller/jaeger/jaeger_controller.go
+++ b/pkg/controller/jaeger/jaeger_controller.go
@@ -297,12 +297,12 @@ func (r *ReconcileJaeger) apply(ctx context.Context, jaeger v1.Jaeger, str strat
 		}).Warn("A Kafka cluster should be provisioned, but provisioning is disabled for this Jaeger Operator")
 	}
 
-	// storage dependencies have to be deployed after ES is ready
-	if err := r.handleDependencies(ctx, str); err != nil {
+	if err := r.applyAccounts(ctx, jaeger, str.Accounts()); err != nil {
 		return jaeger, tracing.HandleError(err, span)
 	}
 
-	if err := r.applyAccounts(ctx, jaeger, str.Accounts()); err != nil {
+	// storage dependencies have to be deployed after ES is ready
+	if err := r.handleDependencies(ctx, str); err != nil {
 		return jaeger, tracing.HandleError(err, span)
 	}
 


### PR DESCRIPTION
The https://github.com/jaegertracing/jaeger-operator/pull/1144 added SA to rollover. However the rollover is also used to init storage schema (dependencies) and the service accounts were created after storage dependencies which was causing errors.



Signed-off-by: Pavol Loffay <ploffay@redhat.com>