### PR TITLE
Allow overriding the vertx example app image and config values

### DIFF
--- a/test/e2e/daemonset_test.go
+++ b/test/e2e/daemonset_test.go
@@ -171,7 +171,7 @@ func getVertxDeployment(namespace string, selector map[string]string) *appsv1.De
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{
-						Image: "jaegertracing/vertx-create-span:operator-e2e-tests",
+						Image: vertxExampleImage,
 						Name:  "vertx-create-span",
 						Env: []corev1.EnvVar{
 							corev1.EnvVar{
@@ -195,7 +195,8 @@ func getVertxDeployment(namespace string, selector map[string]string) *appsv1.De
 									Port: intstr.FromInt(8080),
 								},
 							},
-							InitialDelaySeconds: 1,
+							InitialDelaySeconds: vertxDelaySeconds,
+							TimeoutSeconds:      vertxTimeoutSeconds,
 						},
 						LivenessProbe: &corev1.Probe{
 							Handler: corev1.Handler{
@@ -204,7 +205,8 @@ func getVertxDeployment(namespace string, selector map[string]string) *appsv1.De
 									Port: intstr.FromInt(8080),
 								},
 							},
-							InitialDelaySeconds: 1,
+							InitialDelaySeconds: vertxDelaySeconds,
+							TimeoutSeconds:      vertxTimeoutSeconds,
 						},
 					}},
 				},

--- a/test/e2e/sidecar_test.go
+++ b/test/e2e/sidecar_test.go
@@ -161,7 +161,7 @@ func getVertxDefinition(deploymentName string, annotations map[string]string) *a
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{
-						Image: "jaegertracing/vertx-create-span:operator-e2e-tests",
+						Image: vertxExampleImage,
 						Name:  deploymentName,
 						Ports: []corev1.ContainerPort{
 							{
@@ -175,7 +175,8 @@ func getVertxDefinition(deploymentName string, annotations map[string]string) *a
 									Port: intstr.FromInt(8080),
 								},
 							},
-							InitialDelaySeconds: 1,
+							InitialDelaySeconds: vertxDelaySeconds,
+							TimeoutSeconds:      vertxTimeoutSeconds,
 						},
 						LivenessProbe: &corev1.Probe{
 							Handler: corev1.Handler{
@@ -184,7 +185,8 @@ func getVertxDefinition(deploymentName string, annotations map[string]string) *a
 									Port: intstr.FromInt(8080),
 								},
 							},
-							InitialDelaySeconds: 1,
+							InitialDelaySeconds: vertxDelaySeconds,
+							TimeoutSeconds:      vertxTimeoutSeconds,
 						},
 					}},
 				},

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -58,6 +58,9 @@ var (
 	otelIngesterImage    = "jaegertracing/jaeger-opentelemetry-ingester:latest"
 	otelAgentImage       = "jaegertracing/jaeger-opentelemetry-agent:latest"
 	otelAllInOneImage    = "jaegertracing/opentelemetry-all-in-one:latest"
+	vertxExampleImage    = getStringEnv("VERTX_EXAMPLE_IMAGE", "jaegertracing/vertx-create-span:operator-e2e-tests")
+	vertxDelaySeconds    = int32(getIntEnv("VERTX_DELAY_SECONDS", 1))
+	vertxTimeoutSeconds  = int32(getIntEnv("VERTX_TIMEOUT_SECONDS", 1))
 
 	ctx       *framework.TestCtx
 	fw        *framework.Framework
@@ -83,6 +86,13 @@ func getIntEnv(key string, defaultValue int) int {
 			logrus.Warnf("Error [%v] received converting environment variable [%s] using [%v]", err, key, value)
 		}
 		return intValue
+	}
+	return defaultValue
+}
+
+func getStringEnv(key, defaultValue string) string {
+	if value, ok := os.LookupEnv(key); ok {
+		return value
 	}
 	return defaultValue
 }


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com>

This will be useful for testing on non-x86 architectures