### PR TITLE
Simplify OTEL related environment variables

### DIFF
--- a/.ci/run-e2e-tests.sh
+++ b/.ci/run-e2e-tests.sh
@@ -13,7 +13,8 @@ if [ "${TEST_GROUP}" = "es" ]; then
     make e2e-tests-es
 elif [ "${TEST_GROUP}" = "es-otel" ]; then
     echo "Running elasticsearch tests with OTEL collector"
-    export USE_OTEL_COLLECTOR=true
+    export SPECIFY_OTEL_IMAGES=true
+    export SPECIFY_OTEL_CONFIG=true
     make es
     make e2e-tests-es
 elif [ "${TEST_GROUP}" = "es-self-provisioned" ]; then
@@ -40,8 +41,8 @@ then
 elif [ "${TEST_GROUP}" = "streaming-otel" ]
 then
     echo "Running Streaming Tests with OTEL collector and ingester"
-    export USE_OTEL_COLLECTOR=true
-    export USE_OTEL_INGESTER=true
+    export SPECIFY_OTEL_IMAGES=true
+    export SPECIFY_OTEL_CONFIG=true
     make e2e-tests-streaming
 elif [ "${TEST_GROUP}" = "examples1" ]
 then
@@ -62,9 +63,8 @@ then
 elif [ "${TEST_GROUP}" = "smoke-otel" ]
 then
     echo "Running Smoke Tests with OTEL collector"
-    export USE_OTEL_COLLECTOR=true
-    export USE_OTEL_AGENT=true
-    export USE_OTEL_ALL_IN_ONE=true
+    export SPECIFY_OTEL_IMAGES=true
+    export SPECIFY_OTEL_CONFIG=true
     make e2e-tests-smoke
 else
     echo "Unknown TEST_GROUP [${TEST_GROUP}]"; exit 1

--- a/test/e2e/self_provisioned_elasticsearch_kafka_test.go
+++ b/test/e2e/self_provisioned_elasticsearch_kafka_test.go
@@ -23,11 +23,11 @@ import (
 	esv1 "github.com/jaegertracing/jaeger-operator/pkg/storage/elasticsearch/v1"
 )
 
