### PR TITLE
Adjusted OLM manifests for 1.20, adjusted release script

### DIFF
--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -47,7 +47,7 @@ operator-sdk generate csv \
 # changes to deploy/olm-catalog/jaeger-operator/manifests
 sed "s~containerImage: docker.io/jaegertracing/jaeger-operator:${PREVIOUS_VERSION}~containerImage: docker.io/jaegertracing/jaeger-operator:${OPERATOR_VERSION}~i" -i deploy/olm-catalog/jaeger-operator/manifests/jaeger-operator.clusterserviceversion.yaml
 sed "s~image: jaegertracing/jaeger-operator:${PREVIOUS_VERSION}~image: jaegertracing/jaeger-operator:${OPERATOR_VERSION}~i" -i deploy/olm-catalog/jaeger-operator/manifests/jaeger-operator.clusterserviceversion.yaml
-sed "s~replaces: jaeger-operator.v.*~replaces: jaeger-operator.v${OPERATOR_VERSION}~i" -i deploy/olm-catalog/jaeger-operator/manifests/jaeger-operator.clusterserviceversion.yaml
+sed "s~replaces: jaeger-operator.v.*~replaces: jaeger-operator.v${PREVIOUS_VERSION}~i" -i deploy/olm-catalog/jaeger-operator/manifests/jaeger-operator.clusterserviceversion.yaml
 sed "s~version: ${PREVIOUS_VERSION}~version: ${OPERATOR_VERSION}~i" -i deploy/olm-catalog/jaeger-operator/manifests/jaeger-operator.clusterserviceversion.yaml
 sed "s~name: jaeger-operator.v${PREVIOUS_VERSION}~name: jaeger-operator.v${OPERATOR_VERSION}~i" -i deploy/olm-catalog/jaeger-operator/manifests/jaeger-operator.clusterserviceversion.yaml
 

--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -44,8 +44,15 @@ operator-sdk generate csv \
     --csv-version=${OPERATOR_VERSION} \
     --from-version=${PREVIOUS_VERSION}
 
-# changes to deploy/olm-catalog/jaeger-operator/newversion/...
+# changes to deploy/olm-catalog/jaeger-operator/manifests
 sed "s~containerImage: docker.io/jaegertracing/jaeger-operator:${PREVIOUS_VERSION}~containerImage: docker.io/jaegertracing/jaeger-operator:${OPERATOR_VERSION}~i" -i deploy/olm-catalog/jaeger-operator/manifests/jaeger-operator.clusterserviceversion.yaml
+sed "s~image: jaegertracing/jaeger-operator:${PREVIOUS_VERSION}~image: jaegertracing/jaeger-operator:${OPERATOR_VERSION}~i" -i deploy/olm-catalog/jaeger-operator/manifests/jaeger-operator.clusterserviceversion.yaml
+sed "s~replaces: jaeger-operator.v.*~replaces: jaeger-operator.v${OPERATOR_VERSION}~i" -i deploy/olm-catalog/jaeger-operator/manifests/jaeger-operator.clusterserviceversion.yaml
+sed "s~version: ${PREVIOUS_VERSION}~version: ${OPERATOR_VERSION}~i" -i deploy/olm-catalog/jaeger-operator/manifests/jaeger-operator.clusterserviceversion.yaml
+sed "s~name: jaeger-operator.v${PREVIOUS_VERSION}~name: jaeger-operator.v${OPERATOR_VERSION}~i" -i deploy/olm-catalog/jaeger-operator/manifests/jaeger-operator.clusterserviceversion.yaml
+
+# changes to deploy/olm-catalog/jaeger-operator/jaeger-operator.package.yaml
+sed "s~currentCSV: jaeger-operator.v${PREVIOUS_VERSION}~currentCSV: jaeger-operator.v${OPERATOR_VERSION}~i" -i deploy/olm-catalog/jaeger-operator/jaeger-operator.package.yaml
 
 git diff -s --exit-code
 if [[ $? == 0 ]]; then

--- a/deploy/olm-catalog/jaeger-operator/jaeger-operator.package.yaml
+++ b/deploy/olm-catalog/jaeger-operator/jaeger-operator.package.yaml
@@ -1,5 +1,5 @@
 channels:
-- currentCSV: jaeger-operator.v1.18.1
+- currentCSV: jaeger-operator.v1.20.0
   name: stable
 defaultChannel: stable
 packageName: jaeger

--- a/deploy/olm-catalog/jaeger-operator/manifests/jaeger-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/jaeger-operator/manifests/jaeger-operator.clusterserviceversion.yaml
@@ -538,7 +538,7 @@ spec:
   maturity: alpha
   provider:
     name: CNCF
-  replaces: jaeger-operator.v1.20.0
+  replaces: jaeger-operator.v1.19.0
   selector:
     matchLabels:
       name: jaeger-operator

--- a/deploy/olm-catalog/jaeger-operator/manifests/jaeger-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/jaeger-operator/manifests/jaeger-operator.clusterserviceversion.yaml
@@ -70,7 +70,7 @@ metadata:
       distributed systems
     repository: https://github.com/jaegertracing/jaeger-operator
     support: Jaeger Community
-  name: jaeger-operator.v1.19.0
+  name: jaeger-operator.v1.20.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -337,7 +337,7 @@ spec:
                       fieldPath: metadata.namespace
                 - name: OPERATOR_NAME
                   value: jaeger-operator
-                image: jaegertracing/jaeger-operator:1.19.0
+                image: jaegertracing/jaeger-operator:1.20.0
                 imagePullPolicy: Always
                 name: jaeger-operator
                 ports:
@@ -538,8 +538,8 @@ spec:
   maturity: alpha
   provider:
     name: CNCF
-  replaces: jaeger-operator.v1.18.1
+  replaces: jaeger-operator.v1.20.0
   selector:
     matchLabels:
       name: jaeger-operator
-  version: 1.19.0
+  version: 1.20.0


### PR DESCRIPTION
After the release of 1.20, prior to updating the Operator Hub, I noticed that the operator-sdk didn't automatically bump some fields for 1.20.

As a result, I added a few extra sed commands to bump the versions to the release script and ran the commands separately against the existing manifests, making them up to date for 1.20.

﻿Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
