### PR TITLE
add env var JAEGER_DISABLED

### DIFF
--- a/deploy/crds/jaegertracing.io_jaegers_crd.yaml
+++ b/deploy/crds/jaegertracing.io_jaegers_crd.yaml
@@ -1607,6 +1607,8 @@ spec:
                   type: object
                 image:
                   type: string
+                jaegerDisabled:
+                  type: boolean
                 labels:
                   additionalProperties:
                     type: string
@@ -5520,6 +5522,8 @@ spec:
                   type: object
                 image:
                   type: string
+                jaegerDisabled:
+                  type: boolean
                 labels:
                   additionalProperties:
                     type: string

--- a/deploy/crds/jaegertracing.io_jaegers_crd.yaml
+++ b/deploy/crds/jaegertracing.io_jaegers_crd.yaml
@@ -1607,8 +1607,6 @@ spec:
                   type: object
                 image:
                   type: string
-                jaegerDisabled:
-                  type: boolean
                 labels:
                   additionalProperties:
                     type: string
@@ -1698,6 +1696,8 @@ spec:
                         type: string
                     type: object
                   type: array
+                tracingEnabled:
+                  type: boolean
                 volumeMounts:
                   items:
                     properties:
@@ -5522,8 +5522,6 @@ spec:
                   type: object
                 image:
                   type: string
-                jaegerDisabled:
-                  type: boolean
                 labels:
                   additionalProperties:
                     type: string
@@ -5618,6 +5616,8 @@ spec:
                         type: string
                     type: object
                   type: array
+                tracingEnabled:
+                  type: boolean
                 volumeMounts:
                   items:
                     properties:

--- a/pkg/apis/jaegertracing/v1/jaeger_types.go
+++ b/pkg/apis/jaegertracing/v1/jaeger_types.go
@@ -251,6 +251,12 @@ type JaegerQuerySpec struct {
 	// The default, if omitted, is ClusterIP.
 	// See https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
 	ServiceType v1.ServiceType `json:"serviceType,omitempty"`
+
+	// +optional
+	// JaegerDisabled adds the JAEGER_DISABLED environment flag to the
+	// query component to prevent it from adding its own traces.
+	// The default, if ommited, is false
+	JaegerDisabled *bool `json:"jaegerDisabled,omitempty"`
 }
 
 // JaegerUISpec defines the options to be used to configure the UI
@@ -341,6 +347,12 @@ type JaegerAllInOneSpec struct {
 
 	// +optional
 	JaegerCommonSpec `json:",inline,omitempty"`
+
+	// +optional
+	// JaegerDisabled adds the JAEGER_DISABLED environment flag to the
+	// query component to prevent it from adding its own traces.
+	// The default, if ommited, is false
+	JaegerDisabled *bool `json:"jaegerDisabled,omitempty"`
 }
 
 // AutoScaleSpec defines the common elements used for create HPAs

--- a/pkg/apis/jaegertracing/v1/jaeger_types.go
+++ b/pkg/apis/jaegertracing/v1/jaeger_types.go
@@ -253,10 +253,10 @@ type JaegerQuerySpec struct {
 	ServiceType v1.ServiceType `json:"serviceType,omitempty"`
 
 	// +optional
-	// JaegerDisabled adds the JAEGER_DISABLED environment flag to the
-	// query component to prevent it from adding its own traces.
-	// The default, if ommited, is false
-	JaegerDisabled *bool `json:"jaegerDisabled,omitempty"`
+	// TracingEnabled if set to false adds the JAEGER_DISABLED environment flag and removes the injected
+	// agent container from the query component to disable tracing requests to the query service.
+	// The default, if ommited, is true
+	TracingEnabled *bool `json:"tracingEnabled,omitempty"`
 }
 
 // JaegerUISpec defines the options to be used to configure the UI
@@ -349,10 +349,10 @@ type JaegerAllInOneSpec struct {
 	JaegerCommonSpec `json:",inline,omitempty"`
 
 	// +optional
-	// JaegerDisabled adds the JAEGER_DISABLED environment flag to the
-	// query component to prevent it from adding its own traces.
-	// The default, if ommited, is false
-	JaegerDisabled *bool `json:"jaegerDisabled,omitempty"`
+	// TracingEnabled if set to false adds the JAEGER_DISABLED environment flag and removes the injected
+	// agent container from the query component to disable tracing requests to the query service.
+	// The default, if ommited, is true
+	TracingEnabled *bool `json:"tracingEnabled,omitempty"`
 }
 
 // AutoScaleSpec defines the common elements used for create HPAs

