### PR TITLE
Add volumes and volume-mounts for spark dependencies

### DIFF
--- a/pkg/cronjob/spark_dependencies.go
+++ b/pkg/cronjob/spark_dependencies.go
@@ -96,6 +96,7 @@ func CreateSparkDependencies(jaeger *v1.Jaeger) *batchv1beta1.CronJob {
 									Env:       util.RemoveEmptyVars(envVars),
 									EnvFrom:   envFromSource,
 									Resources: commonSpec.Resources,
+									VolumeMounts: jaeger.Spec.Storage.Dependencies.JaegerCommonSpec.VolumeMounts,
 								},
 							},
 							RestartPolicy:      corev1.RestartPolicyNever,
@@ -103,6 +104,7 @@ func CreateSparkDependencies(jaeger *v1.Jaeger) *batchv1beta1.CronJob {
 							Tolerations:        commonSpec.Tolerations,
 							SecurityContext:    commonSpec.SecurityContext,
 							ServiceAccountName: account.JaegerServiceAccountFor(jaeger, account.DependenciesComponent),
+							Volumes:			jaeger.Spec.Storage.Dependencies.JaegerCommonSpec.Volumes,
 						},
 						ObjectMeta: metav1.ObjectMeta{
 							Labels:      commonSpec.Labels,

--- a/pkg/cronjob/spark_dependencies.go
+++ b/pkg/cronjob/spark_dependencies.go
@@ -93,9 +93,9 @@ func CreateSparkDependencies(jaeger *v1.Jaeger) *batchv1beta1.CronJob {
 									Image: image,
 									Name:  name,
 									// let spark job use its default values
-									Env:       util.RemoveEmptyVars(envVars),
-									EnvFrom:   envFromSource,
-									Resources: commonSpec.Resources,
+									Env:          util.RemoveEmptyVars(envVars),
+									EnvFrom:      envFromSource,
+									Resources:    commonSpec.Resources,
 									VolumeMounts: jaeger.Spec.Storage.Dependencies.JaegerCommonSpec.VolumeMounts,
 								},
 							},
@@ -104,7 +104,7 @@ func CreateSparkDependencies(jaeger *v1.Jaeger) *batchv1beta1.CronJob {
 							Tolerations:        commonSpec.Tolerations,
 							SecurityContext:    commonSpec.SecurityContext,
 							ServiceAccountName: account.JaegerServiceAccountFor(jaeger, account.DependenciesComponent),
-							Volumes:			jaeger.Spec.Storage.Dependencies.JaegerCommonSpec.Volumes,
+							Volumes:            jaeger.Spec.Storage.Dependencies.JaegerCommonSpec.Volumes,
 						},
 						ObjectMeta: metav1.ObjectMeta{
 							Labels:      commonSpec.Labels,

--- a/pkg/cronjob/spark_dependencies_test.go
+++ b/pkg/cronjob/spark_dependencies_test.go
@@ -230,22 +230,22 @@ func TestDependenciesVolumes(t *testing.T) {
 	testConfigMapName := "dvConfigMap"
 	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestDependenciesVolumes"})
 	testVolume := corev1.Volume{
-		Name:         testVolumeName,
+		Name: testVolumeName,
 		VolumeSource: corev1.VolumeSource{
-			ConfigMap:             &corev1.ConfigMapVolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
 				LocalObjectReference: corev1.LocalObjectReference{Name: testConfigMapName},
 			},
 		},
 	}
 	testVolumes := []corev1.Volume{testVolume}
-	jaeger.Spec.Storage.Dependencies.JaegerCommonSpec.Volumes=testVolumes
+	jaeger.Spec.Storage.Dependencies.JaegerCommonSpec.Volumes = testVolumes
 
 	testVolumeMountName := "testVolumeMount"
 	testMountPath := "/es-tls"
 	testVolumeMount := corev1.VolumeMount{
-		Name:             testVolumeMountName,
-		ReadOnly:         false,
-		MountPath:        testMountPath,
+		Name:      testVolumeMountName,
+		ReadOnly:  false,
+		MountPath: testMountPath,
 	}
 	testVolumeMounts := []corev1.VolumeMount{testVolumeMount}
 	jaeger.Spec.Storage.Dependencies.JaegerCommonSpec.VolumeMounts = testVolumeMounts


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com>

This fixes #1332   Note however that TLS access for the spark dependencies job is not fully supported (see issue #294 ) in general but will work for the instance described in this issue.