### PR TITLE
tests to verify toleration feature

### DIFF
--- a/.ci/run-e2e-tests.sh
+++ b/.ci/run-e2e-tests.sh
@@ -56,6 +56,10 @@ elif [ "${TEST_GROUP}" = "istio" ]
 then
     echo "Running Smoke Tests with istio"
     make e2e-tests-istio
+elif [ "${TEST_GROUP}" = "tolerations" ]
+then
+    echo "Running Tolerations Tests"
+    make e2e-tests-tolerations
 else
     echo "Unknown TEST_GROUP [${TEST_GROUP}]"; exit 1
 fi

--- a/.github/workflows/e2e-kubernetes.yaml
+++ b/.github/workflows/e2e-kubernetes.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-16.04
     strategy:
       matrix:
-        TEST_GROUP: [smoke, es, cassandra, streaming, examples1, examples2, generate, upgrade, istio]
+        TEST_GROUP: [smoke, es, cassandra, streaming, examples1, examples2, generate, upgrade, istio, tolerations]
     steps:
     - uses: actions/setup-go@v2.1.3
       with:

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ unit-tests:
 	@go test $(VERBOSE) $(UNIT_TEST_PACKAGES) -cover -coverprofile=cover.out -ldflags $(LD_FLAGS)
 
 .PHONY: e2e-tests
-e2e-tests: prepare-e2e-tests e2e-tests-smoke e2e-tests-cassandra e2e-tests-es e2e-tests-self-provisioned-es e2e-tests-streaming e2e-tests-examples1 e2e-tests-examples2 e2e-tests-examples-openshift e2e-tests-generate
+e2e-tests: prepare-e2e-tests e2e-tests-smoke e2e-tests-cassandra e2e-tests-es e2e-tests-self-provisioned-es e2e-tests-streaming e2e-tests-examples1 e2e-tests-examples2 e2e-tests-examples-openshift e2e-tests-generate e2e-tests-tolerations
 
 .PHONY: prepare-e2e-tests
 prepare-e2e-tests: build docker push
@@ -202,6 +202,11 @@ e2e-tests-upgrade: prepare-e2e-tests
 e2e-tests-istio: prepare-e2e-tests istio
 	@echo Running Istio end-to-end tests...
 	@STORAGE_NAMESPACE=$(STORAGE_NAMESPACE) KAFKA_NAMESPACE=$(KAFKA_NAMESPACE) go test -tags=istio ./test/e2e/... $(TEST_OPTIONS)
+
+.PHONY: e2e-tests-tolerations
+e2e-tests-tolerations: prepare-e2e-tests deploy-es-operator
+	@echo Running Tolerantions end-to-end tests...
+	go test -tags=tolerations ./test/e2e/... $(TEST_OPTIONS)
 
 .PHONY: run
 run: crd

--- a/Makefile
+++ b/Makefile
@@ -204,9 +204,9 @@ e2e-tests-istio: prepare-e2e-tests istio
 	@STORAGE_NAMESPACE=$(STORAGE_NAMESPACE) KAFKA_NAMESPACE=$(KAFKA_NAMESPACE) go test -tags=istio ./test/e2e/... $(TEST_OPTIONS)
 
 .PHONY: e2e-tests-tolerations
-e2e-tests-tolerations: prepare-e2e-tests deploy-es-operator
+e2e-tests-tolerations: prepare-e2e-tests deploy-es-operator es
 	@echo Running Tolerantions end-to-end tests...
-	go test -tags=tolerations ./test/e2e/... $(TEST_OPTIONS)
+	@STORAGE_NAMESPACE=$(STORAGE_NAMESPACE) ES_OPERATOR_NAMESPACE=$(ES_OPERATOR_NAMESPACE) ES_OPERATOR_IMAGE=$(ES_OPERATOR_IMAGE) go test -tags=tolerations ./test/e2e/... $(TEST_OPTIONS)
 
 .PHONY: run
 run: crd

