### PR TITLE
elasticsearch: add SYS_CHROOT capability

### DIFF
--- a/test/elasticsearch.yml
+++ b/test/elasticsearch.yml
@@ -43,6 +43,9 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 5
             timeoutSeconds: 4
+          securityContext:
+            capabilities:
+              add: ["SYS_CHROOT"]
       volumes:
         - name: data
           emptyDir: {}


### PR DESCRIPTION
many container runtimes give SYS_CHROOT by default.  However, CRI-O does not give pods SYS_CHROOT by default.
Instead of relying on the default of a runtime, the pod description should request the capabilities it needs

Signed-off-by: Peter Hunt <pehunt@redhat.com>