### PR TITLE
add agent dnsPolicy option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -393,7 +393,7 @@ install-tools:
 		golang.org/x/lint/golint \
 		golang.org/x/tools/cmd/goimports \
 		github.com/securego/gosec/cmd/gosec@v0.0.0-20191008095658-28c1128b7336 \
-		sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.4 \
+		sigs.k8s.io/controller-tools/cmd/controller-gen@v0.3.0 \
 		k8s.io/code-generator/cmd/client-gen@v0.18.6 \
 		k8s.io/kube-openapi/cmd/openapi-gen@v0.0.0-20200410145947-61e04a5be9a6
 

--- a/deploy/crds/jaegertracing.io_jaegers_crd.yaml
+++ b/deploy/crds/jaegertracing.io_jaegers_crd.yaml
@@ -580,6 +580,8 @@ spec:
                   type: object
                 config:
                   type: object
+                dnsPolicy:
+                  type: string
                 hostNetwork:
                   type: boolean
                 image:

--- a/pkg/apis/jaegertracing/v1/jaeger_types.go
+++ b/pkg/apis/jaegertracing/v1/jaeger_types.go
@@ -460,6 +460,9 @@ type JaegerAgentSpec struct {
 	HostNetwork *bool `json:"hostNetwork,omitempty"`
 
 	// +optional
+	DNSPolicy v1.DNSPolicy `json:"dnsPolicy,omitempty"`
+
+	// +optional
 	PriorityClassName string `json:"priorityClassName,omitempty"`
 }
 

--- a/pkg/apis/jaegertracing/v1/zz_generated.openapi.go
+++ b/pkg/apis/jaegertracing/v1/zz_generated.openapi.go
@@ -346,6 +346,12 @@ func schema_pkg_apis_jaegertracing_v1_JaegerAgentSpec(ref common.ReferenceCallba
 							Format: "",
 						},
 					},
+					"dnsPolicy": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 					"priorityClassName": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},

--- a/pkg/deployment/agent.go
+++ b/pkg/deployment/agent.go
@@ -82,8 +82,12 @@ func (a *Agent) Get() *appsv1.DaemonSet {
 	sort.Strings(args)
 
 	hostNetwork := false
+	dnsPolicy := a.jaeger.Spec.Agent.DNSPolicy
 	if a.jaeger.Spec.Agent.HostNetwork != nil {
 		hostNetwork = *a.jaeger.Spec.Agent.HostNetwork
+		if dnsPolicy == "" {
+			dnsPolicy = corev1.DNSClusterFirstWithHostNet
+		}
 	}
 	priorityClassName := ""
 	if a.jaeger.Spec.Agent.PriorityClassName != "" {
@@ -173,6 +177,7 @@ func (a *Agent) Get() *appsv1.DaemonSet {
 						Resources:    commonSpec.Resources,
 						VolumeMounts: commonSpec.VolumeMounts,
 					}},
+					DNSPolicy:          dnsPolicy,
 					HostNetwork:        hostNetwork,
 					PriorityClassName:  priorityClassName,
 					Volumes:            commonSpec.Volumes,

--- a/pkg/deployment/agent_test.go
+++ b/pkg/deployment/agent_test.go
@@ -246,6 +246,17 @@ func TestAgentHostNetwork(t *testing.T) {
 	assert.Equal(t, trueVar, dep.Spec.Template.Spec.HostNetwork)
 }
 
+func TestAgentDNSPolicyWithHostNetwork(t *testing.T) {
+	trueVar := true
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
+	jaeger.Spec.Agent.Strategy = "daemonset"
+	jaeger.Spec.Agent.HostNetwork = &trueVar
+	a := NewAgent(jaeger)
+	dep := a.Get()
+	assert.Equal(t, trueVar, dep.Spec.Template.Spec.HostNetwork)
+	assert.Equal(t, corev1.DNSClusterFirstWithHostNet, dep.Spec.Template.Spec.DNSPolicy)
+}
+
 func TestAgentPriorityClassName(t *testing.T) {
 	priorityClassName := "test-class"
 	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})

