### PR TITLE
Speed up buildx process

### DIFF
--- a/.ci/publish-images.sh
+++ b/.ci/publish-images.sh
@@ -39,4 +39,4 @@ if [ "${QUAY_PASSWORD}x" != "x" -a "${QUAY_USERNAME}x" != "x" ]; then
 fi
 
 echo "Building with tags ${IMAGE_TAGS}"
-docker buildx build --push --build-arg=GOPROXY=${GOPROXY} --platform=linux/amd64,linux/arm64 ${IMAGE_TAGS} --file build/Dockerfile .
+IMAGE_TAGS=${IMAGE_TAGS} make dockerx

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 VERSION_DATE ?= $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
-GO_FLAGS ?= GOOS=$(go env GOOS) GOARCH=$(go env GOARCH) CGO_ENABLED=0 GO111MODULE=on
+PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x
+GOARCH ?= $(go env GOARCH)
+GOOS ?= $(go env GOOS)
+GO_FLAGS ?= GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 GO111MODULE=on
 KUBERNETES_CONFIG ?= "$(HOME)/.kube/config"
 WATCH_NAMESPACE ?= ""
 BIN_DIR ?= "build/_output/bin"
@@ -75,7 +78,11 @@ gobuild:
 
 .PHONY: docker
 docker:
-	@[ ! -z "$(PIPELINE)" ] || docker build --build-arg=GOPROXY=${GOPROXY} --file build/Dockerfile -t "$(BUILD_IMAGE)" .
+	@[ ! -z "$(PIPELINE)" ] || docker build --build-arg=GOPROXY=${GOPROXY} --build-arg=TARGETARCH=$(GOARCH) --file build/Dockerfile -t "$(BUILD_IMAGE)" .
+
+.PHONY: dockerx
+dockerx:
+	@[ ! -z "$(PIPELINE)" ] || docker buildx build --push --progress=plain --build-arg=GOPROXY=${GOPROXY} --platform=$(PLATFORMS) --file build/Dockerfile -t "$(BUILD_IMAGE)" ${IMAGE_TAGS} .
 
 .PHONY: push
 push:

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,11 +1,23 @@
-FROM golang:1.14 as builder
-
-ARG GOPROXY
-ENV GOPROXY=${GOPROXY}
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.14 as builder
 
 COPY . /go/src/github.com/jaegertracing/jaeger-operator/
 WORKDIR /go/src/github.com/jaegertracing/jaeger-operator
-RUN make gobuild
+
+ARG GOPROXY
+# download deps before gobuild
+RUN go mod download -x
+
+# Dockerfile `FROM --platform=${BUILDPLATFORM}` means
+# prepare image for build for matched BUILDPLATFORM, eq. linux/amd64
+# by this way, we could avoid to using qemu, which slow down compiling process.
+# and usefully for language who support multi-arch build like go.
+# see last part of https://docs.docker.com/buildx/working-with-buildx/#build-multi-platform-images
+ARG TARGETARCH
+# when --platform=linux/amd64,linux/arm64
+#
+# for $TARGETARCH in "amd64 arm64" do
+RUN make gobuild OUTPUT_BINARY=/go/bin/jaeger-operator-${TARGETARCH} GOARCH=${TARGETARCH}
+# done
 
 FROM registry.access.redhat.com/ubi8/ubi
 
@@ -25,7 +37,8 @@ RUN INSTALL_PKGS=" \
 COPY --from=builder /go/src/github.com/jaegertracing/jaeger-operator/scripts/* /scripts/
 
 # install operator binary
-COPY --from=builder /go/src/github.com/jaegertracing/jaeger-operator/build/_output/bin/jaeger-operator ${OPERATOR}
+ARG TARGETARCH
+COPY --from=builder /go/bin/jaeger-operator-${TARGETARCH} ${OPERATOR}
 
 ENTRYPOINT ["/usr/local/bin/jaeger-operator"]
 


### PR DESCRIPTION
avoid to run `gobuild` with `qemu` to speed up multi arch build.

added `make dockerx` for local run.