### PR TITLE
Allow configure custom certificates to collector

### DIFF
--- a/pkg/deployment/agent.go
+++ b/pkg/deployment/agent.go
@@ -45,7 +45,7 @@ func (a *Agent) Get() *appsv1.DaemonSet {
 
 	// Enable tls by default for openshift platform
 	if viper.GetString("platform") == v1.FlagPlatformOpenShift {
-		if len(util.FindItem("--reporter.grpc.tls=true", args)) == 0 {
+		if len(util.FindItem("--reporter.grpc.tls.enabled=true", args)) == 0 {
 			args = append(args, "--reporter.grpc.tls.enabled=true")
 			args = append(args, fmt.Sprintf("--reporter.grpc.tls.ca=%s", ca.ServiceCAPath))
 			args = append(args, fmt.Sprintf("--reporter.grpc.tls.server-name=%s.%s.svc.cluster.local", service.GetNameForHeadlessCollectorService(a.jaeger), a.jaeger.Namespace))

--- a/pkg/deployment/collector.go
+++ b/pkg/deployment/collector.go
@@ -75,8 +75,10 @@ func (c *Collector) Get() *appsv1.Deployment {
 		c.jaeger.Spec.Storage.Options.Filter(storageType.OptionsPrefix()))
 
 	sampling.Update(c.jaeger, commonSpec, &options)
-	tls.Update(c.jaeger, commonSpec, &options)
-	ca.Update(c.jaeger, commonSpec)
+	if len(util.FindItem("--collector.grpc.tls.enabled=true", args)) == 0 {
+		tls.Update(c.jaeger, commonSpec, &options)
+		ca.Update(c.jaeger, commonSpec)
+	}
 
 	// ensure we have a consistent order of the arguments
 	// see https://github.com/jaegertracing/jaeger-operator/issues/334


### PR DESCRIPTION
In the agent (`sidecar` mode) we allow user to set their custom TLS configuration, if we detect that the user set the flat `reporter.tls.enable=true`, we skip the automatic configuration.

That logic is not present on the collector, or in the agent in `daemonset` mode.  This PR fixs it. 

Also added a couple of tests.

Signed-off-by: Ruben Vargas <ruben.vp8510@gmail.com>