-type SelfProvisionedWithKafkaTestSuite struct {
+type SelfProvisionedESWithKafkaTestSuite struct {
 	suite.Suite
 }
 
-func (suite *SelfProvisionedWithKafkaTestSuite) SetupSuite() {
+func (suite *SelfProvisionedESWithKafkaTestSuite) SetupSuite() {
 	t = suite.T()
 	if !isOpenShift(t) {
 		t.Skipf("Test %s is currently supported only on OpenShift because es-operator runs only on OpenShift\n", t.Name())
@@ -66,23 +66,23 @@ func (suite *SelfProvisionedWithKafkaTestSuite) SetupSuite() {
 	require.NotNil(t, namespace, "GetID failed")
 }
 
-func (suite *SelfProvisionedWithKafkaTestSuite) TearDownSuite() {
+func (suite *SelfProvisionedESWithKafkaTestSuite) TearDownSuite() {
 	handleSuiteTearDown()
 }
 
 func TestSelfProvisionedWithKafkaSuite(t *testing.T) {
-	suite.Run(t, new(SelfProvisionedWithKafkaTestSuite))
+	suite.Run(t, new(SelfProvisionedESWithKafkaTestSuite))
 }
 
-func (suite *SelfProvisionedWithKafkaTestSuite) SetupTest() {
+func (suite *SelfProvisionedESWithKafkaTestSuite) SetupTest() {
 	t = suite.T()
 }
 
-func (suite *SelfProvisionedWithKafkaTestSuite) AfterTest(suiteName, testName string) {
+func (suite *SelfProvisionedESWithKafkaTestSuite) AfterTest(suiteName, testName string) {
 	handleTestFailure()
 }
 
-func (suite *SelfProvisionedWithKafkaTestSuite) TestSelfProvisionedESAndKafkaSmokeTest() {
+func (suite *SelfProvisionedESWithKafkaTestSuite) TestSelfProvisionedESAndKafkaSmokeTest() {
 	// create jaeger custom resource
 	jaegerInstanceName := "simple-prod"
 	exampleJaeger := getJaegerSelfProvisionedESAndKafka(jaegerInstanceName)

--- a/test/e2e/self_provisioned_elasticsearch_kafka_test.go
+++ b/test/e2e/self_provisioned_elasticsearch_kafka_test.go
@@ -23,11 +23,11 @@ import (
 	esv1 "github.com/jaegertracing/jaeger-operator/pkg/storage/elasticsearch/v1"
 )
 
-type SelfProvisionedTestSuite struct {
+type SelfProvisionedWithKafkaTestSuite struct {
 	suite.Suite
 }
 
-func (suite *SelfProvisionedTestSuite) SetupSuite() {
+func (suite *SelfProvisionedWithKafkaTestSuite) SetupSuite() {
 	t = suite.T()
 	if !isOpenShift(t) {
 		t.Skipf("Test %s is currently supported only on OpenShift because es-operator runs only on OpenShift\n", t.Name())
@@ -66,26 +66,26 @@ func (suite *SelfProvisionedTestSuite) SetupSuite() {
 	require.NotNil(t, namespace, "GetID failed")
 }
 
-func (suite *SelfProvisionedTestSuite) TearDownSuite() {
+func (suite *SelfProvisionedWithKafkaTestSuite) TearDownSuite() {
 	handleSuiteTearDown()
 }
 
-func TestSelfProvisionedSuite(t *testing.T) {
-	suite.Run(t, new(SelfProvisionedTestSuite))
+func TestSelfProvisionedWithKafkaSuite(t *testing.T) {
+	suite.Run(t, new(SelfProvisionedWithKafkaTestSuite))
 }
 
-func (suite *SelfProvisionedTestSuite) SetupTest() {
+func (suite *SelfProvisionedWithKafkaTestSuite) SetupTest() {
 	t = suite.T()
 }
 
-func (suite *SelfProvisionedTestSuite) AfterTest(suiteName, testName string) {
+func (suite *SelfProvisionedWithKafkaTestSuite) AfterTest(suiteName, testName string) {
 	handleTestFailure()
 }
 
-func (suite *SelfProvisionedTestSuite) TestSelfProvisionedESAndKafkaSmokeTest() {
+func (suite *SelfProvisionedWithKafkaTestSuite) TestSelfProvisionedESAndKafkaSmokeTest() {
 	// create jaeger custom resource
 	jaegerInstanceName := "simple-prod"
-	exampleJaeger := getJaegerSelfProvisionedESAndKafka(jaegerInstanceName, testOtelCollector)
+	exampleJaeger := getJaegerSelfProvisionedESAndKafka(jaegerInstanceName)
 	err := fw.Client.Create(goctx.TODO(), exampleJaeger, &framework.CleanupOptions{TestContext: ctx, Timeout: timeout, RetryInterval: retryInterval})
 	require.NoError(t, err, "Error deploying example Jaeger")
 	defer undeployJaegerInstance(exampleJaeger)
@@ -112,10 +112,10 @@ func (suite *SelfProvisionedTestSuite) TestSelfProvisionedESAndKafkaSmokeTest() 
 	ProductionSmokeTest(jaegerInstanceName)
 
 	// Make sure we were using the correct collector image
-	verifyCollectorImage(jaegerInstanceName, namespace, testOtelCollector)
+	verifyCollectorImage(jaegerInstanceName, namespace, specifyOtelImages)
 }
 
-func getJaegerSelfProvisionedESAndKafka(instanceName string, useOtelCollector bool) *v1.Jaeger {
+func getJaegerSelfProvisionedESAndKafka(instanceName string) *v1.Jaeger {
 	ingressEnabled := true
 	jaegerInstance := &v1.Jaeger{
 		TypeMeta: metav1.TypeMeta{
@@ -145,10 +145,14 @@ func getJaegerSelfProvisionedESAndKafka(instanceName string, useOtelCollector bo
 		},
 	}
 
-	if useOtelCollector {
+	if specifyOtelImages {
 		logrus.Infof("Using OTEL collector for %s", instanceName)
 		jaegerInstance.Spec.Collector.Image = otelCollectorImage
+	}
+
+	if specifyOtelConfig {
 		jaegerInstance.Spec.Collector.Config = v1.NewFreeForm(getOtelConfigForHealthCheckPort("14269"))
+
 	}
 
 	return jaegerInstance

--- a/test/e2e/sidecar_namespace_test.go
+++ b/test/e2e/sidecar_namespace_test.go
@@ -62,7 +62,7 @@ func (suite *SidecarNamespaceTestSuite) TestSidecarNamespace() {
 	cleanupOptions := &framework.CleanupOptions{TestContext: ctx, Timeout: timeout, RetryInterval: retryInterval}
 
 	jaegerInstanceName := "agent-as-sidecar-namespace"
-	j := createJaegerAgentAsSidecarInstance(jaegerInstanceName, namespace, testOtelAgent, testOtelAllInOne)
+	j := createJaegerAgentAsSidecarInstance(jaegerInstanceName, namespace)
 	defer undeployJaegerInstance(j)
 
 	dep := getVertxDefinition(namespace, map[string]string{})

--- a/test/e2e/sidecar_test.go
+++ b/test/e2e/sidecar_test.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -239,7 +240,7 @@ func createJaegerAgentAsSidecarInstance(name, namespace string) *v1.Jaeger {
 	err := fw.Client.Create(goctx.TODO(), j, cleanupOptions)
 	require.NoError(t, err, "Failed to create jaeger instance")
 
-	err = e2eutil.WaitForDeployment(t, fw.KubeClient, namespace, name, 1, retryInterval, timeout)
+	err = e2eutil.WaitForDeployment(t, fw.KubeClient, namespace, name, 1, retryInterval, timeout+1*time.Minute)
 	require.NoError(t, err, "Error waiting for Jaeger instance deployment")
 
 	return j

--- a/test/e2e/sidecar_test.go
+++ b/test/e2e/sidecar_test.go
@@ -70,10 +70,10 @@ func (suite *SidecarTestSuite) TestSidecar() {
 	cleanupOptions := &framework.CleanupOptions{TestContext: ctx, Timeout: timeout, RetryInterval: retryInterval}
 
 	firstJaegerInstanceName := "agent-as-sidecar"
-	firstJaegerInstance := createJaegerAgentAsSidecarInstance(firstJaegerInstanceName, namespace, testOtelAgent, testOtelAllInOne)
+	firstJaegerInstance := createJaegerAgentAsSidecarInstance(firstJaegerInstanceName, namespace)
 	defer undeployJaegerInstance(firstJaegerInstance)
 
-	verifyAllInOneImage(firstJaegerInstanceName, namespace, testOtelAllInOne)
+	verifyAllInOneImage(firstJaegerInstanceName, namespace, specifyOtelImages)
 
 	vertxDeploymentName := "vertx-create-span-sidecar"
 	dep := getVertxDefinition(vertxDeploymentName, map[string]string{inject.Annotation: "true"})
@@ -103,7 +103,7 @@ func (suite *SidecarTestSuite) TestSidecar() {
 
 	/* Testing other instance */
 	secondJaegerInstanceName := "agent-as-sidecar2"
-	secondJaegerInstance := createJaegerAgentAsSidecarInstance(secondJaegerInstanceName, namespace, testOtelAgent, testOtelAllInOne)
+	secondJaegerInstance := createJaegerAgentAsSidecarInstance(secondJaegerInstanceName, namespace)
 	defer undeployJaegerInstance(secondJaegerInstance)
 
 	persisted := &appsv1.Deployment{}
@@ -135,7 +135,7 @@ func (suite *SidecarTestSuite) TestSidecar() {
 		return len(resp.Data) > 0, nil
 	})
 	require.NoError(t, err, "Failed waiting for expected content")
-	verifyAgentImage(vertxDeploymentName, namespace, testOtelAgent)
+	verifyAgentImage(vertxDeploymentName, namespace, specifyOtelImages)
 }
 
 func getVertxDefinition(deploymentName string, annotations map[string]string) *appsv1.Deployment {
@@ -193,7 +193,7 @@ func getVertxDefinition(deploymentName string, annotations map[string]string) *a
 	return dep
 }
 
-func createJaegerAgentAsSidecarInstance(name, namespace string, useOtelAgent, useOtelAllInOne bool) *v1.Jaeger {
+func createJaegerAgentAsSidecarInstance(name, namespace string) *v1.Jaeger {
 	cleanupOptions := &framework.CleanupOptions{TestContext: ctx, Timeout: timeout, RetryInterval: retryInterval}
 
 	j := &v1.Jaeger{
@@ -224,15 +224,15 @@ func createJaegerAgentAsSidecarInstance(name, namespace string, useOtelAgent, us
 		},
 	}
 
-	if useOtelAllInOne {
+	if specifyOtelImages {
 		logrus.Infof("Using OTEL AllInOne image for %s", name)
 		j.Spec.AllInOne.Image = otelAllInOneImage
-		j.Spec.AllInOne.Config = v1.NewFreeForm(getOtelConfigForHealthCheckPort("14269"))
-	}
-
-	if useOtelAgent {
 		logrus.Infof("Using OTEL Agent for %s", name)
 		j.Spec.Agent.Image = otelAgentImage
+	}
+
+	if specifyOtelConfig {
+		j.Spec.AllInOne.Config = v1.NewFreeForm(getOtelConfigForHealthCheckPort("14269"))
 		j.Spec.Agent.Config = v1.NewFreeForm(getOtelConfigForHealthCheckPort("14269"))
 	}
 

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -47,10 +47,8 @@ var (
 	usingJaegerViaOLM  = getBoolEnv("JAEGER_OLM", false)
 	saveLogs           = getBoolEnv("SAVE_LOGS", false)
 	skipCassandraTests = getBoolEnv("SKIP_CASSANDRA_TESTS", false)
-	testOtelCollector  = getBoolEnv("USE_OTEL_COLLECTOR", false)
-	testOtelIngester   = getBoolEnv("USE_OTEL_INGESTER", false)
-	testOtelAgent      = getBoolEnv("USE_OTEL_AGENT", false)
-	testOtelAllInOne   = getBoolEnv("USE_OTEL_ALL_IN_ONE", false)
+	specifyOtelImages  = getBoolEnv("SPECIFY_OTEL_IMAGES", false)
+	specifyOtelConfig  = getBoolEnv("SPECIFY_OTEL_CONFIG", false)
 
 	esServerUrls         = "http://elasticsearch." + storageNamespace + ".svc:9200"
 	cassandraServiceName = "cassandra." + storageNamespace + ".svc"


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com>

This PR reduces the number of OTEL related EVs used by tests to two, and separates their functions.  If SPECIFY_OTEL_IMAGES is true the tests will explicitly add otel image names to CRs.  If SPECIFY_OTEL_CONFIG is true we will remove config values that are not used by the OTEL collector or ingester.
