### PR TITLE
Preparing release v1.22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changes by Version
 ==================
 
+1.22.1 (2021-04-19)
+-------------------
+* Allow configure custom certificates to collector ([#1418](https://github.com/jaegertracing/jaeger-operator/pull/1418), [@rubenvp8510](https://github.com/rubenvp8510))
+* Add support for NodePort in Jaeger Query Service ([#1394](https://github.com/jaegertracing/jaeger-operator/pull/1394), [@CSP197](https://github.com/CSP197))
+
 1.22.0 (2021-03-16)
 -------------------
 * Add ability to indicate PriorityClass for collector and query ([#1413](https://github.com/jaegertracing/jaeger-operator/pull/1413), [@majidazimi](https://github.com/majidazimi))

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,15 +13,15 @@
 1. Commit version change and changelog and create a pull request:
 
    ```
-   git commit -sm "Preparing relase v1.22.0"
+   git commit -sm "Preparing release v1.22.1"
    ```
 
 1. Tag and push
 
     ```
     git checkout master ## it's only possible to release from master for now!
-    git tag release/v1.22.0
-    git push git@github.com:jaegertracing/jaeger-operator.git release/v1.22.0
+    git tag release/v1.22.1
+    git push git@github.com:jaegertracing/jaeger-operator.git release/v1.22.1
     ```
 
 1. Wait until release CI job finishes and then pull the changes:

--- a/deploy/crds/jaegertracing.io_jaegers_crd.yaml
+++ b/deploy/crds/jaegertracing.io_jaegers_crd.yaml
@@ -5651,6 +5651,9 @@ spec:
                   additionalProperties:
                     type: string
                   type: object
+                nodePort:
+                  format: int32
+                  type: integer
                 options:
                   type: object
                 priorityClassName:

--- a/versions.txt
+++ b/versions.txt
@@ -1,7 +1,7 @@
 # The Jaeger version to use by default. This is updated manually. Make sure to update the changelog
 # and add an upgrade procedure (pkg/upgrade) for the new version.
-jaeger=1.21.0
+jaeger=1.22.0
 
 # DO NOT EDIT the next value, it is updated automatically during the release.
 # Represents the current (latest) release of the Jaeger Operator.
-operator=1.22.0
+operator=1.22.1


### PR DESCRIPTION
Signed-off-by: Ruben Vargas <ruben.vp8510@gmail.com>

In order to fix https://github.com/jaegertracing/jaeger-operator/issues/1426 I have to do a new release.

We forgot to bump the Jaeger version on `version.txt`

@kevinearls  @jpkrohling Could you please review?

Thanks