### PR TITLE
Fix override storage and ingress values when upgrade to 1.22

### DIFF
--- a/pkg/upgrade/v1_22_0.go
+++ b/pkg/upgrade/v1_22_0.go
@@ -41,8 +41,8 @@ func upgrade1_22_0(ctx context.Context, client client.Client, jaeger v1.Jaeger) 
 
 func migrateCassandraVerifyFlagv1_22_0(j v1.Jaeger) v1.Jaeger {
 	j.Spec.Collector.Options = updateCassandraVerifyHostFlagv1_22_0(j.Spec.Collector.Options)
-	j.Spec.Storage.Options = updateCassandraVerifyHostFlagv1_22_0(j.Spec.Collector.Options)
-	j.Spec.Ingress.Options = updateCassandraVerifyHostFlagv1_22_0(j.Spec.Collector.Options)
+	j.Spec.Storage.Options = updateCassandraVerifyHostFlagv1_22_0(j.Spec.Storage.Options)
+	j.Spec.Ingress.Options = updateCassandraVerifyHostFlagv1_22_0(j.Spec.Ingress.Options)
 	return j
 }
 

--- a/pkg/upgrade/v1_22_0_test.go
+++ b/pkg/upgrade/v1_22_0_test.go
@@ -20,12 +20,23 @@ func TestUpgradeJaegerTagssv1_22_0(t *testing.T) {
 		"jaeger.tags": "somekey=somevalue",
 	})
 
+	storageOpts := v1.NewOptions(map[string]interface{}{
+		"server-urls": "https://example:9200",
+	})
+
+	ingressOpts := v1.NewOptions(map[string]interface{}{
+		"ingres-option": "value",
+	})
+
 	nsn := types.NamespacedName{Name: "my-instance"}
 	existing := v1.NewJaeger(nsn)
 	existing.Status.Version = "1.21.0"
 	existing.Spec.AllInOne.Options = opts
 	existing.Spec.Agent.Options = opts
 	existing.Spec.Collector.Options = opts
+	existing.Spec.Storage.Options = storageOpts
+	existing.Spec.Ingress.Options = ingressOpts
+
 	objs := []runtime.Object{existing}
 
 	s := scheme.Scheme
@@ -55,6 +66,10 @@ func TestUpgradeJaegerTagssv1_22_0(t *testing.T) {
 	assert.Contains(t, colOpts, "collector.tags")
 	assert.Equal(t, "somekey=somevalue", colOpts["collector.tags"])
 	assert.NotContains(t, colOpts, "jaeger.tags")
+
+	assert.Equal(t, storageOpts.Map(), persisted.Spec.Storage.Options.Map())
+	assert.Equal(t, ingressOpts.Map(), persisted.Spec.Ingress.Options.Map())
+
 }
 
 func TestDeleteQueryRemovedFlags(t *testing.T) {


### PR DESCRIPTION
This Fixes #1437 

Signed-off-by: Ruben Vargas <ruben.vp8510@gmail.com>