### PR TITLE
remove metrics and servicemonitor

### DIFF
--- a/deploy/service_monitor.yaml
+++ b/deploy/service_monitor.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: jaeger-operator-metrics
+  labels:
+    name: jaeger-operator
+spec:
+  endpoints:
+    - path: /metrics
+      port: http-metrics
+    - path: /metrics
+      port: cr-metrics
+  selector:
+    matchLabels:
+      name: jaeger-operator


### PR DESCRIPTION
Currently jaeger-operator is creating its own service and serviceMonitor objects in Kubernetes. This seems to be bad practice and the functions `metrics.CreateMetricsService` and `metrics.CreateServiceMonitors` are removed in the operator-sdk by 1.0.0 https://github.com/operator-framework/operator-sdk/pull/3484 .

Instead, the service and servicemonitor objects are to be created with the Helm chart https://github.com/jaegertracing/helm-charts/pull/152