### PR TITLE
Create missing CA config maps on deployment controller

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
 	github.com/go-openapi/spec v0.19.8
 	github.com/googleapis/gnostic v0.3.1
+	github.com/kr/pretty v0.2.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/openshift/api v0.0.0-20200701144905-de5b010b2b38
 	github.com/opentracing/opentracing-go v1.1.1-0.20190913142402-a7454ce5950e

--- a/go.sum
+++ b/go.sum
@@ -646,6 +646,8 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxv
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
+github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/pty v1.1.8/go.mod h1:O1sed60cT9XZ5uDucP5qwvh+TE3NnUj51EiZO/lmSfw=

--- a/pkg/inject/sidecar.go
+++ b/pkg/inject/sidecar.go
@@ -76,17 +76,34 @@ func Sidecar(jaeger *v1.Jaeger, dep *appsv1.Deployment) *appsv1.Deployment {
 	return dep
 }
 
-// Needed determines whether a pod needs to get a sidecar injected or not
-func Needed(dep *appsv1.Deployment, ns *corev1.Namespace) bool {
+// Desired determines whether a sidecar is desired, based on the annotation from both the deployment and the namespace
+func Desired(dep *appsv1.Deployment, ns *corev1.Namespace) bool {
+	logger := log.WithFields(log.Fields{
+		"namespace":  dep.Namespace,
+		"deployment": dep.Name,
+	})
 	_, depExist := dep.Annotations[Annotation]
 	_, nsExist := ns.Annotations[Annotation]
-	if !depExist && !nsExist {
-		log.WithFields(log.Fields{
-			"namespace":  dep.Namespace,
-			"deployment": dep.Name,
-		}).Trace("annotation not present, not injecting")
+
+	if depExist {
+		logger.Debug("annotation present on deployment")
+		return true
+	}
+
+	if nsExist {
+		logger.Debug("annotation present on namespace")
+		return true
+	}
+
+	return false
+}
+
+// Needed determines whether a pod needs to get a sidecar injected or not
+func Needed(dep *appsv1.Deployment, ns *corev1.Namespace) bool {
+	if !Desired(dep, ns) {
 		return false
 	}
+
 	// do not inject jaeger due to port collision
 	// do not inject if deployment's Annotation value is false
 	if dep.Labels["app"] == "jaeger" {


### PR DESCRIPTION
This PR changes the deployment controller so that it always attempt to create the configmaps in the namespace for the target deployments, as long as sidecar injection is desired for the deployment.

﻿Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