--- a/test/e2e/all_in_one_test.go
+++ b/test/e2e/all_in_one_test.go
@@ -127,7 +127,7 @@ func (suite *AllInOneTestSuite) TestAllInOneWithUIConfig() {
 	cleanupOptions := &framework.CleanupOptions{TestContext: ctx, Timeout: timeout, RetryInterval: retryInterval}
 	basePath := "/jaeger"
 
-	j := GetJaegerAllInOneWithUiCR(basePath, TrackingID)
+	j := GetJaegerAllInOneWithUICR(basePath, TrackingID)
 	err := fw.Client.Create(goctx.TODO(), j, cleanupOptions)
 	require.NoError(t, err, "Error creating jaeger instance")
 	err = e2eutil.WaitForDeployment(t, fw.KubeClient, namespace, "all-in-one-with-ui-config", 1, retryInterval, timeout)

--- a/test/e2e/smoketest.go
+++ b/test/e2e/smoketest.go
@@ -37,18 +37,18 @@ func AllInOneSmokeTestWithQueryBasePath(jaegerInstanceName, queryBasePath string
 
 	// Use ingress for k8s or on OpenShift if we have an insecure route
 	var apiTracesEndpoint string
-	queryApi := "/api/traces"
+	queryAPI := "/api/traces"
 	if queryBasePath != "" {
 		if !strings.HasPrefix(queryBasePath, "/") {
 			queryBasePath = fmt.Sprintf("/%s", queryBasePath)
 		}
-		queryApi = fmt.Sprintf("%s/api/traces", queryBasePath)
+		queryAPI = fmt.Sprintf("%s/api/traces", queryBasePath)
 	}
 	insecureEndpoint := hasInsecureEndpoint(jaegerInstanceName, namespace)
 	if insecureEndpoint {
-		apiTracesEndpoint = getQueryURL(jaegerInstanceName, namespace, "%s"+queryApi)
+		apiTracesEndpoint = getQueryURL(jaegerInstanceName, namespace, "%s"+queryAPI)
 	} else {
-		apiTracesEndpoint = fmt.Sprintf("http://localhost:%d%s", queryPort, queryApi)
+		apiTracesEndpoint = fmt.Sprintf("http://localhost:%d%s", queryPort, queryAPI)
 	}
 	collectorEndpoint := fmt.Sprintf("http://localhost:%d/api/traces", collectorPort)
 	executeSmokeTest(apiTracesEndpoint, collectorEndpoint, insecureEndpoint)

--- a/test/e2e/tolerations_test.go
+++ b/test/e2e/tolerations_test.go
@@ -1,0 +1,170 @@
+// +build tolerations
+
+package e2e
+
+import (
+	goctx "context"
+	"fmt"
+	"testing"
+
+	framework "github.com/operator-framework/operator-sdk/pkg/test"
+	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+type TolerationsTestSuite struct {
+	suite.Suite
+}
+
+func (suite *TolerationsTestSuite) SetupSuite() {
+	t = suite.T()
+	var err error
+	ctx, err = prepare(t)
+	if err != nil {
+		if ctx != nil {
+			ctx.Cleanup()
+		}
+		require.FailNow(t, "Failed in prepare")
+	}
+	fw = framework.Global
+	namespace = ctx.GetID()
+	require.NotNil(t, namespace, "GetID failed")
+
+	addToFrameworkSchemeForSmokeTests(t)
+}
+
+func (suite *TolerationsTestSuite) TearDownSuite() {
+	handleSuiteTearDown()
+}
+
+func TestTolerationsTestSuite(t *testing.T) {
+	suite.Run(t, new(TolerationsTestSuite))
+}
+
+func (suite *TolerationsTestSuite) SetupTest() {
+	t = suite.T()
+}
+
+func (suite *TolerationsTestSuite) AfterTest(suiteName, testName string) {
+	handleTestFailure()
+}
+
+func (suite *TolerationsTestSuite) TestAllInOneTolerations() {
+	jaegerInstanceName := "all-in-one-tolerations"
+
+	jaegerCR := GetJaegerAllInOneCR(jaegerInstanceName, namespace)
+
+	// get tolerations sample sets
+	tolerationsAllInOne := suite.getTolerations("all-in-one")
+
+	// update tolerations to jaeger cr
+	jaegerCR.Spec.AllInOne.Tolerations = tolerationsAllInOne
+
+	logrus.Infof("Creating jaeger services for tolerations test. jaeger-cr:%s, namespace:%s", jaegerInstanceName, namespace)
+	err := fw.Client.Create(goctx.TODO(), jaegerCR, &framework.CleanupOptions{TestContext: ctx, Timeout: timeout, RetryInterval: retryInterval})
+	require.NoError(t, err, "Error deploying Jaeger-all-in-one")
+	defer undeployJaegerInstance(jaegerCR)
+
+	err = e2eutil.WaitForDeployment(t, fw.KubeClient, namespace, jaegerInstanceName, 1, retryInterval, timeout)
+	require.NoError(t, err, "Error waiting for all-in-one deployment")
+
+	AllInOneSmokeTest(jaegerInstanceName)
+
+	// verify tolerations
+	instanceLabel := fmt.Sprintf("app=jaeger,app.kubernetes.io/component=all-in-one,app.kubernetes.io/instance=%s", jaegerInstanceName)
+	allInOneDeployments := getDeployments(namespace, instanceLabel)
+	require.Equal(t, 1, len(allInOneDeployments), "AllInOne deployments count not matching")
+	allInOneDeployment := allInOneDeployments[0]
+	require.Equal(t, int32(1), allInOneDeployment.Status.ReadyReplicas, "AllInOne deployment replicas count not matching")
+	suite.verifyTolerations(allInOneDeployment.Name, tolerationsAllInOne, allInOneDeployment.Spec.Template.Spec.Tolerations)
+}
+
+func (suite *TolerationsTestSuite) TestElasticsearchProdTolerations() {
+	jaegerInstanceName := "simple-prod-tolerations"
+	collectorReplicasCount := int32(1)
+	queryReplicasCount := int32(1)
+	esNodeCount := int32(1)
+
+	jaegerCR := GetJaegerSelfProvSimpleProdCR(jaegerInstanceName, namespace, esNodeCount)
+
+	// update replicas count
+	jaegerCR.Spec.Collector.Replicas = &collectorReplicasCount
+	jaegerCR.Spec.Query.Replicas = &queryReplicasCount
+
+	// get tolerations sample sets
+	tolerationsCollector := suite.getTolerations("collector")
+	tolerationsQuery := suite.getTolerations("query")
+	tolerationsES := suite.getTolerations("es")
+
+	// update tolerations to jaeger cr
+	jaegerCR.Spec.Collector.Tolerations = tolerationsCollector
+	jaegerCR.Spec.Query.Tolerations = tolerationsQuery
+	jaegerCR.Spec.Storage.Elasticsearch.Tolerations = tolerationsES
+
+	logrus.Infof("Creating jaeger services for tolerations test. jaeger-cr:%s, namespace:%s", jaegerInstanceName, namespace)
+	createESSelfProvDeployment(jaegerCR, jaegerInstanceName, namespace)
+	defer undeployJaegerInstance(jaegerCR)
+
+	// ProductionSmokeTest(jaegerInstanceName)
+
+	// verify tolerations
+
+	collectorDeployments := getDeployments(namespace, fmt.Sprintf("app=jaeger,app.kubernetes.io/component=collector,app.kubernetes.io/instance=%s", jaegerInstanceName))
+	require.Equal(t, 1, len(collectorDeployments), "Collector deployments count not matching")
+	collectorDeployment := collectorDeployments[0]
+	require.Equal(t, collectorReplicasCount, collectorDeployment.Status.ReadyReplicas, "Collector deployment replicas count not matching")
+	suite.verifyTolerations(collectorDeployment.Name, tolerationsCollector, collectorDeployment.Spec.Template.Spec.Tolerations)
+
+	queryDeployments := getDeployments(namespace, fmt.Sprintf("app=jaeger,app.kubernetes.io/component=query,app.kubernetes.io/instance=%s", jaegerInstanceName))
+	require.Equal(t, 1, len(queryDeployments), "Query deployments count not matching")
+	queryDeployment := queryDeployments[0]
+	require.Equal(t, queryReplicasCount, queryDeployment.Status.ReadyReplicas, "Query deployment replicas count not matching")
+	suite.verifyTolerations(queryDeployment.Name, tolerationsQuery, queryDeployment.Spec.Template.Spec.Tolerations)
+
+	esDeployments := getDeployments(namespace, "component=elasticsearch")
+	require.Equal(t, esNodeCount, int32(len(esDeployments)), "Elasticsearch deployments count not matching")
+
+	for index := 0; index < len(esDeployments); index++ {
+		esDeployment := esDeployments[index]
+		require.Equal(t, int32(1), esDeployment.Status.ReadyReplicas, "Elasticsearch deployment replicas count not matching")
+		suite.verifyTolerations(esDeployment.Name, tolerationsES, esDeployment.Spec.Template.Spec.Tolerations)
+	}
+}
+
+func (suite *TolerationsTestSuite) getTolerations(prefix string) []v1.Toleration {
+	tolerations := []v1.Toleration{
+		{Key: fmt.Sprintf("%s_equal_key1", prefix), Operator: v1.TolerationOpEqual, Value: "value1", Effect: v1.TaintEffectNoExecute},
+		{Key: fmt.Sprintf("%s_equal_key2", prefix), Operator: v1.TolerationOpEqual, Value: "value2", Effect: v1.TaintEffectNoSchedule},
+		{Key: fmt.Sprintf("%s_equal_key3", prefix), Operator: v1.TolerationOpEqual, Value: "value3", Effect: v1.TaintEffectPreferNoSchedule},
+
+		{Key: fmt.Sprintf("%s_exists_key1", prefix), Operator: v1.TolerationOpExists, Effect: v1.TaintEffectNoExecute},
+		{Key: fmt.Sprintf("%s_exists_key2", prefix), Operator: v1.TolerationOpExists, Effect: v1.TaintEffectNoSchedule},
+		{Key: fmt.Sprintf("%s_exists_key3", prefix), Operator: v1.TolerationOpExists, Effect: v1.TaintEffectPreferNoSchedule},
+	}
+	return tolerations
+}
+
+func (suite *TolerationsTestSuite) verifyTolerations(deploymentName string, expectedList []v1.Toleration, actualList []v1.Toleration) {
+	logrus.Infof("tolerations, deploymentName:%s, expectedList:[%+v]", deploymentName, expectedList)
+	logrus.Infof("tolerations, deploymentName:%s, actualList:[%+v]", deploymentName, actualList)
+	require.True(t, len(expectedList) <= len(actualList), "actual tolerations count is less than the expected")
+	for expectedIndex := 0; expectedIndex < len(expectedList); expectedIndex++ {
+		expected := expectedList[expectedIndex]
+		found := false
+		for actualIndex := 0; actualIndex < len(actualList); actualIndex++ {
+			actual := actualList[actualIndex]
+			if expected.Key == actual.Key &&
+				expected.Operator == actual.Operator &&
+				expected.Value == actual.Value &&
+				expected.Effect == actual.Effect {
+				found = true
+				break
+			}
+		}
+		require.True(t, found, "toleration not found on the actual list, %+v", expected)
+	}
+}

--- a/test/e2e/tolerations_test.go
+++ b/test/e2e/tolerations_test.go
@@ -104,9 +104,9 @@ func (suite *TolerationsTestSuite) TestElasticsearchProdTolerations() {
 }
 
 func (suite *TolerationsTestSuite) runProdTolerations(includeESSelfProvision bool) {
-	jaegerInstanceName := "simple-prod-tolerations"
+	jaegerInstanceName := "prod-tolerations"
 	if includeESSelfProvision {
-		jaegerInstanceName = "simple-prod-tolerations-with-es-prod"
+		jaegerInstanceName = "prod-es-tolerations"
 	}
 
 	collectorReplicasCount := int32(1)
@@ -137,7 +137,9 @@ func (suite *TolerationsTestSuite) runProdTolerations(includeESSelfProvision boo
 	// update tolerations to jaeger cr
 	jaegerCR.Spec.Collector.Tolerations = tolerationsCollector
 	jaegerCR.Spec.Query.Tolerations = tolerationsQuery
-	jaegerCR.Spec.Storage.Elasticsearch.Tolerations = tolerationsES
+	if includeESSelfProvision {
+		jaegerCR.Spec.Storage.Elasticsearch.Tolerations = tolerationsES
+	}
 
 	logrus.Infof("Creating jaeger services for tolerations test. jaeger-cr:%s, namespace:%s", jaegerInstanceName, namespace)
 	createESSelfProvDeployment(jaegerCR, jaegerInstanceName, namespace)

--- a/test/e2e/tolerations_test.go
+++ b/test/e2e/tolerations_test.go
@@ -109,7 +109,7 @@ func (suite *TolerationsTestSuite) TestElasticsearchProdTolerations() {
 	createESSelfProvDeployment(jaegerCR, jaegerInstanceName, namespace)
 	defer undeployJaegerInstance(jaegerCR)
 
-	// ProductionSmokeTest(jaegerInstanceName)
+	ProductionSmokeTest(jaegerInstanceName)
 
 	// verify tolerations
 
@@ -127,7 +127,6 @@ func (suite *TolerationsTestSuite) TestElasticsearchProdTolerations() {
 
 	esDeployments := getDeployments(namespace, "component=elasticsearch")
 	require.Equal(t, esNodeCount, int32(len(esDeployments)), "Elasticsearch deployments count not matching")
-
 	for index := 0; index < len(esDeployments); index++ {
 		esDeployment := esDeployments[index]
 		require.Equal(t, int32(1), esDeployment.Status.ReadyReplicas, "Elasticsearch deployment replicas count not matching")

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -814,3 +814,10 @@ func getBusinessAppCR() *os.File {
 	require.NoError(t, err)
 	return file
 }
+
+func getDeployments(namespace, labels string) []appsv1.Deployment {
+	listOptions := &metav1.ListOptions{LabelSelector: labels}
+	deploymentList, err := fw.KubeClient.AppsV1().Deployments(namespace).List(context.Background(), *listOptions)
+	require.NoError(t, err, "Failed get deployment details")
+	return deploymentList.Items
+}

--- a/test/e2e/utils_cr.go
+++ b/test/e2e/utils_cr.go
@@ -97,8 +97,8 @@ func GetJaegerAllInOneCR(instanceName, namespace string) *v1.Jaeger {
 	return allInOneCR
 }
 
-// GetJaegerAllInOneWithUiCR returns all-in-one with query base path and gaID CR
-func GetJaegerAllInOneWithUiCR(queryBasePath, trackingID string) *v1.Jaeger {
+// GetJaegerAllInOneWithUICR returns all-in-one with query base path and gaID CR
+func GetJaegerAllInOneWithUICR(queryBasePath, trackingID string) *v1.Jaeger {
 	allInOneCR := &v1.Jaeger{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Jaeger",

--- a/test/e2e/utils_cr.go
+++ b/test/e2e/utils_cr.go
@@ -98,14 +98,14 @@ func GetJaegerAllInOneCR(instanceName, namespace string) *v1.Jaeger {
 }
 
 // GetJaegerAllInOneWithUICR returns all-in-one with query base path and gaID CR
-func GetJaegerAllInOneWithUICR(queryBasePath, trackingID string) *v1.Jaeger {
+func GetJaegerAllInOneWithUICR(instanceName, namespace, queryBasePath, trackingID string) *v1.Jaeger {
 	allInOneCR := &v1.Jaeger{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Jaeger",
 			APIVersion: "jaegertracing.io/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "all-in-one-with-ui-config",
+			Name:      instanceName,
 			Namespace: namespace,
 		},
 		Spec: v1.JaegerSpec{

--- a/test/e2e/utils_cr.go
+++ b/test/e2e/utils_cr.go
@@ -71,3 +71,62 @@ func GetJaegerSelfProvSimpleProdCR(instanceName, namespace string, nodeCount int
 
 	return selfProvSimpleProdCR
 }
+
+// GetJaegerAllInOneCR returns all-in-one with additional options CR
+func GetJaegerAllInOneCR(instanceName, namespace string) *v1.Jaeger {
+	allInOneCR := &v1.Jaeger{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Jaeger",
+			APIVersion: "jaegertracing.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      instanceName,
+			Namespace: namespace,
+		},
+		Spec: v1.JaegerSpec{
+			Strategy: v1.DeploymentStrategyAllInOne,
+			AllInOne: v1.JaegerAllInOneSpec{
+				Options: v1.NewOptions(map[string]interface{}{
+					"log-level":         "debug",
+					"memory.max-traces": 10000,
+				}),
+			},
+		},
+	}
+
+	return allInOneCR
+}
+
+// GetJaegerAllInOneWithUiCR returns all-in-one with query base path and gaID CR
+func GetJaegerAllInOneWithUiCR(queryBasePath, trackingID string) *v1.Jaeger {
+	allInOneCR := &v1.Jaeger{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Jaeger",
+			APIVersion: "jaegertracing.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "all-in-one-with-ui-config",
+			Namespace: namespace,
+		},
+		Spec: v1.JaegerSpec{
+			Strategy: v1.DeploymentStrategyAllInOne,
+			AllInOne: v1.JaegerAllInOneSpec{
+				Options: v1.NewOptions(map[string]interface{}{
+					"query.base-path": queryBasePath,
+				}),
+			},
+			UI: v1.JaegerUISpec{
+				Options: v1.NewFreeForm(map[string]interface{}{
+					"tracking": map[string]interface{}{
+						"gaID": trackingID,
+					},
+				}),
+			},
+		},
+	}
+	allInOneCR.Spec.Annotations = map[string]string{
+		"nginx.ingress.kubernetes.io/ssl-redirect": "false",
+	}
+
+	return allInOneCR
+}


### PR DESCRIPTION
Signed-off-by: Jeeva Kandasamy <jkandasa@gmail.com>

#### Summary: 

##### Additions:
* added test suite for `tolerations` tests
* tolerations test suite has threes tests
  * `TestAllInOneTolerations` - verifies `tolerations` on all-in-one -- tolerations on all-in-one deployment
  * `TestProdTolerations` - verifies `tolerations` on production environment with external es cluster -- tolerations on collector, and query deployments
  * `TestElasticsearchProdTolerations` -  verifies `tolerations` on production environment with es self provision -- tolerations on collector, query, and es cluster deployments
* **NOTE:** `TestElasticsearchProdTolerations` will be skipped in the Kubernetes environment, however in the Makefile, I have mentioned `deploy-es-operator` (`e2e-tests-tolerations: prepare-e2e-tests deploy-es-operator es`), hence `es-operator` will be deployed on Kubernetes environment (which is not useful for now). To avoid this I have to split the `tolerations` suite. I need your input here.

##### Changes:
* To reuse `all-in-one` cr I have moved the CRs func from `all_in_one_test.go` to `utils_cr.go`
* Added `AllInOneSmokeTest` to all the tests in `all_in_one_test.go`, to ensure the functionality of the deployment
* minor change on `AllInOneSmokeTest` to support custom query base path, as a result created another func `AllInOneSmokeTestWithQueryBasePath`

@jpkrohling @kevinearls can you please review the changes