### PR TITLE
Specify request memory

### DIFF
--- a/test/e2e/elasticsearch_token_propagation_test.go
+++ b/test/e2e/elasticsearch_token_propagation_test.go
@@ -192,10 +192,6 @@ func (suite *TokenTestSuite) deployJaegerWithPropagationEnabled() {
 	require.NoError(t, err, "Error deploying example Jaeger")
 
 	err = e2eutil.WaitForDeployment(t, fw.KubeClient, namespace, collectorName, 1, retryInterval, timeout)
-	if err != nil {
-		fmt.Printf("WTF Error %v in %s\n", err, namespace)
-		time.Sleep(5 * time.Minute)
-	}
 	require.NoError(t, err, "Error waiting for collector deployment")
 
 	err = e2eutil.WaitForDeployment(t, fw.KubeClient, namespace, queryName, 1, retryInterval, timeout)


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com>

Enable specifying ResourceMemory and ResourceCPU when creating auto provisioned ElasticSearch instances.  This is useful when testing on certain architectures.

