### PR TITLE
e2e index cleaner tests improvements 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/googleapis/gnostic v0.3.1
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/openshift/api v0.0.0-20200701144905-de5b010b2b38
+	github.com/opentracing/opentracing-go v1.1.1-0.20190913142402-a7454ce5950e
 	github.com/operator-framework/operator-sdk v0.18.2
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.5.0

--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -79,7 +79,7 @@ func (suite *AutoscaleTestSuite) TestAutoScaleCollector() {
 	jaegerInstanceName := "simple-prod"
 	var jaegerInstance *v1.Jaeger
 	if skipESExternal {
-		jaegerInstance = getJaegerSelfProvSimpleProd(jaegerInstanceName, namespace, int32(1))
+		jaegerInstance = GetJaegerSelfProvSimpleProdCR(jaegerInstanceName, namespace, int32(1))
 		createESSelfProvDeployment(jaegerInstance, jaegerInstanceName, namespace)
 	} else {
 		waitForElasticSearch()

--- a/test/e2e/elasticsearch_index_test.go
+++ b/test/e2e/elasticsearch_index_test.go
@@ -133,13 +133,6 @@ func (suite *ElasticSearchIndexTestSuite) runIndexCleaner(esIndexPrefix string, 
 		jaegerInstance.Spec.Storage.Options.Map()["es.index-prefix"] = esIndexPrefix
 	}
 
-	// update otel specific change
-	if specifyOtelImages {
-		logrus.Infof("Using OTEL collector for %s", jaegerInstanceName)
-		jaegerInstance.Spec.Collector.Image = otelCollectorImage
-		jaegerInstance.Spec.Collector.Config = v1.NewFreeForm(getOtelConfigForHealthCheckPort("14269"))
-	}
-
 	logrus.Infof("Creating jaeger services for es index cleaner test: %s", jaegerInstanceName)
 	createESSelfProvDeployment(jaegerInstance, jaegerInstanceName, namespace)
 	defer undeployJaegerInstance(jaegerInstance)

--- a/test/e2e/elasticsearch_index_test.go
+++ b/test/e2e/elasticsearch_index_test.go
@@ -1,0 +1,305 @@
+// +build elasticsearch
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/opentracing/opentracing-go"
+	framework "github.com/operator-framework/operator-sdk/pkg/test"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+)
+
+type ElasticSearchIndexTestSuite struct {
+	suite.Suite
+	esIndexCleanerHistoryDays int    // generate spans and services history
+	esNamespace               string // default storage namespace location
+}
+
+const ElasticSearchIndexDateLayout = "2006-01-02" // date layout in elasticsearch indices, example:
+
+// esIndexData struct is used to keep index data in simple format
+// will be useful for the validations
+type esIndexData struct {
+	IndexName string    // original index name
+	Type      string    // index type. span or service?
+	Prefix    string    // prefix of the index
+	Date      time.Time // index day/date
+}
+
+func TestElasticSearchIndexSuite(t *testing.T) {
+	indexSuite := new(ElasticSearchIndexTestSuite)
+	// update default values
+	indexSuite.esIndexCleanerHistoryDays = 45
+	// storage namespace
+	if skipESExternal {
+		indexSuite.esNamespace = namespace
+	} else {
+		indexSuite.esNamespace = storageNamespace
+	}
+	suite.Run(t, indexSuite)
+}
+
+func (suite *ElasticSearchIndexTestSuite) SetupSuite() {
+	t = suite.T()
+	var err error
+	ctx, err = prepare(t)
+	if err != nil {
+		if ctx != nil {
+			ctx.Cleanup()
+		}
+		require.FailNow(t, "Failed in prepare")
+	}
+	fw = framework.Global
+	namespace = ctx.GetID()
+	require.NotNil(t, namespace, "GetID failed")
+
+	addToFrameworkSchemeForSmokeTests(t)
+}
+
+func (suite *ElasticSearchIndexTestSuite) TearDownSuite() {
+	handleSuiteTearDown()
+}
+
+func (suite *ElasticSearchIndexTestSuite) SetupTest() {
+	t = suite.T()
+	// delete indices from external elasticsearch node
+	if !skipESExternal {
+		DeleteEsIndices(suite.esNamespace)
+	}
+}
+
+func (suite *ElasticSearchIndexTestSuite) AfterTest(suiteName, testName string) {
+	handleTestFailure()
+}
+
+// executes es index cleaner with default index prefix
+func (suite *ElasticSearchIndexTestSuite) TestEsIndexCleaner() {
+	suite.runIndexCleaner("", []int{45, 30, 7, 1, 0})
+}
+
+// executes es index cleaner tests with custom index prefix
+func (suite *ElasticSearchIndexTestSuite) TestEsIndexCleanerWithIndexPrefix() {
+	suite.runIndexCleaner("my-custom_prefix", []int{3, 1, 0})
+}
+
+// executes index cleaner tests
+func (suite *ElasticSearchIndexTestSuite) runIndexCleaner(esIndexPrefix string, daysRange []int) {
+	logrus.Infof("index cleaner test started. daysRange=%v, prefix=%s", daysRange, esIndexPrefix)
+	jaegerInstanceName := "test-es-index-cleaner"
+	if esIndexPrefix != "" {
+		jaegerInstanceName = "test-es-index-cleaner-with-prefix"
+	}
+	// get jaeger CR to create jaeger services
+	jaegerInstance := GetJaegerSelfProvSimpleProdCR(jaegerInstanceName, namespace, 1)
+
+	// If there is an external es deployment use it instead of creating a self provision one
+	if !skipESExternal {
+		if isOpenShift(t) {
+			esServerUrls = "http://elasticsearch." + storageNamespace + ".svc.cluster.local:9200"
+		}
+		jaegerInstance.Spec.Storage = v1.JaegerStorageSpec{
+			Type: v1.JaegerESStorage,
+			Options: v1.NewOptions(map[string]interface{}{
+				"es.server-urls": esServerUrls,
+			}),
+		}
+	}
+
+	// update jaeger CR with index cleaner specifications
+	// initially disable es index cleaner job
+	esIndexCleanerEnabled := false
+	esIndexCleanerNumberOfDays := suite.esIndexCleanerHistoryDays
+	jaegerInstance.Spec.Storage.EsIndexCleaner.Enabled = &esIndexCleanerEnabled
+	jaegerInstance.Spec.Storage.EsIndexCleaner.NumberOfDays = &esIndexCleanerNumberOfDays
+	jaegerInstance.Spec.Storage.EsIndexCleaner.Schedule = "*/1 * * * *"
+	// update es.index-prefix, if supplied
+	if esIndexPrefix != "" {
+		if jaegerInstance.Spec.Storage.Options.Map() == nil {
+			jaegerInstance.Spec.Storage.Options = v1.NewOptions(map[string]interface{}{})
+		}
+		jaegerInstance.Spec.Storage.Options.Map()["es.index-prefix"] = esIndexPrefix
+	}
+
+	// update otel specific change
+	if specifyOtelImages {
+		logrus.Infof("Using OTEL collector for %s", jaegerInstanceName)
+		jaegerInstance.Spec.Collector.Image = otelCollectorImage
+		jaegerInstance.Spec.Collector.Config = v1.NewFreeForm(getOtelConfigForHealthCheckPort("14269"))
+	}
+
+	logrus.Infof("Creating jaeger services for es index cleaner test: %s", jaegerInstanceName)
+	createESSelfProvDeployment(jaegerInstance, jaegerInstanceName, namespace)
+	defer undeployJaegerInstance(jaegerInstance)
+
+	suite.generateSpansHistoy(namespace, jaegerInstanceName)
+
+	suite.triggerIndexCleanerAndVerifyIndices(jaegerInstance, esIndexPrefix, daysRange)
+
+}
+
+func (suite *ElasticSearchIndexTestSuite) generateSpansHistoy(namespace, jaegerInstanceName string) {
+	logrus.Info("Enabling collector port forward")
+	fwdPortColl, closeChanColl := CreatePortForward(namespace, jaegerInstanceName+"-collector", "collector", []string{fmt.Sprintf(":%d", jaegerCollectorPort)}, fw.KubeConfig)
+	defer fwdPortColl.Close()
+	defer close(closeChanColl)
+	// get localhost collector port
+	colPorts, err := fwdPortColl.GetPorts()
+	require.NoError(t, err)
+	localPortColl := colPorts[0].Local
+	logrus.Infof("Generating spans and services for the last %d days", suite.esIndexCleanerHistoryDays)
+	currentDate := time.Now()
+	for day := 0; day < suite.esIndexCleanerHistoryDays; day++ {
+		spanDate := currentDate.AddDate(0, 0, -1*day)
+		stringDate := spanDate.Format(ElasticSearchIndexDateLayout)
+		// get tracing client
+		serviceName := fmt.Sprintf("%s_%s", jaegerInstanceName, stringDate)
+		tracer, closer, err := getTracingClientWithCollectorEndpoint(serviceName, fmt.Sprintf("http://localhost:%d/api/traces", localPortColl))
+		require.NoError(t, err)
+		// generate span
+		tracer.StartSpan("span-index-cleaner", opentracing.StartTime(spanDate)).
+			SetTag("jaeger-instance", jaegerInstanceName).
+			SetTag("test-case", t.Name()).
+			SetTag("string-date", stringDate).
+			FinishWithOptions(opentracing.FinishOptions{FinishTime: spanDate.Add(time.Second)})
+		closer.Close()
+	}
+}
+
+// function to get indices
+// returns in order: serviceIndices, spansIndices
+func (suite *ElasticSearchIndexTestSuite) getIndices() ([]esIndexData, []esIndexData) {
+	// get indices from es node
+	esIndices, err := GetEsIndices(suite.esNamespace)
+	require.NoError(t, err)
+	logrus.Infof("Number of indices found on rest api response:%d", len(esIndices))
+
+	servicesIndices := make([]esIndexData, 0)
+	spansIndices := make([]esIndexData, 0)
+
+	// parse date, prefix, type from index
+	re := regexp.MustCompile(`\d{4}-\d{2}-\d{2}`)
+	for _, esIndex := range esIndices {
+		indexName := esIndex.Index
+		dateString := re.FindString(indexName)
+		if dateString == "" { // assume this index not belongs to jaeger
+			continue
+		}
+
+		indexName = strings.Replace(indexName, dateString, "", 1)
+
+		indexDate, err := time.Parse(ElasticSearchIndexDateLayout, dateString)
+		require.NoError(t, err)
+
+		esData := esIndexData{
+			IndexName: esIndex.Index,
+			Date:      indexDate,
+		}
+
+		// reference
+		// https://github.com/jaegertracing/jaeger/blob/6c2be456ca41cdb98ac4b81cb8d9a9a9044463cd/plugin/storage/es/spanstore/reader.go#L40
+		if strings.Contains(indexName, "jaeger-span-") {
+			esData.Type = "span"
+			prefix := strings.Replace(indexName, "jaeger-span-", "", 1)
+			if len(prefix) > 0 {
+				esData.Prefix = prefix[:len(prefix)-1] // removes "-" at end
+			}
+			spansIndices = append(spansIndices, esData)
+		} else if strings.Contains(indexName, "jaeger-service-") {
+			esData.Type = "service"
+			prefix := strings.Replace(indexName, "jaeger-service-", "", 1)
+			if len(prefix) > 0 {
+				esData.Prefix = prefix[:len(prefix)-1] // removes "-" at end
+			}
+			servicesIndices = append(servicesIndices, esData)
+		}
+	}
+	return servicesIndices, spansIndices
+}
+
+// function to validate indices
+func (suite *ElasticSearchIndexTestSuite) assertIndex(esIndexPrefix string, indices []esIndexData, verifyDateAfter time.Time, count int) {
+	// sort and print indices
+	sort.Slice(indices, func(i, j int) bool {
+		return indices[i].Date.After(indices[j].Date)
+	})
+	indicesSlice := make([]string, 0)
+	for _, ind := range indices {
+		indicesSlice = append(indicesSlice, ind.IndexName)
+	}
+	logrus.Infof("indices should be after %v, indices list: %v", verifyDateAfter, indicesSlice)
+	require.Equal(t, count, len(indices), "number of available indices not matching, %v", indices)
+	for _, index := range indices {
+		require.True(t, index.Date.After(verifyDateAfter), "this index must removed by index cleaner job: %v", index)
+		require.Equal(t, esIndexPrefix, index.Prefix, "index prefix not matching")
+	}
+}
+
+// trigger the index cleaner job for the given day range and verifies the indices availability
+func (suite *ElasticSearchIndexTestSuite) triggerIndexCleanerAndVerifyIndices(jaegerInstance *v1.Jaeger, esIndexPrefix string, daysRange []int) {
+	for _, verifyDays := range daysRange {
+		logrus.Infof("Scheduling index cleaner job for %d days", verifyDays)
+		// update and trigger index cleaner job
+		suite.turnOnEsIndexCleaner(jaegerInstance, verifyDays)
+
+		// get services and spans indices
+		servicesIndices, spanIndices := suite.getIndices()
+		// set valid index start date
+		indexDateReference := time.Now().AddDate(0, 0, -1*verifyDays)
+		// set hours, minutes, seconds, etc.. to 0
+		indexDateReference = time.Date(indexDateReference.Year(), indexDateReference.Month(), indexDateReference.Day(), 0, 0, 0, 0, indexDateReference.Location())
+		logrus.Infof("indices status on es node={numberOfDays:%d, services:%d, spans:%d}", verifyDays, len(servicesIndices), len(spanIndices))
+		suite.assertIndex(esIndexPrefix, servicesIndices, indexDateReference, verifyDays)
+		suite.assertIndex(esIndexPrefix, spanIndices, indexDateReference, verifyDays)
+	}
+}
+
+func (suite *ElasticSearchIndexTestSuite) turnOnEsIndexCleaner(jaegerInstance *v1.Jaeger, indexCleanerNumOfDays int) {
+	// enable index cleaner job
+	suite.updateJaegerCR(jaegerInstance, indexCleanerNumOfDays, true)
+
+	// wait till the cron job created
+	err := WaitForCronJob(t, fw.KubeClient, namespace, fmt.Sprintf("%s-es-index-cleaner", jaegerInstance.Name), retryInterval, timeout+1*time.Minute)
+	require.NoError(t, err, "Error waiting for Cron Job")
+
+	// wait for the first successful cron job pod
+	err = WaitForJobOfAnOwner(t, fw.KubeClient, namespace, fmt.Sprintf("%s-es-index-cleaner", jaegerInstance.Name), retryInterval, timeout)
+	require.NoError(t, err, "Error waiting for Cron Job")
+
+	// disable index cleaner job
+	suite.updateJaegerCR(jaegerInstance, indexCleanerNumOfDays, false)
+
+	// delete completed job pods
+	err = fw.KubeClient.CoreV1().Pods(namespace).DeleteCollection(
+		context.Background(),
+		metav1.DeleteOptions{},
+		metav1.ListOptions{LabelSelector: "app.kubernetes.io/component=cronjob-es-index-cleaner"})
+	require.NoError(t, err, "Error on delete index cleaner pods")
+
+}
+
+// function to update jaeger CR
+func (suite *ElasticSearchIndexTestSuite) updateJaegerCR(jaegerInstance *v1.Jaeger, indexCleanerNumOfDays int, indexCleanerEnabled bool) {
+	// get existing values
+	key := types.NamespacedName{Name: jaegerInstance.Name, Namespace: jaegerInstance.GetNamespace()}
+	err := fw.Client.Get(context.Background(), key, jaegerInstance)
+	require.NoError(t, err)
+
+	// update values
+	jaegerInstance.Spec.Storage.EsIndexCleaner.Enabled = &indexCleanerEnabled
+	jaegerInstance.Spec.Storage.EsIndexCleaner.NumberOfDays = &indexCleanerNumOfDays
+	err = fw.Client.Update(context.Background(), jaegerInstance)
+	require.NoError(t, err)
+}

--- a/test/e2e/elasticsearch_index_test.go
+++ b/test/e2e/elasticsearch_index_test.go
@@ -274,13 +274,16 @@ func (suite *ElasticSearchIndexTestSuite) turnOnEsIndexCleaner(jaegerInstance *v
 	// disable index cleaner job
 	suite.updateJaegerCR(jaegerInstance, indexCleanerNumOfDays, false)
 
+	// seeing inconsistency in minikube when immediately disabling and enabling index cleaner job
+	// as a result index clear job is not triggering, so sleep for a while
+	time.Sleep(time.Second * 5)
+
 	// delete completed job pods
 	err = fw.KubeClient.CoreV1().Pods(namespace).DeleteCollection(
 		context.Background(),
 		metav1.DeleteOptions{},
 		metav1.ListOptions{LabelSelector: "app.kubernetes.io/component=cronjob-es-index-cleaner"})
 	require.NoError(t, err, "Error on delete index cleaner pods")
-
 }
 
 // function to update jaeger CR

--- a/test/e2e/elasticsearch_test.go
+++ b/test/e2e/elasticsearch_test.go
@@ -4,56 +4,21 @@ package e2e
 
 import (
 	"context"
-	"crypto/tls"
-	"crypto/x509"
-	"encoding/json"
-	"fmt"
-	"io/ioutil"
-	"net/http"
-	"regexp"
-	"sort"
-	"strconv"
-	"strings"
 	"testing"
-	"time"
 
-	"github.com/opentracing/opentracing-go"
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/tools/portforward"
 
 	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 )
 
-type ElasticSearchTestSuite struct {
+type ElasticSearchBasicTestSuite struct {
 	suite.Suite
 }
 
-// EsIndex struct to map indices data from es rest api response
-// es api: /_cat/indices?format=json
-type EsIndex struct {
-	UUID        string `json:"uuid"`
-	Status      string `json:"status"`
-	Index       string `json:"index"`
-	Health      string `json:"health"`
-	DocsCount   string `json:"docs.count"`
-	DocsDeleted string `json:"docs.deleted"`
-	StoreSize   string `json:"store.size"`
-}
-
-var (
-	esIndexCleanerEnabled = false            // global variable used to enable/disable index cleaner (pass-by-reference in jaeger CR object)
-	numberOfDays          = 0                // index cleaner number of days (pass-by-reference in jaeger CR object)
-	esNamespace           = storageNamespace // default storage namespace location
-	esUrl                 string             // es node url
-)
-
-func (suite *ElasticSearchTestSuite) SetupSuite() {
+func (suite *ElasticSearchBasicTestSuite) SetupSuite() {
 	t = suite.T()
 	var err error
 	ctx, err = prepare(t)
@@ -74,27 +39,23 @@ func (suite *ElasticSearchTestSuite) SetupSuite() {
 	}
 }
 
-func (suite *ElasticSearchTestSuite) TearDownSuite() {
+func (suite *ElasticSearchBasicTestSuite) TearDownSuite() {
 	handleSuiteTearDown()
 }
 
 func TestElasticSearchSuite(t *testing.T) {
-	suite.Run(t, new(ElasticSearchTestSuite))
+	suite.Run(t, new(ElasticSearchBasicTestSuite))
 }
 
-func (suite *ElasticSearchTestSuite) SetupTest() {
+func (suite *ElasticSearchBasicTestSuite) SetupTest() {
 	t = suite.T()
-	// delete indices from external elasticsearch
-	if !skipESExternal {
-		deleteEsIndices()
-	}
 }
 
-func (suite *ElasticSearchTestSuite) AfterTest(suiteName, testName string) {
+func (suite *ElasticSearchBasicTestSuite) AfterTest(suiteName, testName string) {
 	handleTestFailure()
 }
 
-func (suite *ElasticSearchTestSuite) TestSparkDependenciesES() {
+func (suite *ElasticSearchBasicTestSuite) TestSparkDependenciesES() {
 	if skipESExternal {
 		t.Skip("This test requires an insecure ElasticSearch instance")
 	}
@@ -108,7 +69,7 @@ func (suite *ElasticSearchTestSuite) TestSparkDependenciesES() {
 	require.NoError(t, err, "SparkTest failed")
 }
 
-func (suite *ElasticSearchTestSuite) TestSimpleProd() {
+func (suite *ElasticSearchBasicTestSuite) TestSimpleProd() {
 	if skipESExternal {
 		t.Skip("This case is covered by the self_provisioned_elasticsearch_test")
 	}
@@ -117,7 +78,7 @@ func (suite *ElasticSearchTestSuite) TestSimpleProd() {
 
 	// create jaeger custom resource
 	name := "simple-prod"
-	exampleJaeger := getJaegerSimpleProdWithServerUrls(name)
+	exampleJaeger := GetJaegerSimpleProdWithServerUrlsCR(name, esServerUrls)
 	err = fw.Client.Create(context.TODO(), exampleJaeger, &framework.CleanupOptions{TestContext: ctx, Timeout: timeout, RetryInterval: retryInterval})
 	require.NoError(t, err, "Error deploying example Jaeger")
 	defer undeployJaegerInstance(exampleJaeger)
@@ -132,323 +93,4 @@ func (suite *ElasticSearchTestSuite) TestSimpleProd() {
 
 	// Make sure we were using the correct collector image
 	verifyCollectorImage(name, namespace, specifyOtelImages)
-}
-
-// executes es index cleaner tests with custom index prefix
-func (suite *ElasticSearchTestSuite) TestEsIndexCleanerWithIndexPrefix() {
-	suite.runIndexCleaner("my-custom_prefix", []int{3, 1, 0})
-}
-
-// executes es index cleaner with default index prefix
-func (suite *ElasticSearchTestSuite) TestEsIndexCleaner() {
-	suite.runIndexCleaner("", []int{45, 30, 7, 1, 0})
-}
-
-// executes index cleaner tests
-func (suite *ElasticSearchTestSuite) runIndexCleaner(esIndexPrefix string, daysRange []int) {
-	logrus.Infof("index cleaner test started. daysRange=%v, prefix=%s", daysRange, esIndexPrefix)
-	jaegerInstanceName := "test-es-index-cleaner"
-	if esIndexPrefix != "" {
-		jaegerInstanceName = "test-es-index-cleaner-with-prefix"
-	}
-	// get jaeger CR to create jaeger services
-	jaegerInstance := getJaegerSelfProvSimpleProd(jaegerInstanceName, namespace, 1)
-
-	// storage namespace
-	esNamespace = namespace
-
-	// update es node namespace and es node url into jaeger CR for external es deployment
-	if !skipESExternal {
-		esNamespace = storageNamespace
-		jaegerInstance.Spec.Storage = v1.JaegerStorageSpec{
-			Type: v1.JaegerESStorage,
-			Options: v1.NewOptions(map[string]interface{}{
-				"es.server-urls": esServerUrls,
-			}),
-		}
-	}
-
-	// update jaeger CR with index cleaner specifications
-	indexHistoryDays := 45 // maximum number of days to generate spans and services
-	numberOfDays = indexHistoryDays
-	// initially disable es index cleaner job
-	esIndexCleanerEnabled = false
-	jaegerInstance.Spec.Storage.EsIndexCleaner.Enabled = &esIndexCleanerEnabled
-	jaegerInstance.Spec.Storage.EsIndexCleaner.Schedule = "*/1 * * * *"
-	jaegerInstance.Spec.Storage.EsIndexCleaner.NumberOfDays = &numberOfDays
-	// update es.index-prefix, if supplied
-	if esIndexPrefix != "" {
-		if jaegerInstance.Spec.Storage.Options.Map() == nil {
-			jaegerInstance.Spec.Storage.Options = v1.NewOptions(map[string]interface{}{})
-		}
-		jaegerInstance.Spec.Storage.Options.Map()["es.index-prefix"] = esIndexPrefix
-	}
-
-	// update otel specific change
-	if specifyOtelImages {
-		logrus.Infof("Using OTEL collector for %s", jaegerInstanceName)
-		jaegerInstance.Spec.Collector.Image = otelCollectorImage
-		jaegerInstance.Spec.Collector.Config = v1.NewFreeForm(getOtelConfigForHealthCheckPort("14269"))
-	}
-
-	// deploy jaeger services
-	logrus.Infof("Creating jaeger services for es index cleaner test: %s", jaegerInstanceName)
-	createESSelfProvDeployment(jaegerInstance, jaegerInstanceName, namespace)
-	defer undeployJaegerInstance(jaegerInstance)
-
-	// generate spans and service for last 45 days
-	currentDate := time.Now()
-	indexDateLayout := "2006-01-02"
-	// enable port forward for collector port
-	logrus.Info("Enabling collector port forward")
-	fwdPortColl, closeChanColl := CreatePortForward(namespace, jaegerInstanceName+"-collector", "collector", []string{fmt.Sprintf(":%d", jaegerCollectorPort)}, fw.KubeConfig)
-	defer fwdPortColl.Close()
-	defer close(closeChanColl)
-	// get localhost collector port
-	colPorts, err := fwdPortColl.GetPorts()
-	require.NoError(t, err)
-	localPortColl := colPorts[0].Local
-
-	logrus.Infof("Generating spans and services for the last %d days", indexHistoryDays)
-	for day := 0; day < indexHistoryDays; day++ {
-		spanDate := currentDate.AddDate(0, 0, -1*day)
-		stringDate := spanDate.Format(indexDateLayout)
-		// get tracing client
-		serviceName := fmt.Sprintf("%s_%s", jaegerInstanceName, stringDate)
-		tracer, closer, err := getTracerClientWithCollectorEndpoint(serviceName, fmt.Sprintf("http://localhost:%d/api/traces", localPortColl))
-		require.NoError(t, err)
-		// generate span
-		tracer.StartSpan("span-index-cleaner", opentracing.StartTime(spanDate)).
-			SetTag("jaeger-instance", jaegerInstanceName).
-			SetTag("test-case", t.Name()).
-			SetTag("string-date", stringDate).
-			FinishWithOptions(opentracing.FinishOptions{FinishTime: spanDate.Add(time.Second)})
-		closer.Close()
-	}
-
-	// esIndexData struct is used to keep index data in simple format
-	// will be useful for the validations
-	type esIndexData struct {
-		IndexName string    // original index name
-		Type      string    // index type. span or service?
-		Prefix    string    // prefix of the index
-		Date      time.Time // index day/date
-	}
-
-	// function to get indices
-	// returns in order: serviceIndices, spansIndices
-	getIndices := func() ([]esIndexData, []esIndexData) {
-		// get indices from es node
-		esIndices, err := getEsIndices()
-		require.NoError(t, err)
-		fmt.Println("indices found on rest api response:", len(esIndices))
-
-		servicesIndices := make([]esIndexData, 0)
-		spansIndices := make([]esIndexData, 0)
-
-		// parse date, prefix, type from index
-		re := regexp.MustCompile(`\d{4}-\d{2}-\d{2}`)
-		for _, esIndex := range esIndices {
-			indexName := esIndex.Index
-			dateString := re.FindString(indexName)
-			if dateString == "" { // assume this index not belongs to jaeger
-				continue
-			}
-
-			indexName = strings.Replace(indexName, dateString, "", 1)
-
-			indexDate, err := time.Parse(indexDateLayout, dateString)
-			require.NoError(t, err)
-
-			esData := esIndexData{
-				IndexName: esIndex.Index,
-				Date:      indexDate,
-			}
-
-			// reference
-			// https://github.com/jaegertracing/jaeger/blob/6c2be456ca41cdb98ac4b81cb8d9a9a9044463cd/plugin/storage/es/spanstore/reader.go#L40
-			if strings.Contains(indexName, "jaeger-span-") {
-				esData.Type = "span"
-				prefix := strings.Replace(indexName, "jaeger-span-", "", 1)
-				if len(prefix) > 0 {
-					esData.Prefix = prefix[:len(prefix)-1] // removes "-" at end
-				}
-				spansIndices = append(spansIndices, esData)
-			} else if strings.Contains(indexName, "jaeger-service-") {
-				esData.Type = "service"
-				prefix := strings.Replace(indexName, "jaeger-service-", "", 1)
-				if len(prefix) > 0 {
-					esData.Prefix = prefix[:len(prefix)-1] // removes "-" at end
-				}
-				servicesIndices = append(servicesIndices, esData)
-			}
-		}
-		return servicesIndices, spansIndices
-	}
-
-	// function to validate indices
-	assertIndex := func(indices []esIndexData, verifyDateAfter time.Time, count int) {
-		// sort and print indices
-		sort.Slice(indices, func(i, j int) bool {
-			return indices[i].Date.After(indices[j].Date)
-		})
-		indicesSlice := make([]string, 0)
-		for _, ind := range indices {
-			indicesSlice = append(indicesSlice, ind.IndexName)
-		}
-		logrus.Infof("indices should be after %v, indices list: %v", verifyDateAfter, indicesSlice)
-		require.Equal(t, count, len(indices), "number of available indices not matching, %v", indices)
-		for _, index := range indices {
-			require.True(t, index.Date.After(verifyDateAfter), "this index must removed by index cleaner job: %v", index)
-			require.Equal(t, esIndexPrefix, index.Prefix, "index prefix not matching")
-		}
-	}
-
-	// trigger the index cleaner for multiple day range and verify indices
-	for _, verifyDays := range daysRange {
-		logrus.Infof("Scheduling index cleaner job for %d days", verifyDays)
-		// update and trigger index cleaner job
-		turnOnEsIndexCleaner(jaegerInstance, verifyDays)
-
-		// get servies and spans indices
-		servicesIndices, spanIndices := getIndices()
-		// valid index start date
-		indexDateReference := time.Now().AddDate(0, 0, -1*verifyDays)
-		// set hours, minutes, seconds, etc.. to 0
-		indexDateReference = time.Date(indexDateReference.Year(), indexDateReference.Month(), indexDateReference.Day(), 0, 0, 0, 0, indexDateReference.Location())
-		logrus.Infof("indices found={numberOfDays:%d, services:%d, spans:%d}", verifyDays, len(servicesIndices), len(spanIndices))
-		assertIndex(servicesIndices, indexDateReference, verifyDays)
-		assertIndex(spanIndices, indexDateReference, verifyDays)
-	}
-}
-
-func getJaegerSimpleProdWithServerUrls(name string) *v1.Jaeger {
-	ingressEnabled := true
-	exampleJaeger := &v1.Jaeger{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Jaeger",
-			APIVersion: "jaegertracing.io/v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
-		Spec: v1.JaegerSpec{
-			Ingress: v1.JaegerIngressSpec{
-				Enabled:  &ingressEnabled,
-				Security: v1.IngressSecurityNoneExplicit,
-			},
-			Strategy: v1.DeploymentStrategyProduction,
-			Storage: v1.JaegerStorageSpec{
-				Type: v1.JaegerESStorage,
-				Options: v1.NewOptions(map[string]interface{}{
-					"es.server-urls": esServerUrls,
-				}),
-			},
-		},
-	}
-
-	if specifyOtelImages {
-		logrus.Infof("Using OTEL collector for %s", name)
-		exampleJaeger.Spec.Collector.Image = otelCollectorImage
-		exampleJaeger.Spec.Collector.Config = v1.NewFreeForm(getOtelConfigForHealthCheckPort("14269"))
-	}
-
-	return exampleJaeger
-}
-
-// return indices from es node
-func getEsIndices() ([]EsIndex, error) {
-	bodyBytes, err := executeEsRequest(http.MethodGet, "/_cat/indices?format=json")
-	require.NoError(t, err)
-
-	// convert json data to struct format
-	esIndices := make([]EsIndex, 0)
-	err = json.Unmarshal(bodyBytes, &esIndices)
-	require.NoError(t, err)
-
-	return esIndices, nil
-}
-
-// deletes all the indices on es node
-func deleteEsIndices() {
-	logrus.Info("deleting all es node indices")
-	_, err := executeEsRequest(http.MethodDelete, "/_all?format=json")
-	require.NoError(t, err)
-}
-
-// executes rest api request on es node
-func executeEsRequest(httpMethod, api string) ([]byte, error) {
-	// enable port forward
-	fwdPortES, closeChanES, esPort := createEsPortForward(esNamespace)
-	defer fwdPortES.Close()
-	defer close(closeChanES)
-
-	// update es node url
-	urlScheme := "http"
-	if skipESExternal {
-		urlScheme = "https"
-	}
-	esUrl = fmt.Sprintf("%s://localhost:%s%s", urlScheme, esPort, api)
-
-	// create rest client to access es node rest API
-	transport := &http.Transport{}
-	client := http.Client{Transport: transport}
-
-	// update certificates, if the es node provided by jaeger-operator
-	if skipESExternal {
-		esSecret, err := fw.KubeClient.CoreV1().Secrets(namespace).Get(context.Background(), "elasticsearch", metav1.GetOptions{})
-		require.NoError(t, err)
-		pool := x509.NewCertPool()
-		pool.AppendCertsFromPEM(esSecret.Data["admin-ca"])
-
-		clientCert, err := tls.X509KeyPair(esSecret.Data["admin-cert"], esSecret.Data["admin-key"])
-		require.NoError(t, err)
-
-		transport.TLSClientConfig = &tls.Config{
-			RootCAs:      pool,
-			Certificates: []tls.Certificate{clientCert},
-		}
-	}
-
-	req, err := http.NewRequest(httpMethod, esUrl, nil)
-	require.NoError(t, err)
-
-	resp, err := client.Do(req)
-	require.NoError(t, err)
-	defer resp.Body.Close()
-
-	require.EqualValues(t, 200, resp.StatusCode)
-
-	return ioutil.ReadAll(resp.Body)
-}
-
-func createEsPortForward(esNamespace string) (portForwES *portforward.PortForwarder, closeChanES chan struct{}, esPort string) {
-	portForwES, closeChanES = CreatePortForward(esNamespace, string(v1.JaegerESStorage), string(v1.JaegerESStorage), []string{"0:9200"}, fw.KubeConfig)
-	forwardedPorts, err := portForwES.GetPorts()
-	require.NoError(t, err)
-	return portForwES, closeChanES, strconv.Itoa(int(forwardedPorts[0].Local))
-}
-
-func turnOnEsIndexCleaner(jaegerInstance *v1.Jaeger, days int) {
-	key := types.NamespacedName{Name: jaegerInstance.Name, Namespace: jaegerInstance.GetNamespace()}
-	err := fw.Client.Get(context.Background(), key, jaegerInstance)
-	require.NoError(t, err)
-
-	// update values
-	esIndexCleanerEnabled = true
-	numberOfDays = days
-	err = fw.Client.Update(context.Background(), jaegerInstance)
-	require.NoError(t, err)
-
-	err = WaitForCronJob(t, fw.KubeClient, namespace, fmt.Sprintf("%s-es-index-cleaner", jaegerInstance.Name), retryInterval, timeout+1*time.Minute)
-	require.NoError(t, err, "Error waiting for Cron Job")
-
-	err = WaitForJobOfAnOwner(t, fw.KubeClient, namespace, fmt.Sprintf("%s-es-index-cleaner", jaegerInstance.Name), retryInterval, timeout)
-	require.NoError(t, err, "Error waiting for Cron Job")
-
-	// disable index cleaner job
-	esIndexCleanerEnabled = false
-	err = fw.Client.Update(context.Background(), jaegerInstance)
-	require.NoError(t, err)
 }

--- a/test/e2e/multiple_instances_test.go
+++ b/test/e2e/multiple_instances_test.go
@@ -60,7 +60,7 @@ func (suite *MultipleInstanceTestSuite) TestVerifySecrets() {
 
 	jaegerInstanceName := "simple-prod"
 	// In production we'd use 3 nodes but 1 is sufficient for this test.
-	jaegerInstance := getJaegerSelfProvSimpleProd(jaegerInstanceName, namespace, 1)
+	jaegerInstance := GetJaegerSelfProvSimpleProdCR(jaegerInstanceName, namespace, 1)
 	createESSelfProvDeployment(jaegerInstance, jaegerInstanceName, namespace)
 	defer undeployJaegerInstance(jaegerInstance)
 
@@ -68,7 +68,7 @@ func (suite *MultipleInstanceTestSuite) TestVerifySecrets() {
 	secondContext, err := createNewTestContext()
 	defer secondContext.Cleanup()
 	secondNamespace := secondContext.GetID()
-	secondJaegerInstance := getJaegerSelfProvSimpleProd(jaegerInstanceName, secondNamespace, 1)
+	secondJaegerInstance := GetJaegerSelfProvSimpleProdCR(jaegerInstanceName, secondNamespace, 1)
 	createESSelfProvDeployment(secondJaegerInstance, jaegerInstanceName, secondNamespace)
 	defer undeployJaegerInstance(secondJaegerInstance)
 

--- a/test/e2e/self_provisioned_elasticsearch_test.go
+++ b/test/e2e/self_provisioned_elasticsearch_test.go
@@ -80,7 +80,7 @@ func (suite *SelfProvisionedTestSuite) AfterTest(suiteName, testName string) {
 func (suite *SelfProvisionedTestSuite) TestSelfProvisionedESSmokeTest() {
 	// create jaeger custom resource
 	jaegerInstanceName := "simple-prod"
-	jaegerInstance := getJaegerSelfProvSimpleProd(jaegerInstanceName, namespace, 1)
+	jaegerInstance := GetJaegerSelfProvSimpleProdCR(jaegerInstanceName, namespace, 1)
 	createESSelfProvDeployment(jaegerInstance, jaegerInstanceName, namespace)
 	defer undeployJaegerInstance(jaegerInstance)
 
@@ -92,7 +92,7 @@ func (suite *SelfProvisionedTestSuite) TestSelfProvisionedESSmokeTest() {
 
 func (suite *SelfProvisionedTestSuite) TestIncreasingReplicas() {
 	jaegerInstanceName := "simple-prod2"
-	jaegerInstance := getJaegerSelfProvSimpleProd(jaegerInstanceName, namespace, 1)
+	jaegerInstance := GetJaegerSelfProvSimpleProdCR(jaegerInstanceName, namespace, 1)
 	createESSelfProvDeployment(jaegerInstance, jaegerInstanceName, namespace)
 	defer undeployJaegerInstance(jaegerInstance)
 

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -738,16 +738,6 @@ func waitForElasticSearch() {
 	require.NoError(t, err, "Error waiting for elasticsearch")
 }
 
-func deleteElasticSearchPod() {
-	// unique label to select elesticsearch pods: app: jaeger-elasticsearch
-	logrus.Info("Deleting elasticsearch pods")
-	err := fw.KubeClient.CoreV1().Pods(storageNamespace).DeleteCollection(
-		context.Background(),
-		metav1.DeleteOptions{},
-		metav1.ListOptions{LabelSelector: "app=jaeger-elasticsearch"})
-	require.NoError(t, err, "Error on delete elasticsearch pod(s)")
-}
-
 func createESSelfProvDeployment(jaegerInstance *v1.Jaeger, jaegerInstanceName, jaegerNamespace string) {
 	err := fw.Client.Create(context.TODO(), jaegerInstance, &framework.CleanupOptions{TestContext: ctx, Timeout: timeout, RetryInterval: retryInterval})
 	require.NoError(t, err, "Error deploying example Jaeger")

--- a/test/e2e/utils_cr.go
+++ b/test/e2e/utils_cr.go
@@ -1,11 +1,12 @@
 package e2e
 
 import (
-	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 )
 
 func updateOtelImages(jaegerInstance *v1.Jaeger) {

--- a/test/e2e/utils_cr.go
+++ b/test/e2e/utils_cr.go
@@ -1,0 +1,85 @@
+package e2e
+
+import (
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func updateOtelImages(jaegerInstance *v1.Jaeger) {
+	if specifyOtelImages {
+		logrus.Infof("Using OTEL collector for %s", jaegerInstance.Name)
+		jaegerInstance.Spec.Collector.Image = otelCollectorImage
+		jaegerInstance.Spec.Collector.Config = v1.NewFreeForm(getOtelConfigForHealthCheckPort("14269"))
+	}
+}
+
+// GetJaegerSimpleProdWithServerUrlsCR returns simple production CR with external es server urls
+func GetJaegerSimpleProdWithServerUrlsCR(name, esServerUrls string) *v1.Jaeger {
+	ingressEnabled := true
+	simpleProdCR := &v1.Jaeger{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Jaeger",
+			APIVersion: "jaegertracing.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: v1.JaegerSpec{
+			Ingress: v1.JaegerIngressSpec{
+				Enabled:  &ingressEnabled,
+				Security: v1.IngressSecurityNoneExplicit,
+			},
+			Strategy: v1.DeploymentStrategyProduction,
+			Storage: v1.JaegerStorageSpec{
+				Type: v1.JaegerESStorage,
+				Options: v1.NewOptions(map[string]interface{}{
+					"es.server-urls": esServerUrls,
+				}),
+			},
+		},
+	}
+
+	updateOtelImages(simpleProdCR)
+
+	return simpleProdCR
+}
+
+// GetJaegerSelfProvSimpleProdCR returns self provisioned production simple CR
+func GetJaegerSelfProvSimpleProdCR(instanceName, namespace string, nodeCount int32) *v1.Jaeger {
+	ingressEnabled := true
+	selfProvSimpleProdCR := &v1.Jaeger{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Jaeger",
+			APIVersion: "jaegertracing.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      instanceName,
+			Namespace: namespace,
+		},
+		Spec: v1.JaegerSpec{
+			Ingress: v1.JaegerIngressSpec{
+				Enabled:  &ingressEnabled,
+				Security: v1.IngressSecurityNoneExplicit,
+			},
+			Strategy: v1.DeploymentStrategyProduction,
+			Storage: v1.JaegerStorageSpec{
+				Type: v1.JaegerESStorage,
+				Elasticsearch: v1.ElasticsearchSpec{
+					NodeCount: nodeCount,
+					Resources: &corev1.ResourceRequirements{
+						Limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("2Gi")},
+						Requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("1Gi")},
+					},
+				},
+			},
+		},
+	}
+
+	updateOtelImages(selfProvSimpleProdCR)
+
+	return selfProvSimpleProdCR
+}

--- a/test/e2e/utils_elasticsearch.go
+++ b/test/e2e/utils_elasticsearch.go
@@ -10,11 +10,12 @@ import (
 	"net/http"
 	"strconv"
 
-	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/portforward"
+
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 )
 
 // EsIndex struct to map indices data from es rest api response

--- a/test/e2e/utils_elasticsearch.go
+++ b/test/e2e/utils_elasticsearch.go
@@ -1,0 +1,104 @@
+package e2e
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/portforward"
+)
+
+// EsIndex struct to map indices data from es rest api response
+// es api: /_cat/indices?format=json
+type EsIndex struct {
+	UUID        string `json:"uuid"`
+	Status      string `json:"status"`
+	Index       string `json:"index"`
+	Health      string `json:"health"`
+	DocsCount   string `json:"docs.count"`
+	DocsDeleted string `json:"docs.deleted"`
+	StoreSize   string `json:"store.size"`
+}
+
+// GetEsIndices return indices from es node
+func GetEsIndices(esNamespace string) ([]EsIndex, error) {
+	bodyBytes, err := ExecuteEsRequest(esNamespace, http.MethodGet, "/_cat/indices?format=json")
+	require.NoError(t, err)
+
+	// convert json data to struct format
+	esIndices := make([]EsIndex, 0)
+	err = json.Unmarshal(bodyBytes, &esIndices)
+	require.NoError(t, err)
+
+	return esIndices, nil
+}
+
+// DeleteEsIndices deletes all the indices on es node
+func DeleteEsIndices(esNamespace string) {
+	logrus.Info("deleting all es node indices")
+	_, err := ExecuteEsRequest(esNamespace, http.MethodDelete, "/_all?format=json")
+	require.NoError(t, err)
+}
+
+// ExecuteEsRequest executes rest api request on es node
+func ExecuteEsRequest(esNamespace, httpMethod, api string) ([]byte, error) {
+	// enable port forward
+	fwdPortES, closeChanES, esPort := CreateEsPortForward(esNamespace)
+	defer fwdPortES.Close()
+	defer close(closeChanES)
+
+	// update es node url
+	urlScheme := "http"
+	if skipESExternal {
+		urlScheme = "https"
+	}
+	esURL := fmt.Sprintf("%s://localhost:%s%s", urlScheme, esPort, api)
+
+	// create rest client to access es node rest API
+	transport := &http.Transport{}
+	client := http.Client{Transport: transport}
+
+	// update certificates, if the es node provided by jaeger-operator
+	if skipESExternal {
+		esSecret, err := fw.KubeClient.CoreV1().Secrets(namespace).Get(context.Background(), "elasticsearch", metav1.GetOptions{})
+		require.NoError(t, err)
+		pool := x509.NewCertPool()
+		pool.AppendCertsFromPEM(esSecret.Data["admin-ca"])
+
+		clientCert, err := tls.X509KeyPair(esSecret.Data["admin-cert"], esSecret.Data["admin-key"])
+		require.NoError(t, err)
+
+		transport.TLSClientConfig = &tls.Config{
+			RootCAs:      pool,
+			Certificates: []tls.Certificate{clientCert},
+		}
+	}
+
+	req, err := http.NewRequest(httpMethod, esURL, nil)
+	require.NoError(t, err)
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.EqualValues(t, 200, resp.StatusCode)
+
+	return ioutil.ReadAll(resp.Body)
+}
+
+// CreateEsPortForward creates local port forwarding
+func CreateEsPortForward(esNamespace string) (portForwES *portforward.PortForwarder, closeChanES chan struct{}, esPort string) {
+	portForwES, closeChanES = CreatePortForward(esNamespace, string(v1.JaegerESStorage), string(v1.JaegerESStorage), []string{"0:9200"}, fw.KubeConfig)
+	forwardedPorts, err := portForwES.GetPorts()
+	require.NoError(t, err)
+	return portForwES, closeChanES, strconv.Itoa(int(forwardedPorts[0].Local))
+}


### PR DESCRIPTION
#### Changes summary:
* Generates spans/services data for 45 days, generates 45 days indices
* runs index cleaner tests with different day limits (`numberOfDays`), 45, 30, 7, 1, 0 days
* Verifies the indices were removed
* Verifies there are no past indices
* Verifies index prefix
* all the tests on production environment