### PR TITLE
Add support for NodePort in Jaeger Query Service

### DIFF
--- a/pkg/apis/jaegertracing/v1/jaeger_types.go
+++ b/pkg/apis/jaegertracing/v1/jaeger_types.go
@@ -253,6 +253,10 @@ type JaegerQuerySpec struct {
 	ServiceType v1.ServiceType `json:"serviceType,omitempty"`
 
 	// +optional
+	// NodePort represents the port at which the NodePort service to allocate
+	NodePort int32 `json:"nodePort,omitempty"`
+
+	// +optional
 	// TracingEnabled if set to false adds the JAEGER_DISABLED environment flag and removes the injected
 	// agent container from the query component to disable tracing requests to the query service.
 	// The default, if ommited, is true

--- a/pkg/apis/jaegertracing/v1/zz_generated.openapi.go
+++ b/pkg/apis/jaegertracing/v1/zz_generated.openapi.go
@@ -1704,6 +1704,13 @@ func schema_pkg_apis_jaegertracing_v1_JaegerQuerySpec(ref common.ReferenceCallba
 							Format:      "",
 						},
 					},
+					"nodePort": {
+						SchemaProps: spec.SchemaProps{
+							Description: "NodePort represents the port at which the NodePort service to allocate",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 					"tracingEnabled": {
 						SchemaProps: spec.SchemaProps{
 							Description: "TracingEnabled if set to false adds the JAEGER_DISABLED environment flag and removes the injected agent container from the query component to disable tracing requests to the query service. The default, if ommited, is true",

--- a/pkg/service/query.go
+++ b/pkg/service/query.go
@@ -18,6 +18,17 @@ func NewQueryService(jaeger *v1.Jaeger, selector map[string]string) *corev1.Serv
 		annotations["service.alpha.openshift.io/serving-cert-secret-name"] = GetTLSSecretNameForQueryService(jaeger)
 	}
 
+	ports := []corev1.ServicePort{
+		{
+			Name:       getPortNameForQueryService(jaeger),
+			Port:       int32(GetPortForQueryService(jaeger)),
+			TargetPort: intstr.FromInt(getTargetPortForQueryService(jaeger)),
+		},
+	}
+	if jaeger.Spec.Query.ServiceType == corev1.ServiceTypeNodePort {
+		ports[0].NodePort = int32(GetNodePortForQueryService(jaeger))
+	}
+
 	return &corev1.Service{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Service",
@@ -41,13 +52,7 @@ func NewQueryService(jaeger *v1.Jaeger, selector map[string]string) *corev1.Serv
 		Spec: corev1.ServiceSpec{
 			Selector: selector,
 			Type:     getTypeForQueryService(jaeger),
-			Ports: []corev1.ServicePort{
-				{
-					Name:       getPortNameForQueryService(jaeger),
-					Port:       int32(GetPortForQueryService(jaeger)),
-					TargetPort: intstr.FromInt(getTargetPortForQueryService(jaeger)),
-				},
-			},
+			Ports:    ports,
 		},
 	}
 }
@@ -89,4 +94,9 @@ func getTypeForQueryService(jaeger *v1.Jaeger) corev1.ServiceType {
 		return jaeger.Spec.Query.ServiceType
 	}
 	return corev1.ServiceTypeClusterIP
+}
+
+// GetNodePortForQueryService returns the query service NodePort for this Jaeger instance
+func GetNodePortForQueryService(jaeger *v1.Jaeger) int {
+	return int(jaeger.Spec.Query.NodePort)
 }

--- a/pkg/service/query.go
+++ b/pkg/service/query.go
@@ -26,7 +26,7 @@ func NewQueryService(jaeger *v1.Jaeger, selector map[string]string) *corev1.Serv
 		},
 	}
 	if jaeger.Spec.Query.ServiceType == corev1.ServiceTypeNodePort {
-		ports[0].NodePort = int32(GetNodePortForQueryService(jaeger))
+		ports[0].NodePort = GetNodePortForQueryService(jaeger)
 	}
 
 	return &corev1.Service{
@@ -97,6 +97,6 @@ func getTypeForQueryService(jaeger *v1.Jaeger) corev1.ServiceType {
 }
 
 // GetNodePortForQueryService returns the query service NodePort for this Jaeger instance
-func GetNodePortForQueryService(jaeger *v1.Jaeger) int {
-	return int(jaeger.Spec.Query.NodePort)
+func GetNodePortForQueryService(jaeger *v1.Jaeger) int32 {
+	return jaeger.Spec.Query.NodePort
 }

--- a/pkg/service/query_test.go
+++ b/pkg/service/query_test.go
@@ -65,7 +65,7 @@ func TestQueryServiceNodePortWithIngress(t *testing.T) {
 	assert.Len(t, svc.Spec.Ports, 1)
 	assert.Equal(t, int32(16686), svc.Spec.Ports[0].Port)
 	assert.Equal(t, "http-query", svc.Spec.Ports[0].Name)
-	assert.Equal(t, 0, svc.Spec.Ports[0].NodePort)
+	assert.Equal(t, int32(0), svc.Spec.Ports[0].NodePort)
 	assert.Equal(t, intstr.FromInt(16686), svc.Spec.Ports[0].TargetPort)
 	assert.Equal(t, svc.Spec.Type, corev1.ServiceTypeNodePort) // make sure we get a NodePort service
 }
@@ -97,9 +97,9 @@ func TestQueryServiceSpecifiedNodePortWithIngress(t *testing.T) {
 
 	assert.Equal(t, "testqueryservicespecifiednodeportwithingress-query", svc.ObjectMeta.Name)
 	assert.Len(t, svc.Spec.Ports, 1)
-	assert.Equal(t, 16686, svc.Spec.Ports[0].Port)
+	assert.Equal(t, int32(16686), svc.Spec.Ports[0].Port)
 	assert.Equal(t, "http-query", svc.Spec.Ports[0].Name)
-	assert.Equal(t, 32767, svc.Spec.Ports[0].NodePort) // make sure we get the same NodePort as set above
+	assert.Equal(t, int32(32767), svc.Spec.Ports[0].NodePort) // make sure we get the same NodePort as set above
 	assert.Equal(t, intstr.FromInt(16686), svc.Spec.Ports[0].TargetPort)
 	assert.Equal(t, svc.Spec.Type, corev1.ServiceTypeNodePort)
 }

--- a/pkg/service/query_test.go
+++ b/pkg/service/query_test.go
@@ -65,6 +65,7 @@ func TestQueryServiceNodePortWithIngress(t *testing.T) {
 	assert.Len(t, svc.Spec.Ports, 1)
 	assert.Equal(t, int32(16686), svc.Spec.Ports[0].Port)
 	assert.Equal(t, "http-query", svc.Spec.Ports[0].Name)
+	assert.Equal(t, int32(0), svc.Spec.Ports[0].NodePort)
 	assert.Equal(t, intstr.FromInt(16686), svc.Spec.Ports[0].TargetPort)
 	assert.Equal(t, svc.Spec.Type, corev1.ServiceTypeNodePort) // make sure we get a NodePort service
 }
@@ -83,4 +84,22 @@ func TestQueryServiceLoadBalancerWithIngress(t *testing.T) {
 	assert.Equal(t, "http-query", svc.Spec.Ports[0].Name)
 	assert.Equal(t, intstr.FromInt(16686), svc.Spec.Ports[0].TargetPort)
 	assert.Equal(t, svc.Spec.Type, corev1.ServiceTypeLoadBalancer) // make sure we get a LoadBalancer service
+}
+
+func TestQueryServiceSpecifiedNodePortWithIngress(t *testing.T) {
+	name := "TestQueryServiceSpecifiedNodePortWithIngress"
+	selector := map[string]string{"app": "myapp", "jaeger": name, "jaeger-component": "query"}
+
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: name})
+	jaeger.Spec.Query.ServiceType = corev1.ServiceTypeNodePort
+	jaeger.Spec.Query.NodePort = 32767
+	svc := NewQueryService(jaeger, selector)
+
+	assert.Equal(t, "testqueryservicespecifiednodeportwithingress-query", svc.ObjectMeta.Name)
+	assert.Len(t, svc.Spec.Ports, 1)
+	assert.Equal(t, int32(16686), svc.Spec.Ports[0].Port)
+	assert.Equal(t, "http-query", svc.Spec.Ports[0].Name)
+	assert.Equal(t, int32(32767), svc.Spec.Ports[0].NodePort) // make sure we get the same NodePort as set above
+	assert.Equal(t, intstr.FromInt(16686), svc.Spec.Ports[0].TargetPort)
+	assert.Equal(t, svc.Spec.Type, corev1.ServiceTypeNodePort)
 }