--- a/test/e2e/sidecar_namespace_test.go
+++ b/test/e2e/sidecar_namespace_test.go
@@ -62,7 +62,7 @@ func (suite *SidecarNamespaceTestSuite) TestSidecarNamespace() {
 	cleanupOptions := &framework.CleanupOptions{TestContext: ctx, Timeout: timeout, RetryInterval: retryInterval}
 
 	jaegerInstanceName := "agent-as-sidecar-namespace"
-	j := createJaegerAgentAsSidecarInstance(jaegerInstanceName, namespace)
+	j := createJaegerAgentAsSidecarInstance(jaegerInstanceName, namespace, &falseVar)
 	defer undeployJaegerInstance(j)
 
 	dep := getVertxDefinition(namespace, map[string]string{})

--- a/test/e2e/sidecar_test.go
+++ b/test/e2e/sidecar_test.go
@@ -26,6 +26,8 @@ import (
 )
 
 var ingressEnabled = true
+var trueVar = true
+var falseVar = true
 
 type SidecarTestSuite struct {
 	suite.Suite
@@ -68,8 +70,8 @@ func (suite *SidecarTestSuite) AfterTest(suiteName, testName string) {
 func (suite *SidecarTestSuite) TestSidecar() {
 	cleanupOptions := &framework.CleanupOptions{TestContext: ctx, Timeout: timeout, RetryInterval: retryInterval}
 
-	firstJaegerInstanceName := "agent-as-sidecar"
-	firstJaegerInstance := createJaegerAgentAsSidecarInstance(firstJaegerInstanceName, namespace)
+	firstJaegerInstanceName := "agent-as-sidecar-with-hostnetwork"
+	firstJaegerInstance := createJaegerAgentAsSidecarInstance(firstJaegerInstanceName, namespace, &trueVar)
 	defer undeployJaegerInstance(firstJaegerInstance)
 
 	vertxDeploymentName := "vertx-create-span-sidecar"
@@ -100,7 +102,7 @@ func (suite *SidecarTestSuite) TestSidecar() {
 
 	/* Testing other instance */
 	secondJaegerInstanceName := "agent-as-sidecar2"
-	secondJaegerInstance := createJaegerAgentAsSidecarInstance(secondJaegerInstanceName, namespace)
+	secondJaegerInstance := createJaegerAgentAsSidecarInstance(secondJaegerInstanceName, namespace, &falseVar)
 	defer undeployJaegerInstance(secondJaegerInstance)
 
 	persisted := &appsv1.Deployment{}
@@ -109,7 +111,7 @@ func (suite *SidecarTestSuite) TestSidecar() {
 		Namespace: namespace,
 	}, persisted)
 	require.NoError(t, err, "Error getting jaeger instance")
-	require.Equal(t, "agent-as-sidecar", persisted.Labels[inject.Label])
+	require.Equal(t, firstJaegerInstanceName, persisted.Labels[inject.Label])
 
 	err = fw.Client.Delete(goctx.TODO(), firstJaegerInstance)
 	require.NoError(t, err, "Error deleting instance")
@@ -191,7 +193,7 @@ func getVertxDefinition(deploymentName string, annotations map[string]string) *a
 	return dep
 }
 
-func createJaegerAgentAsSidecarInstance(name, namespace string) *v1.Jaeger {
+func createJaegerAgentAsSidecarInstance(name, namespace string, hostNetwork *bool) *v1.Jaeger {
 	cleanupOptions := &framework.CleanupOptions{TestContext: ctx, Timeout: timeout, RetryInterval: retryInterval}
 
 	j := &v1.Jaeger{
@@ -211,6 +213,7 @@ func createJaegerAgentAsSidecarInstance(name, namespace string) *v1.Jaeger {
 			},
 			AllInOne: v1.JaegerAllInOneSpec{},
 			Agent: v1.JaegerAgentSpec{
+				HostNetwork: hostNetwork,
 				Options: v1.NewOptions(map[string]interface{}{
 					"log-level": "debug",
 				}),


### PR DESCRIPTION
ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy

It should solve some dns problems, like this https://github.com/jaegertracing/jaeger-operator/issues/676#issuecomment-731601405