### PR TITLE
Remove gRPC host-port from being added to the CR (agent)

### DIFF
--- a/pkg/upgrade/v1_18_0.go
+++ b/pkg/upgrade/v1_18_0.go
@@ -7,7 +7,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
-	"github.com/jaegertracing/jaeger-operator/pkg/service"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -58,14 +57,7 @@ func migrateAgentOptions(jaeger *v1.Jaeger) v1.Options {
 	}
 
 	ops := migrateDeprecatedOptions(jaeger, jaeger.Spec.Agent.Options, deleteAgentFlags)
-	opsMap := ops.GenericMap()
-
-	// Removed support for tchannel, so we need to make sure grpc is enabled and properly configured.
-	if _, ok := opsMap["reporter.grpc.host-port"]; !ok {
-		opsMap["reporter.grpc.host-port"] = fmt.Sprintf("dns:///%s.%s:14250",
-			service.GetNameForHeadlessCollectorService(jaeger), jaeger.Namespace)
-	}
-	return v1.NewOptions(opsMap)
+	return v1.NewOptions(ops.GenericMap())
 }
 
 func transformCollectorPorts(logger *log.Entry, opts v1.Options, collectorNewFlagsMap []deprecationFlagMap) v1.Options {

--- a/pkg/upgrade/v1_18_0_test.go
+++ b/pkg/upgrade/v1_18_0_test.go
@@ -95,5 +95,5 @@ func TestUpgradeAgentWithTChannelEnablev1_18_0_(t *testing.T) {
 
 	collectorOpts := persisted.Spec.Agent.Options.Map()
 
-	assert.Contains(t, collectorOpts, "reporter.grpc.host-port")
+	assert.NotContains(t, collectorOpts, "reporter.grpc.host-port")
 }


### PR DESCRIPTION
Fixes #1271.

Previously, the upgrade routine for 1.18 was adding the gRPC host-port option to the CR. In fact, the host-port is already being added by the sidecar/daemonset if this options isn't set. The CR should only be set by users, in which case we wouldn't touch it again (not for sidecar/daemonset, not for upgrades).

﻿Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
