### PR TITLE
Removed the remaining otel items from the mergify configuration

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -10,17 +10,20 @@ pull_request_rules:
       - "#approved-reviews-by>=1"
       - "-draft"
       - "status-success=basic-checks"
-      - "status-success=end-to-end (smoke)"
-      - "status-success=end-to-end (es)"
+      - "status-success=codecov/patch" # we don't require those, but we might want to manually check before automatically merging
+      - "status-success=codecov/project"
+      - "status-success=CodeQL Analyze (go)"
+      - "status-success=DCO"
       - "status-success=end-to-end (cassandra)"
-      - "status-success=end-to-end (streaming)"
+      - "status-success=end-to-end (es)"
       - "status-success=end-to-end (examples1)"
       - "status-success=end-to-end (examples2)"
       - "status-success=end-to-end (generate)"
-      - "status-success=DCO"
+      - "status-success=end-to-end (istio)"
+      - "status-success=end-to-end (smoke)"
+      - "status-success=end-to-end (streaming)"
+      - "status-success=end-to-end (upgrade)"
       - "status-success=WIP"
-      - "status-success=codecov/patch" # we don't require those, but we might want to manually check before automatically merging
-      - "status-success=codecov/project"
     actions:
       merge:
         method: squash
@@ -75,16 +78,19 @@ pull_request_rules:
     conditions:
       - author~=^dependabot(|-preview)\[bot\]$
       - "status-success=basic-checks"
-      - "status-success=end-to-end (smoke)"
-      - "status-success=end-to-end (es)"
+      - "status-success=codecov/patch" # we don't require those, but we might want to manually check before automatically merging
+      - "status-success=codecov/project"
+      - "status-success=CodeQL Analyze (go)"
+      - "status-success=DCO"
       - "status-success=end-to-end (cassandra)"
-      - "status-success=end-to-end (streaming)"
+      - "status-success=end-to-end (es)"
       - "status-success=end-to-end (examples1)"
       - "status-success=end-to-end (examples2)"
       - "status-success=end-to-end (generate)"
-      - "status-success=end-to-end (es-otel)"
-      - "status-success=end-to-end (streaming-otel)"
-      - "status-success=DCO"
+      - "status-success=end-to-end (istio)"
+      - "status-success=end-to-end (smoke)"
+      - "status-success=end-to-end (streaming)"
+      - "status-success=end-to-end (upgrade)"
       - "status-success=WIP"
     actions:
       merge:

--- a/.github/workflows/base-checks.yaml
+++ b/.github/workflows/base-checks.yaml
@@ -1,5 +1,10 @@
 name: "CI Workflow"
-on: [push, pull_request]
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   basic-checks:

--- a/.github/workflows/e2e-kubernetes.yaml
+++ b/.github/workflows/e2e-kubernetes.yaml
@@ -1,5 +1,10 @@
 name: "Kubernetes end-to-end tests"
-on: [push, pull_request]
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   end-to-end:

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -1,8 +1,8 @@
 name: "Publish images"
+
 on:
   push:
-    branches:
-      - master
+    branches: [ master ]
 
 jobs:
   publish:


### PR DESCRIPTION
Additionally, changed some actions to run only for master or for pull requests for master, avoiding double run for branches pushed to this repository, as it's the case for dependabot PRs.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