--- a/pkg/apis/jaegertracing/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/jaegertracing/v1/zz_generated.deepcopy.go
@@ -162,8 +162,8 @@ func (in *JaegerAllInOneSpec) DeepCopyInto(out *JaegerAllInOneSpec) {
 	in.Options.DeepCopyInto(&out.Options)
 	in.Config.DeepCopyInto(&out.Config)
 	in.JaegerCommonSpec.DeepCopyInto(&out.JaegerCommonSpec)
-	if in.JaegerDisabled != nil {
-		in, out := &in.JaegerDisabled, &out.JaegerDisabled
+	if in.TracingEnabled != nil {
+		in, out := &in.TracingEnabled, &out.TracingEnabled
 		*out = new(bool)
 		**out = **in
 	}
@@ -545,8 +545,8 @@ func (in *JaegerQuerySpec) DeepCopyInto(out *JaegerQuerySpec) {
 	}
 	in.Options.DeepCopyInto(&out.Options)
 	in.JaegerCommonSpec.DeepCopyInto(&out.JaegerCommonSpec)
-	if in.JaegerDisabled != nil {
-		in, out := &in.JaegerDisabled, &out.JaegerDisabled
+	if in.TracingEnabled != nil {
+		in, out := &in.TracingEnabled, &out.TracingEnabled
 		*out = new(bool)
 		**out = **in
 	}

--- a/pkg/apis/jaegertracing/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/jaegertracing/v1/zz_generated.deepcopy.go
@@ -162,6 +162,11 @@ func (in *JaegerAllInOneSpec) DeepCopyInto(out *JaegerAllInOneSpec) {
 	in.Options.DeepCopyInto(&out.Options)
 	in.Config.DeepCopyInto(&out.Config)
 	in.JaegerCommonSpec.DeepCopyInto(&out.JaegerCommonSpec)
+	if in.JaegerDisabled != nil {
+		in, out := &in.JaegerDisabled, &out.JaegerDisabled
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 
@@ -540,6 +545,11 @@ func (in *JaegerQuerySpec) DeepCopyInto(out *JaegerQuerySpec) {
 	}
 	in.Options.DeepCopyInto(&out.Options)
 	in.JaegerCommonSpec.DeepCopyInto(&out.JaegerCommonSpec)
+	if in.JaegerDisabled != nil {
+		in, out := &in.JaegerDisabled, &out.JaegerDisabled
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/jaegertracing/v1/zz_generated.openapi.go
+++ b/pkg/apis/jaegertracing/v1/zz_generated.openapi.go
@@ -460,9 +460,9 @@ func schema_pkg_apis_jaegertracing_v1_JaegerAllInOneSpec(ref common.ReferenceCal
 							Format: "",
 						},
 					},
-					"jaegerDisabled": {
+					"tracingEnabled": {
 						SchemaProps: spec.SchemaProps{
-							Description: "JaegerDisabled adds the JAEGER_DISABLED environment flag to the query component to prevent it from adding its own traces. The default, if ommited, is false",
+							Description: "TracingEnabled if set to false adds the JAEGER_DISABLED environment flag and removes the injected agent container from the query component to disable tracing requests to the query service. The default, if ommited, is true",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
@@ -1680,9 +1680,9 @@ func schema_pkg_apis_jaegertracing_v1_JaegerQuerySpec(ref common.ReferenceCallba
 							Format:      "",
 						},
 					},
-					"jaegerDisabled": {
+					"tracingEnabled": {
 						SchemaProps: spec.SchemaProps{
-							Description: "JaegerDisabled adds the JAEGER_DISABLED environment flag to the query component to prevent it from adding its own traces. The default, if ommited, is false",
+							Description: "TracingEnabled if set to false adds the JAEGER_DISABLED environment flag and removes the injected agent container from the query component to disable tracing requests to the query service. The default, if ommited, is true",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},

--- a/pkg/apis/jaegertracing/v1/zz_generated.openapi.go
+++ b/pkg/apis/jaegertracing/v1/zz_generated.openapi.go
@@ -460,6 +460,13 @@ func schema_pkg_apis_jaegertracing_v1_JaegerAllInOneSpec(ref common.ReferenceCal
 							Format: "",
 						},
 					},
+					"jaegerDisabled": {
+						SchemaProps: spec.SchemaProps{
+							Description: "JaegerDisabled adds the JAEGER_DISABLED environment flag to the query component to prevent it from adding its own traces. The default, if ommited, is false",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},
@@ -1670,6 +1677,13 @@ func schema_pkg_apis_jaegertracing_v1_JaegerQuerySpec(ref common.ReferenceCallba
 						SchemaProps: spec.SchemaProps{
 							Description: "ServiceType represents the type of Service to create. Valid values include: ClusterIP, NodePort, LoadBalancer, and ExternalName. The default, if omitted, is ClusterIP. See https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types",
 							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"jaegerDisabled": {
+						SchemaProps: spec.SchemaProps{
+							Description: "JaegerDisabled adds the JAEGER_DISABLED environment flag to the query component to prevent it from adding its own traces. The default, if ommited, is false",
+							Type:        []string{"boolean"},
 							Format:      "",
 						},
 					},

--- a/pkg/deployment/all_in_one.go
+++ b/pkg/deployment/all_in_one.go
@@ -43,9 +43,9 @@ func (a *AllInOne) Get() *appsv1.Deployment {
 
 	adminPort := util.GetAdminPort(args, 14269)
 
-	jaegerDisabled := &falseVar
-	if a.jaeger.Spec.AllInOne.JaegerDisabled != nil {
-		jaegerDisabled = a.jaeger.Spec.AllInOne.JaegerDisabled
+	jaegerDisabled := false
+	if a.jaeger.Spec.AllInOne.TracingEnabled != nil && *a.jaeger.Spec.AllInOne.TracingEnabled == false {
+		jaegerDisabled = true
 	}
 
 	baseCommonSpec := v1.JaegerCommonSpec{
@@ -147,7 +147,7 @@ func (a *AllInOne) Get() *appsv1.Deployment {
 							},
 							{
 								Name:  "JAEGER_DISABLED",
-								Value: strconv.FormatBool(*jaegerDisabled),
+								Value: strconv.FormatBool(jaegerDisabled),
 							},
 						},
 						VolumeMounts: commonSpec.VolumeMounts,

--- a/pkg/deployment/all_in_one.go
+++ b/pkg/deployment/all_in_one.go
@@ -43,6 +43,11 @@ func (a *AllInOne) Get() *appsv1.Deployment {
 
 	adminPort := util.GetAdminPort(args, 14269)
 
+	jaegerDisabled := &falseVar
+	if a.jaeger.Spec.AllInOne.JaegerDisabled != nil {
+		jaegerDisabled = a.jaeger.Spec.AllInOne.JaegerDisabled
+	}
+
 	baseCommonSpec := v1.JaegerCommonSpec{
 		Annotations: map[string]string{
 			"prometheus.io/scrape":    "true",
@@ -139,6 +144,10 @@ func (a *AllInOne) Get() *appsv1.Deployment {
 							{
 								Name:  "COLLECTOR_ZIPKIN_HTTP_PORT",
 								Value: "9411",
+							},
+							{
+								Name:  "JAEGER_DISABLED",
+								Value: strconv.FormatBool(*jaegerDisabled),
 							},
 						},
 						VolumeMounts: commonSpec.VolumeMounts,

--- a/pkg/deployment/all_in_one_test.go
+++ b/pkg/deployment/all_in_one_test.go
@@ -357,10 +357,10 @@ func TestAllInOneServiceLinks(t *testing.T) {
 	assert.Equal(t, &falseVar, dep.Spec.Template.Spec.EnableServiceLinks)
 }
 
-func TestAllInOneJaegerDisabled(t *testing.T) {
-	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestAllInOneJaegerDisabled"})
-	trueVar := true
-	jaeger.Spec.AllInOne.JaegerDisabled = &trueVar
+func TestAllInOneTracingDisabled(t *testing.T) {
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestAllInOneTracingDisabled"})
+	falseVar := false
+	jaeger.Spec.AllInOne.TracingEnabled = &falseVar
 	d := NewAllInOne(jaeger).Get()
 	assert.Equal(t, "true", getEnvVarByName(d.Spec.Template.Spec.Containers[0].Env, "JAEGER_DISABLED").Value)
 }

--- a/pkg/deployment/all_in_one_test.go
+++ b/pkg/deployment/all_in_one_test.go
@@ -41,6 +41,10 @@ func TestDefaultAllInOneImage(t *testing.T) {
 			Name:  "COLLECTOR_ZIPKIN_HTTP_PORT",
 			Value: "9411",
 		},
+		{
+			Name:  "JAEGER_DISABLED",
+			Value: "false",
+		},
 	}
 	assert.Equal(t, envvars, d.Spec.Template.Spec.Containers[0].Env)
 }
@@ -351,4 +355,22 @@ func TestAllInOneServiceLinks(t *testing.T) {
 	dep := a.Get()
 	falseVar := false
 	assert.Equal(t, &falseVar, dep.Spec.Template.Spec.EnableServiceLinks)
+}
+
+func TestAllInOneJaegerDisabled(t *testing.T) {
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestAllInOneJaegerDisabled"})
+	trueVar := true
+	jaeger.Spec.AllInOne.JaegerDisabled = &trueVar
+	d := NewAllInOne(jaeger).Get()
+	assert.Equal(t, "true", getEnvVarByName(d.Spec.Template.Spec.Containers[0].Env, "JAEGER_DISABLED").Value)
+}
+
+func getEnvVarByName(vars []corev1.EnvVar, name string) corev1.EnvVar {
+	envVar := corev1.EnvVar{}
+	for _, v := range vars {
+		if v.Name == name {
+			envVar = v
+		}
+	}
+	return envVar
 }

--- a/pkg/deployment/query.go
+++ b/pkg/deployment/query.go
@@ -39,9 +39,9 @@ func (q *Query) Get() *appsv1.Deployment {
 
 	adminPort := util.GetAdminPort(args, 16687)
 
-	jaegerDisabled := &falseVar
-	if q.jaeger.Spec.Query.JaegerDisabled != nil {
-		jaegerDisabled = q.jaeger.Spec.Query.JaegerDisabled
+	jaegerDisabled := false
+	if q.jaeger.Spec.Query.TracingEnabled != nil && *q.jaeger.Spec.Query.TracingEnabled == false {
+		jaegerDisabled = true
 	}
 
 	baseCommonSpec := v1.JaegerCommonSpec{
@@ -124,7 +124,7 @@ func (q *Query) Get() *appsv1.Deployment {
 							},
 							{
 								Name:  "JAEGER_DISABLED",
-								Value: strconv.FormatBool(*jaegerDisabled),
+								Value: strconv.FormatBool(jaegerDisabled),
 							},
 						},
 						VolumeMounts: commonSpec.VolumeMounts,

--- a/pkg/deployment/query_test.go
+++ b/pkg/deployment/query_test.go
@@ -323,10 +323,10 @@ func TestQueryServiceLinks(t *testing.T) {
 	assert.Equal(t, &falseVar, dep.Spec.Template.Spec.EnableServiceLinks)
 }
 
-func TestQueryJaegerDisabled(t *testing.T) {
+func TestQueryTracingDisabled(t *testing.T) {
 	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestQueryJaegerDisabled"})
-	trueVar := true
-	jaeger.Spec.Query.JaegerDisabled = &trueVar
+	falseVar := false
+	jaeger.Spec.Query.TracingEnabled = &falseVar
 	query := NewQuery(jaeger)
 	dep := query.Get()
 	assert.Equal(t, "true", getEnvVarByName(dep.Spec.Template.Spec.Containers[0].Env, "JAEGER_DISABLED").Value)

--- a/pkg/deployment/query_test.go
+++ b/pkg/deployment/query_test.go
@@ -322,3 +322,12 @@ func TestQueryServiceLinks(t *testing.T) {
 	falseVar := false
 	assert.Equal(t, &falseVar, dep.Spec.Template.Spec.EnableServiceLinks)
 }
+
+func TestQueryJaegerDisabled(t *testing.T) {
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestQueryJaegerDisabled"})
+	trueVar := true
+	jaeger.Spec.Query.JaegerDisabled = &trueVar
+	query := NewQuery(jaeger)
+	dep := query.Get()
+	assert.Equal(t, "true", getEnvVarByName(dep.Spec.Template.Spec.Containers[0].Env, "JAEGER_DISABLED").Value)
+}

--- a/pkg/strategy/production.go
+++ b/pkg/strategy/production.go
@@ -125,7 +125,10 @@ func newProductionStrategy(ctx context.Context, jaeger *v1.Jaeger) S {
 
 	// prepare the deployments, which may get changed by the elasticsearch routine
 	cDep := collector.Get()
-	queryDep := inject.Sidecar(jaeger, inject.OAuthProxy(jaeger, query.Get()))
+	queryDep := inject.OAuthProxy(jaeger, query.Get())
+	if jaeger.Spec.Query.TracingEnabled == nil || *jaeger.Spec.Query.TracingEnabled == true {
+		queryDep = inject.Sidecar(jaeger, queryDep)
+	}
 	c.dependencies = storage.Dependencies(jaeger)
 
 	// assembles the pieces for an elasticsearch self-provisioned deployment via the elasticsearch operator

--- a/pkg/strategy/production_test.go
+++ b/pkg/strategy/production_test.go
@@ -198,6 +198,18 @@ func TestAgentSidecarIsInjectedIntoQueryForStreamingForProduction(t *testing.T) 
 	}
 }
 
+func TestAgentSidecarNotInjectedTracingEnabledFalseForProduction(t *testing.T) {
+	j := v1.NewJaeger(types.NamespacedName{Name: "TestAgentSidecarNotInjectedTracingEnabledFalseForProduction"})
+	falseVar := false
+	j.Spec.Query.TracingEnabled = &falseVar
+	c := newProductionStrategy(context.Background(), j)
+	for _, dep := range c.Deployments() {
+		if strings.HasSuffix(dep.Name, "-query") {
+			assert.Equal(t, 1, len(dep.Spec.Template.Spec.Containers))
+		}
+	}
+}
+
 func TestElasticsearchInject(t *testing.T) {
 	j := v1.NewJaeger(types.NamespacedName{Name: t.Name()})
 	j.Spec.Storage.Type = v1.JaegerESStorage

--- a/pkg/strategy/streaming.go
+++ b/pkg/strategy/streaming.go
@@ -138,7 +138,10 @@ func newStreamingStrategy(ctx context.Context, jaeger *v1.Jaeger) S {
 
 	// prepare the deployments, which may get changed by the elasticsearch routine
 	cDep := collector.Get()
-	queryDep := inject.Sidecar(jaeger, inject.OAuthProxy(jaeger, query.Get()))
+	queryDep := inject.OAuthProxy(jaeger, query.Get())
+	if jaeger.Spec.Query.TracingEnabled == nil || *jaeger.Spec.Query.TracingEnabled == true {
+		queryDep = inject.Sidecar(jaeger, queryDep)
+	}
 	var ingesterDep *appsv1.Deployment
 	if d := ingester.Get(); d != nil {
 		ingesterDep = d

--- a/pkg/strategy/streaming_test.go
+++ b/pkg/strategy/streaming_test.go
@@ -249,6 +249,18 @@ func TestAgentSidecarIsInjectedIntoQueryForStreaming(t *testing.T) {
 	}
 }
 
+func TestAgentSidecarNotInjectedTracingEnabledFalseForStreaming(t *testing.T) {
+	j := v1.NewJaeger(types.NamespacedName{Name: "TestAgentSidecarNotInjectedTracingEnabledFalseForStreaming"})
+	falseVar := false
+	j.Spec.Query.TracingEnabled = &falseVar
+	c := newStreamingStrategy(context.Background(), j)
+	for _, dep := range c.Deployments() {
+		if strings.HasSuffix(dep.Name, "-query") {
+			assert.Equal(t, 1, len(dep.Spec.Template.Spec.Containers))
+		}
+	}
+}
+
 func TestAutoProvisionedKafkaInjectsIntoInstance(t *testing.T) {
 	name := "my-instance"
 	jaeger := v1.NewJaeger(types.NamespacedName{Name: name, Namespace: "project"})


### PR DESCRIPTION
Adds option to set the environment variable JAEGER_DISABLED to query or all-in-one deployment.

Closes: #1148

Signed-off-by: Simon Schneider <github@simon-schneider.eu>