--- a/pkg/service/query_test.go
+++ b/pkg/service/query_test.go
@@ -65,7 +65,7 @@ func TestQueryServiceNodePortWithIngress(t *testing.T) {
 	assert.Len(t, svc.Spec.Ports, 1)
 	assert.Equal(t, int32(16686), svc.Spec.Ports[0].Port)
 	assert.Equal(t, "http-query", svc.Spec.Ports[0].Name)
-	assert.Equal(t, int32(0), svc.Spec.Ports[0].NodePort)
+	assert.Equal(t, 0, svc.Spec.Ports[0].NodePort)
 	assert.Equal(t, intstr.FromInt(16686), svc.Spec.Ports[0].TargetPort)
 	assert.Equal(t, svc.Spec.Type, corev1.ServiceTypeNodePort) // make sure we get a NodePort service
 }
@@ -97,9 +97,9 @@ func TestQueryServiceSpecifiedNodePortWithIngress(t *testing.T) {
 
 	assert.Equal(t, "testqueryservicespecifiednodeportwithingress-query", svc.ObjectMeta.Name)
 	assert.Len(t, svc.Spec.Ports, 1)
-	assert.Equal(t, int32(16686), svc.Spec.Ports[0].Port)
+	assert.Equal(t, 16686, svc.Spec.Ports[0].Port)
 	assert.Equal(t, "http-query", svc.Spec.Ports[0].Name)
-	assert.Equal(t, int32(32767), svc.Spec.Ports[0].NodePort) // make sure we get the same NodePort as set above
+	assert.Equal(t, 32767, svc.Spec.Ports[0].NodePort) // make sure we get the same NodePort as set above
 	assert.Equal(t, intstr.FromInt(16686), svc.Spec.Ports[0].TargetPort)
 	assert.Equal(t, svc.Spec.Type, corev1.ServiceTypeNodePort)
 }


### PR DESCRIPTION
This PR should allow users to expose Jaeger's Query service as a NodePort at a specific port. Earlier, the Jaeger Operator did not support specifying a port value and would depend on K8s to randomly select an apt port value. This should resolve this blocker.

Resolves #1307 