### PR TITLE
Implement backoff limit for jobs

### DIFF
--- a/deploy/crds/jaegertracing.io_jaegers_crd.yaml
+++ b/deploy/crds/jaegertracing.io_jaegers_crd.yaml
@@ -1,11 +1,31 @@
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.5.0
+    controller-gen.kubebuilder.io/version: v0.3.0
   creationTimestamp: null
   name: jaegers.jaegertracing.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.phase
+    description: Jaeger instance's status
+    name: Status
+    type: string
+  - JSONPath: .status.version
+    description: Jaeger Version
+    name: Version
+    type: string
+  - JSONPath: .spec.strategy
+    description: Jaeger deployment strategy
+    name: Strategy
+    type: string
+  - JSONPath: .spec.storage.type
+    description: Jaeger storage type
+    name: Storage
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: jaegertracing.io
   names:
     kind: Jaeger
@@ -13,11066 +33,11056 @@ spec:
     plural: jaegers
     singular: jaeger
   scope: Namespaced
-  versions:
-  - additionalPrinterColumns:
-    - description: Jaeger instance's status
-      jsonPath: .status.phase
-      name: Status
-      type: string
-    - description: Jaeger Version
-      jsonPath: .status.version
-      name: Version
-      type: string
-    - description: Jaeger deployment strategy
-      jsonPath: .spec.strategy
-      name: Strategy
-      type: string
-    - description: Jaeger storage type
-      jsonPath: .spec.storage.type
-      name: Storage
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1
-    schema:
-      openAPIV3Schema:
-        properties:
-          apiVersion:
-            type: string
-          kind:
-            type: string
-          metadata:
-            type: object
-          spec:
-            properties:
-              affinity:
-                properties:
-                  nodeAffinity:
-                    properties:
-                      preferredDuringSchedulingIgnoredDuringExecution:
-                        items:
-                          properties:
-                            preference:
-                              properties:
-                                matchExpressions:
-                                  items:
-                                    properties:
-                                      key:
-                                        type: string
-                                      operator:
-                                        type: string
-                                      values:
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                matchFields:
-                                  items:
-                                    properties:
-                                      key:
-                                        type: string
-                                      operator:
-                                        type: string
-                                      values:
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                              type: object
-                            weight:
-                              format: int32
-                              type: integer
-                          required:
-                          - preference
-                          - weight
-                          type: object
-                        type: array
-                      requiredDuringSchedulingIgnoredDuringExecution:
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            affinity:
+              properties:
+                nodeAffinity:
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      items:
                         properties:
-                          nodeSelectorTerms:
-                            items:
-                              properties:
-                                matchExpressions:
-                                  items:
-                                    properties:
-                                      key:
-                                        type: string
-                                      operator:
-                                        type: string
-                                      values:
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                matchFields:
-                                  items:
-                                    properties:
-                                      key:
-                                        type: string
-                                      operator:
-                                        type: string
-                                      values:
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                              type: object
-                            type: array
-                        required:
-                        - nodeSelectorTerms
-                        type: object
-                    type: object
-                  podAffinity:
-                    properties:
-                      preferredDuringSchedulingIgnoredDuringExecution:
-                        items:
-                          properties:
-                            podAffinityTerm:
-                              properties:
-                                labelSelector:
-                                  properties:
-                                    matchExpressions:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      type: object
-                                  type: object
-                                namespaces:
-                                  items:
-                                    type: string
-                                  type: array
-                                topologyKey:
-                                  type: string
-                              required:
-                              - topologyKey
-                              type: object
-                            weight:
-                              format: int32
-                              type: integer
-                          required:
-                          - podAffinityTerm
-                          - weight
-                          type: object
-                        type: array
-                      requiredDuringSchedulingIgnoredDuringExecution:
-                        items:
-                          properties:
-                            labelSelector:
-                              properties:
-                                matchExpressions:
-                                  items:
-                                    properties:
-                                      key:
-                                        type: string
-                                      operator:
-                                        type: string
-                                      values:
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                matchLabels:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                              type: object
-                            namespaces:
-                              items:
-                                type: string
-                              type: array
-                            topologyKey:
-                              type: string
-                          required:
-                          - topologyKey
-                          type: object
-                        type: array
-                    type: object
-                  podAntiAffinity:
-                    properties:
-                      preferredDuringSchedulingIgnoredDuringExecution:
-                        items:
-                          properties:
-                            podAffinityTerm:
-                              properties:
-                                labelSelector:
-                                  properties:
-                                    matchExpressions:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      type: object
-                                  type: object
-                                namespaces:
-                                  items:
-                                    type: string
-                                  type: array
-                                topologyKey:
-                                  type: string
-                              required:
-                              - topologyKey
-                              type: object
-                            weight:
-                              format: int32
-                              type: integer
-                          required:
-                          - podAffinityTerm
-                          - weight
-                          type: object
-                        type: array
-                      requiredDuringSchedulingIgnoredDuringExecution:
-                        items:
-                          properties:
-                            labelSelector:
-                              properties:
-                                matchExpressions:
-                                  items:
-                                    properties:
-                                      key:
-                                        type: string
-                                      operator:
-                                        type: string
-                                      values:
-                                        items:
-                                          type: string
-                                        type: array
-                                    required:
-                                    - key
-                                    - operator
-                                    type: object
-                                  type: array
-                                matchLabels:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                              type: object
-                            namespaces:
-                              items:
-                                type: string
-                              type: array
-                            topologyKey:
-                              type: string
-                          required:
-                          - topologyKey
-                          type: object
-                        type: array
-                    type: object
-                type: object
-              agent:
-                nullable: true
-                properties:
-                  affinity:
-                    properties:
-                      nodeAffinity:
-                        properties:
-                          preferredDuringSchedulingIgnoredDuringExecution:
-                            items:
-                              properties:
-                                preference:
-                                  properties:
-                                    matchExpressions:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchFields:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                  type: object
-                                weight:
-                                  format: int32
-                                  type: integer
-                              required:
-                              - preference
-                              - weight
-                              type: object
-                            type: array
-                          requiredDuringSchedulingIgnoredDuringExecution:
+                          preference:
                             properties:
-                              nodeSelectorTerms:
+                              matchExpressions:
                                 items:
                                   properties:
-                                    matchExpressions:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
                                       items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
+                                        type: string
                                       type: array
-                                    matchFields:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
+                                  required:
+                                  - key
+                                  - operator
                                   type: object
                                 type: array
-                            required:
-                            - nodeSelectorTerms
-                            type: object
-                        type: object
-                      podAffinity:
-                        properties:
-                          preferredDuringSchedulingIgnoredDuringExecution:
-                            items:
-                              properties:
-                                podAffinityTerm:
-                                  properties:
-                                    labelSelector:
-                                      properties:
-                                        matchExpressions:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchLabels:
-                                          additionalProperties:
-                                            type: string
-                                          type: object
-                                      type: object
-                                    namespaces:
-                                      items:
-                                        type: string
-                                      type: array
-                                    topologyKey:
-                                      type: string
-                                  required:
-                                  - topologyKey
-                                  type: object
-                                weight:
-                                  format: int32
-                                  type: integer
-                              required:
-                              - podAffinityTerm
-                              - weight
-                              type: object
-                            type: array
-                          requiredDuringSchedulingIgnoredDuringExecution:
-                            items:
-                              properties:
-                                labelSelector:
-                                  properties:
-                                    matchExpressions:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      type: object
-                                  type: object
-                                namespaces:
-                                  items:
-                                    type: string
-                                  type: array
-                                topologyKey:
-                                  type: string
-                              required:
-                              - topologyKey
-                              type: object
-                            type: array
-                        type: object
-                      podAntiAffinity:
-                        properties:
-                          preferredDuringSchedulingIgnoredDuringExecution:
-                            items:
-                              properties:
-                                podAffinityTerm:
-                                  properties:
-                                    labelSelector:
-                                      properties:
-                                        matchExpressions:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchLabels:
-                                          additionalProperties:
-                                            type: string
-                                          type: object
-                                      type: object
-                                    namespaces:
-                                      items:
-                                        type: string
-                                      type: array
-                                    topologyKey:
-                                      type: string
-                                  required:
-                                  - topologyKey
-                                  type: object
-                                weight:
-                                  format: int32
-                                  type: integer
-                              required:
-                              - podAffinityTerm
-                              - weight
-                              type: object
-                            type: array
-                          requiredDuringSchedulingIgnoredDuringExecution:
-                            items:
-                              properties:
-                                labelSelector:
-                                  properties:
-                                    matchExpressions:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      type: object
-                                  type: object
-                                namespaces:
-                                  items:
-                                    type: string
-                                  type: array
-                                topologyKey:
-                                  type: string
-                              required:
-                              - topologyKey
-                              type: object
-                            type: array
-                        type: object
-                    type: object
-                  annotations:
-                    additionalProperties:
-                      type: string
-                    nullable: true
-                    type: object
-                  config:
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                  dnsPolicy:
-                    type: string
-                  hostNetwork:
-                    type: boolean
-                  image:
-                    type: string
-                  imagePullSecrets:
-                    items:
-                      properties:
-                        name:
-                          type: string
-                      type: object
-                    type: array
-                    x-kubernetes-list-type: atomic
-                  labels:
-                    additionalProperties:
-                      type: string
-                    type: object
-                  options:
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                  priorityClassName:
-                    type: string
-                  resources:
-                    nullable: true
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        type: object
-                    type: object
-                  securityContext:
-                    properties:
-                      fsGroup:
-                        format: int64
-                        type: integer
-                      fsGroupChangePolicy:
-                        type: string
-                      runAsGroup:
-                        format: int64
-                        type: integer
-                      runAsNonRoot:
-                        type: boolean
-                      runAsUser:
-                        format: int64
-                        type: integer
-                      seLinuxOptions:
-                        properties:
-                          level:
-                            type: string
-                          role:
-                            type: string
-                          type:
-                            type: string
-                          user:
-                            type: string
-                        type: object
-                      seccompProfile:
-                        properties:
-                          localhostProfile:
-                            type: string
-                          type:
-                            type: string
-                        required:
-                        - type
-                        type: object
-                      supplementalGroups:
-                        items:
-                          format: int64
-                          type: integer
-                        type: array
-                      sysctls:
-                        items:
-                          properties:
-                            name:
-                              type: string
-                            value:
-                              type: string
-                          required:
-                          - name
-                          - value
-                          type: object
-                        type: array
-                      windowsOptions:
-                        properties:
-                          gmsaCredentialSpec:
-                            type: string
-                          gmsaCredentialSpecName:
-                            type: string
-                          runAsUserName:
-                            type: string
-                        type: object
-                    type: object
-                  serviceAccount:
-                    type: string
-                  sidecarSecurityContext:
-                    properties:
-                      allowPrivilegeEscalation:
-                        type: boolean
-                      capabilities:
-                        properties:
-                          add:
-                            items:
-                              type: string
-                            type: array
-                          drop:
-                            items:
-                              type: string
-                            type: array
-                        type: object
-                      privileged:
-                        type: boolean
-                      procMount:
-                        type: string
-                      readOnlyRootFilesystem:
-                        type: boolean
-                      runAsGroup:
-                        format: int64
-                        type: integer
-                      runAsNonRoot:
-                        type: boolean
-                      runAsUser:
-                        format: int64
-                        type: integer
-                      seLinuxOptions:
-                        properties:
-                          level:
-                            type: string
-                          role:
-                            type: string
-                          type:
-                            type: string
-                          user:
-                            type: string
-                        type: object
-                      seccompProfile:
-                        properties:
-                          localhostProfile:
-                            type: string
-                          type:
-                            type: string
-                        required:
-                        - type
-                        type: object
-                      windowsOptions:
-                        properties:
-                          gmsaCredentialSpec:
-                            type: string
-                          gmsaCredentialSpecName:
-                            type: string
-                          runAsUserName:
-                            type: string
-                        type: object
-                    type: object
-                  strategy:
-                    type: string
-                  tolerations:
-                    items:
-                      properties:
-                        effect:
-                          type: string
-                        key:
-                          type: string
-                        operator:
-                          type: string
-                        tolerationSeconds:
-                          format: int64
-                          type: integer
-                        value:
-                          type: string
-                      type: object
-                    type: array
-                    x-kubernetes-list-type: atomic
-                  volumeMounts:
-                    items:
-                      properties:
-                        mountPath:
-                          type: string
-                        mountPropagation:
-                          type: string
-                        name:
-                          type: string
-                        readOnly:
-                          type: boolean
-                        subPath:
-                          type: string
-                        subPathExpr:
-                          type: string
-                      required:
-                      - mountPath
-                      - name
-                      type: object
-                    type: array
-                    x-kubernetes-list-type: atomic
-                  volumes:
-                    items:
-                      properties:
-                        awsElasticBlockStore:
-                          properties:
-                            fsType:
-                              type: string
-                            partition:
-                              format: int32
-                              type: integer
-                            readOnly:
-                              type: boolean
-                            volumeID:
-                              type: string
-                          required:
-                          - volumeID
-                          type: object
-                        azureDisk:
-                          properties:
-                            cachingMode:
-                              type: string
-                            diskName:
-                              type: string
-                            diskURI:
-                              type: string
-                            fsType:
-                              type: string
-                            kind:
-                              type: string
-                            readOnly:
-                              type: boolean
-                          required:
-                          - diskName
-                          - diskURI
-                          type: object
-                        azureFile:
-                          properties:
-                            readOnly:
-                              type: boolean
-                            secretName:
-                              type: string
-                            shareName:
-                              type: string
-                          required:
-                          - secretName
-                          - shareName
-                          type: object
-                        cephfs:
-                          properties:
-                            monitors:
-                              items:
-                                type: string
-                              type: array
-                            path:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            secretFile:
-                              type: string
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                            user:
-                              type: string
-                          required:
-                          - monitors
-                          type: object
-                        cinder:
-                          properties:
-                            fsType:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                            volumeID:
-                              type: string
-                          required:
-                          - volumeID
-                          type: object
-                        configMap:
-                          properties:
-                            defaultMode:
-                              format: int32
-                              type: integer
-                            items:
-                              items:
-                                properties:
-                                  key:
-                                    type: string
-                                  mode:
-                                    format: int32
-                                    type: integer
-                                  path:
-                                    type: string
-                                required:
-                                - key
-                                - path
-                                type: object
-                              type: array
-                            name:
-                              type: string
-                            optional:
-                              type: boolean
-                          type: object
-                        csi:
-                          properties:
-                            driver:
-                              type: string
-                            fsType:
-                              type: string
-                            nodePublishSecretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                            readOnly:
-                              type: boolean
-                            volumeAttributes:
-                              additionalProperties:
-                                type: string
-                              type: object
-                          required:
-                          - driver
-                          type: object
-                        downwardAPI:
-                          properties:
-                            defaultMode:
-                              format: int32
-                              type: integer
-                            items:
-                              items:
-                                properties:
-                                  fieldRef:
-                                    properties:
-                                      apiVersion:
-                                        type: string
-                                      fieldPath:
-                                        type: string
-                                    required:
-                                    - fieldPath
-                                    type: object
-                                  mode:
-                                    format: int32
-                                    type: integer
-                                  path:
-                                    type: string
-                                  resourceFieldRef:
-                                    properties:
-                                      containerName:
-                                        type: string
-                                      divisor:
-                                        anyOf:
-                                        - type: integer
-                                        - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      resource:
-                                        type: string
-                                    required:
-                                    - resource
-                                    type: object
-                                required:
-                                - path
-                                type: object
-                              type: array
-                          type: object
-                        emptyDir:
-                          properties:
-                            medium:
-                              type: string
-                            sizeLimit:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                          type: object
-                        ephemeral:
-                          properties:
-                            readOnly:
-                              type: boolean
-                            volumeClaimTemplate:
-                              properties:
-                                metadata:
-                                  type: object
-                                spec:
-                                  properties:
-                                    accessModes:
-                                      items:
-                                        type: string
-                                      type: array
-                                    dataSource:
-                                      properties:
-                                        apiGroup:
-                                          type: string
-                                        kind:
-                                          type: string
-                                        name:
-                                          type: string
-                                      required:
-                                      - kind
-                                      - name
-                                      type: object
-                                    resources:
-                                      properties:
-                                        limits:
-                                          additionalProperties:
-                                            anyOf:
-                                            - type: integer
-                                            - type: string
-                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                            x-kubernetes-int-or-string: true
-                                          type: object
-                                        requests:
-                                          additionalProperties:
-                                            anyOf:
-                                            - type: integer
-                                            - type: string
-                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                            x-kubernetes-int-or-string: true
-                                          type: object
-                                      type: object
-                                    selector:
-                                      properties:
-                                        matchExpressions:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchLabels:
-                                          additionalProperties:
-                                            type: string
-                                          type: object
-                                      type: object
-                                    storageClassName:
-                                      type: string
-                                    volumeMode:
-                                      type: string
-                                    volumeName:
-                                      type: string
-                                  type: object
-                              required:
-                              - spec
-                              type: object
-                          type: object
-                        fc:
-                          properties:
-                            fsType:
-                              type: string
-                            lun:
-                              format: int32
-                              type: integer
-                            readOnly:
-                              type: boolean
-                            targetWWNs:
-                              items:
-                                type: string
-                              type: array
-                            wwids:
-                              items:
-                                type: string
-                              type: array
-                          type: object
-                        flexVolume:
-                          properties:
-                            driver:
-                              type: string
-                            fsType:
-                              type: string
-                            options:
-                              additionalProperties:
-                                type: string
-                              type: object
-                            readOnly:
-                              type: boolean
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                          required:
-                          - driver
-                          type: object
-                        flocker:
-                          properties:
-                            datasetName:
-                              type: string
-                            datasetUUID:
-                              type: string
-                          type: object
-                        gcePersistentDisk:
-                          properties:
-                            fsType:
-                              type: string
-                            partition:
-                              format: int32
-                              type: integer
-                            pdName:
-                              type: string
-                            readOnly:
-                              type: boolean
-                          required:
-                          - pdName
-                          type: object
-                        gitRepo:
-                          properties:
-                            directory:
-                              type: string
-                            repository:
-                              type: string
-                            revision:
-                              type: string
-                          required:
-                          - repository
-                          type: object
-                        glusterfs:
-                          properties:
-                            endpoints:
-                              type: string
-                            path:
-                              type: string
-                            readOnly:
-                              type: boolean
-                          required:
-                          - endpoints
-                          - path
-                          type: object
-                        hostPath:
-                          properties:
-                            path:
-                              type: string
-                            type:
-                              type: string
-                          required:
-                          - path
-                          type: object
-                        iscsi:
-                          properties:
-                            chapAuthDiscovery:
-                              type: boolean
-                            chapAuthSession:
-                              type: boolean
-                            fsType:
-                              type: string
-                            initiatorName:
-                              type: string
-                            iqn:
-                              type: string
-                            iscsiInterface:
-                              type: string
-                            lun:
-                              format: int32
-                              type: integer
-                            portals:
-                              items:
-                                type: string
-                              type: array
-                            readOnly:
-                              type: boolean
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                            targetPortal:
-                              type: string
-                          required:
-                          - iqn
-                          - lun
-                          - targetPortal
-                          type: object
-                        name:
-                          type: string
-                        nfs:
-                          properties:
-                            path:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            server:
-                              type: string
-                          required:
-                          - path
-                          - server
-                          type: object
-                        persistentVolumeClaim:
-                          properties:
-                            claimName:
-                              type: string
-                            readOnly:
-                              type: boolean
-                          required:
-                          - claimName
-                          type: object
-                        photonPersistentDisk:
-                          properties:
-                            fsType:
-                              type: string
-                            pdID:
-                              type: string
-                          required:
-                          - pdID
-                          type: object
-                        portworxVolume:
-                          properties:
-                            fsType:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            volumeID:
-                              type: string
-                          required:
-                          - volumeID
-                          type: object
-                        projected:
-                          properties:
-                            defaultMode:
-                              format: int32
-                              type: integer
-                            sources:
-                              items:
-                                properties:
-                                  configMap:
-                                    properties:
-                                      items:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            mode:
-                                              format: int32
-                                              type: integer
-                                            path:
-                                              type: string
-                                          required:
-                                          - key
-                                          - path
-                                          type: object
-                                        type: array
-                                      name:
-                                        type: string
-                                      optional:
-                                        type: boolean
-                                    type: object
-                                  downwardAPI:
-                                    properties:
-                                      items:
-                                        items:
-                                          properties:
-                                            fieldRef:
-                                              properties:
-                                                apiVersion:
-                                                  type: string
-                                                fieldPath:
-                                                  type: string
-                                              required:
-                                              - fieldPath
-                                              type: object
-                                            mode:
-                                              format: int32
-                                              type: integer
-                                            path:
-                                              type: string
-                                            resourceFieldRef:
-                                              properties:
-                                                containerName:
-                                                  type: string
-                                                divisor:
-                                                  anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                  x-kubernetes-int-or-string: true
-                                                resource:
-                                                  type: string
-                                              required:
-                                              - resource
-                                              type: object
-                                          required:
-                                          - path
-                                          type: object
-                                        type: array
-                                    type: object
-                                  secret:
-                                    properties:
-                                      items:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            mode:
-                                              format: int32
-                                              type: integer
-                                            path:
-                                              type: string
-                                          required:
-                                          - key
-                                          - path
-                                          type: object
-                                        type: array
-                                      name:
-                                        type: string
-                                      optional:
-                                        type: boolean
-                                    type: object
-                                  serviceAccountToken:
-                                    properties:
-                                      audience:
-                                        type: string
-                                      expirationSeconds:
-                                        format: int64
-                                        type: integer
-                                      path:
-                                        type: string
-                                    required:
-                                    - path
-                                    type: object
-                                type: object
-                              type: array
-                          type: object
-                        quobyte:
-                          properties:
-                            group:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            registry:
-                              type: string
-                            tenant:
-                              type: string
-                            user:
-                              type: string
-                            volume:
-                              type: string
-                          required:
-                          - registry
-                          - volume
-                          type: object
-                        rbd:
-                          properties:
-                            fsType:
-                              type: string
-                            image:
-                              type: string
-                            keyring:
-                              type: string
-                            monitors:
-                              items:
-                                type: string
-                              type: array
-                            pool:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                            user:
-                              type: string
-                          required:
-                          - image
-                          - monitors
-                          type: object
-                        scaleIO:
-                          properties:
-                            fsType:
-                              type: string
-                            gateway:
-                              type: string
-                            protectionDomain:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                            sslEnabled:
-                              type: boolean
-                            storageMode:
-                              type: string
-                            storagePool:
-                              type: string
-                            system:
-                              type: string
-                            volumeName:
-                              type: string
-                          required:
-                          - gateway
-                          - secretRef
-                          - system
-                          type: object
-                        secret:
-                          properties:
-                            defaultMode:
-                              format: int32
-                              type: integer
-                            items:
-                              items:
-                                properties:
-                                  key:
-                                    type: string
-                                  mode:
-                                    format: int32
-                                    type: integer
-                                  path:
-                                    type: string
-                                required:
-                                - key
-                                - path
-                                type: object
-                              type: array
-                            optional:
-                              type: boolean
-                            secretName:
-                              type: string
-                          type: object
-                        storageos:
-                          properties:
-                            fsType:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                            volumeName:
-                              type: string
-                            volumeNamespace:
-                              type: string
-                          type: object
-                        vsphereVolume:
-                          properties:
-                            fsType:
-                              type: string
-                            storagePolicyID:
-                              type: string
-                            storagePolicyName:
-                              type: string
-                            volumePath:
-                              type: string
-                          required:
-                          - volumePath
-                          type: object
-                      required:
-                      - name
-                      type: object
-                    type: array
-                    x-kubernetes-list-type: atomic
-                type: object
-              allInOne:
-                properties:
-                  affinity:
-                    properties:
-                      nodeAffinity:
-                        properties:
-                          preferredDuringSchedulingIgnoredDuringExecution:
-                            items:
-                              properties:
-                                preference:
-                                  properties:
-                                    matchExpressions:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchFields:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                  type: object
-                                weight:
-                                  format: int32
-                                  type: integer
-                              required:
-                              - preference
-                              - weight
-                              type: object
-                            type: array
-                          requiredDuringSchedulingIgnoredDuringExecution:
-                            properties:
-                              nodeSelectorTerms:
+                              matchFields:
                                 items:
                                   properties:
-                                    matchExpressions:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
                                       items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
+                                        type: string
                                       type: array
-                                    matchFields:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
+                                  required:
+                                  - key
+                                  - operator
                                   type: object
                                 type: array
-                            required:
-                            - nodeSelectorTerms
                             type: object
+                          weight:
+                            format: int32
+                            type: integer
+                        required:
+                        - preference
+                        - weight
                         type: object
-                      podAffinity:
-                        properties:
-                          preferredDuringSchedulingIgnoredDuringExecution:
-                            items:
-                              properties:
-                                podAffinityTerm:
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      properties:
+                        nodeSelectorTerms:
+                          items:
+                            properties:
+                              matchExpressions:
+                                items:
                                   properties:
-                                    labelSelector:
-                                      properties:
-                                        matchExpressions:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchLabels:
-                                          additionalProperties:
-                                            type: string
-                                          type: object
-                                      type: object
-                                    namespaces:
-                                      items:
-                                        type: string
-                                      type: array
-                                    topologyKey:
+                                    key:
                                       type: string
-                                  required:
-                                  - topologyKey
-                                  type: object
-                                weight:
-                                  format: int32
-                                  type: integer
-                              required:
-                              - podAffinityTerm
-                              - weight
-                              type: object
-                            type: array
-                          requiredDuringSchedulingIgnoredDuringExecution:
-                            items:
-                              properties:
-                                labelSelector:
-                                  properties:
-                                    matchExpressions:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      type: object
-                                  type: object
-                                namespaces:
-                                  items:
-                                    type: string
-                                  type: array
-                                topologyKey:
-                                  type: string
-                              required:
-                              - topologyKey
-                              type: object
-                            type: array
-                        type: object
-                      podAntiAffinity:
-                        properties:
-                          preferredDuringSchedulingIgnoredDuringExecution:
-                            items:
-                              properties:
-                                podAffinityTerm:
-                                  properties:
-                                    labelSelector:
-                                      properties:
-                                        matchExpressions:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchLabels:
-                                          additionalProperties:
-                                            type: string
-                                          type: object
-                                      type: object
-                                    namespaces:
-                                      items:
-                                        type: string
-                                      type: array
-                                    topologyKey:
+                                    operator:
                                       type: string
-                                  required:
-                                  - topologyKey
-                                  type: object
-                                weight:
-                                  format: int32
-                                  type: integer
-                              required:
-                              - podAffinityTerm
-                              - weight
-                              type: object
-                            type: array
-                          requiredDuringSchedulingIgnoredDuringExecution:
-                            items:
-                              properties:
-                                labelSelector:
-                                  properties:
-                                    matchExpressions:
+                                    values:
                                       items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
                                         type: string
-                                      type: object
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
                                   type: object
-                                namespaces:
-                                  items:
-                                    type: string
-                                  type: array
-                                topologyKey:
+                                type: array
+                              matchFields:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                            type: object
+                          type: array
+                      required:
+                      - nodeSelectorTerms
+                      type: object
+                  type: object
+                podAffinity:
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      items:
+                        properties:
+                          podAffinityTerm:
+                            properties:
+                              labelSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              namespaces:
+                                items:
                                   type: string
-                              required:
-                              - topologyKey
-                              type: object
+                                type: array
+                              topologyKey:
+                                type: string
+                            required:
+                            - topologyKey
+                            type: object
+                          weight:
+                            format: int32
+                            type: integer
+                        required:
+                        - podAffinityTerm
+                        - weight
+                        type: object
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      items:
+                        properties:
+                          labelSelector:
+                            properties:
+                              matchExpressions:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            type: object
+                          namespaces:
+                            items:
+                              type: string
                             type: array
-                        type: object
-                    type: object
-                  annotations:
-                    additionalProperties:
-                      type: string
-                    nullable: true
-                    type: object
-                  config:
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                  image:
-                    type: string
-                  labels:
-                    additionalProperties:
-                      type: string
-                    type: object
-                  options:
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                  resources:
-                    nullable: true
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        type: object
-                    type: object
-                  securityContext:
-                    properties:
-                      fsGroup:
-                        format: int64
-                        type: integer
-                      fsGroupChangePolicy:
-                        type: string
-                      runAsGroup:
-                        format: int64
-                        type: integer
-                      runAsNonRoot:
-                        type: boolean
-                      runAsUser:
-                        format: int64
-                        type: integer
-                      seLinuxOptions:
-                        properties:
-                          level:
-                            type: string
-                          role:
-                            type: string
-                          type:
-                            type: string
-                          user:
-                            type: string
-                        type: object
-                      seccompProfile:
-                        properties:
-                          localhostProfile:
-                            type: string
-                          type:
+                          topologyKey:
                             type: string
                         required:
-                        - type
+                        - topologyKey
                         type: object
-                      supplementalGroups:
-                        items:
-                          format: int64
-                          type: integer
-                        type: array
-                      sysctls:
-                        items:
-                          properties:
-                            name:
-                              type: string
-                            value:
-                              type: string
-                          required:
-                          - name
-                          - value
-                          type: object
-                        type: array
-                      windowsOptions:
+                      type: array
+                  type: object
+                podAntiAffinity:
+                  properties:
+                    preferredDuringSchedulingIgnoredDuringExecution:
+                      items:
                         properties:
-                          gmsaCredentialSpec:
-                            type: string
-                          gmsaCredentialSpecName:
-                            type: string
-                          runAsUserName:
-                            type: string
+                          podAffinityTerm:
+                            properties:
+                              labelSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              namespaces:
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                type: string
+                            required:
+                            - topologyKey
+                            type: object
+                          weight:
+                            format: int32
+                            type: integer
+                        required:
+                        - podAffinityTerm
+                        - weight
                         type: object
-                    type: object
-                  serviceAccount:
-                    type: string
-                  tolerations:
-                    items:
-                      properties:
-                        effect:
-                          type: string
-                        key:
-                          type: string
-                        operator:
-                          type: string
-                        tolerationSeconds:
-                          format: int64
-                          type: integer
-                        value:
-                          type: string
-                      type: object
-                    type: array
-                    x-kubernetes-list-type: atomic
-                  tracingEnabled:
-                    type: boolean
-                  volumeMounts:
-                    items:
-                      properties:
-                        mountPath:
-                          type: string
-                        mountPropagation:
-                          type: string
-                        name:
-                          type: string
-                        readOnly:
-                          type: boolean
-                        subPath:
-                          type: string
-                        subPathExpr:
-                          type: string
-                      required:
-                      - mountPath
-                      - name
-                      type: object
-                    type: array
-                    x-kubernetes-list-type: atomic
-                  volumes:
-                    items:
-                      properties:
-                        awsElasticBlockStore:
-                          properties:
-                            fsType:
-                              type: string
-                            partition:
-                              format: int32
-                              type: integer
-                            readOnly:
-                              type: boolean
-                            volumeID:
-                              type: string
-                          required:
-                          - volumeID
-                          type: object
-                        azureDisk:
-                          properties:
-                            cachingMode:
-                              type: string
-                            diskName:
-                              type: string
-                            diskURI:
-                              type: string
-                            fsType:
-                              type: string
-                            kind:
-                              type: string
-                            readOnly:
-                              type: boolean
-                          required:
-                          - diskName
-                          - diskURI
-                          type: object
-                        azureFile:
-                          properties:
-                            readOnly:
-                              type: boolean
-                            secretName:
-                              type: string
-                            shareName:
-                              type: string
-                          required:
-                          - secretName
-                          - shareName
-                          type: object
-                        cephfs:
-                          properties:
-                            monitors:
-                              items:
-                                type: string
-                              type: array
-                            path:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            secretFile:
-                              type: string
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                            user:
-                              type: string
-                          required:
-                          - monitors
-                          type: object
-                        cinder:
-                          properties:
-                            fsType:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                            volumeID:
-                              type: string
-                          required:
-                          - volumeID
-                          type: object
-                        configMap:
-                          properties:
-                            defaultMode:
-                              format: int32
-                              type: integer
-                            items:
-                              items:
-                                properties:
-                                  key:
-                                    type: string
-                                  mode:
-                                    format: int32
-                                    type: integer
-                                  path:
-                                    type: string
-                                required:
-                                - key
-                                - path
-                                type: object
-                              type: array
-                            name:
-                              type: string
-                            optional:
-                              type: boolean
-                          type: object
-                        csi:
-                          properties:
-                            driver:
-                              type: string
-                            fsType:
-                              type: string
-                            nodePublishSecretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                            readOnly:
-                              type: boolean
-                            volumeAttributes:
-                              additionalProperties:
-                                type: string
-                              type: object
-                          required:
-                          - driver
-                          type: object
-                        downwardAPI:
-                          properties:
-                            defaultMode:
-                              format: int32
-                              type: integer
-                            items:
-                              items:
-                                properties:
-                                  fieldRef:
-                                    properties:
-                                      apiVersion:
-                                        type: string
-                                      fieldPath:
-                                        type: string
-                                    required:
-                                    - fieldPath
-                                    type: object
-                                  mode:
-                                    format: int32
-                                    type: integer
-                                  path:
-                                    type: string
-                                  resourceFieldRef:
-                                    properties:
-                                      containerName:
-                                        type: string
-                                      divisor:
-                                        anyOf:
-                                        - type: integer
-                                        - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      resource:
-                                        type: string
-                                    required:
-                                    - resource
-                                    type: object
-                                required:
-                                - path
-                                type: object
-                              type: array
-                          type: object
-                        emptyDir:
-                          properties:
-                            medium:
-                              type: string
-                            sizeLimit:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                          type: object
-                        ephemeral:
-                          properties:
-                            readOnly:
-                              type: boolean
-                            volumeClaimTemplate:
-                              properties:
-                                metadata:
-                                  type: object
-                                spec:
+                      type: array
+                    requiredDuringSchedulingIgnoredDuringExecution:
+                      items:
+                        properties:
+                          labelSelector:
+                            properties:
+                              matchExpressions:
+                                items:
                                   properties:
-                                    accessModes:
+                                    key:
+                                      type: string
+                                    operator:
+                                      type: string
+                                    values:
                                       items:
                                         type: string
                                       type: array
-                                    dataSource:
-                                      properties:
-                                        apiGroup:
-                                          type: string
-                                        kind:
-                                          type: string
-                                        name:
-                                          type: string
-                                      required:
-                                      - kind
-                                      - name
-                                      type: object
-                                    resources:
-                                      properties:
-                                        limits:
-                                          additionalProperties:
-                                            anyOf:
-                                            - type: integer
-                                            - type: string
-                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                            x-kubernetes-int-or-string: true
-                                          type: object
-                                        requests:
-                                          additionalProperties:
-                                            anyOf:
-                                            - type: integer
-                                            - type: string
-                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                            x-kubernetes-int-or-string: true
-                                          type: object
-                                      type: object
-                                    selector:
-                                      properties:
-                                        matchExpressions:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchLabels:
-                                          additionalProperties:
-                                            type: string
-                                          type: object
-                                      type: object
-                                    storageClassName:
-                                      type: string
-                                    volumeMode:
-                                      type: string
-                                    volumeName:
-                                      type: string
+                                  required:
+                                  - key
+                                  - operator
                                   type: object
-                              required:
-                              - spec
-                              type: object
-                          type: object
-                        fc:
-                          properties:
-                            fsType:
-                              type: string
-                            lun:
-                              format: int32
-                              type: integer
-                            readOnly:
-                              type: boolean
-                            targetWWNs:
-                              items:
-                                type: string
-                              type: array
-                            wwids:
-                              items:
-                                type: string
-                              type: array
-                          type: object
-                        flexVolume:
-                          properties:
-                            driver:
-                              type: string
-                            fsType:
-                              type: string
-                            options:
-                              additionalProperties:
-                                type: string
-                              type: object
-                            readOnly:
-                              type: boolean
-                            secretRef:
-                              properties:
-                                name:
+                                type: array
+                              matchLabels:
+                                additionalProperties:
                                   type: string
-                              type: object
-                          required:
-                          - driver
-                          type: object
-                        flocker:
+                                type: object
+                            type: object
+                          namespaces:
+                            items:
+                              type: string
+                            type: array
+                          topologyKey:
+                            type: string
+                        required:
+                        - topologyKey
+                        type: object
+                      type: array
+                  type: object
+              type: object
+            agent:
+              nullable: true
+              properties:
+                affinity:
+                  properties:
+                    nodeAffinity:
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              preference:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchFields:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                type: object
+                              weight:
+                                format: int32
+                                type: integer
+                            required:
+                            - preference
+                            - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
                           properties:
-                            datasetName:
-                              type: string
-                            datasetUUID:
-                              type: string
-                          type: object
-                        gcePersistentDisk:
-                          properties:
-                            fsType:
-                              type: string
-                            partition:
-                              format: int32
-                              type: integer
-                            pdName:
-                              type: string
-                            readOnly:
-                              type: boolean
-                          required:
-                          - pdName
-                          type: object
-                        gitRepo:
-                          properties:
-                            directory:
-                              type: string
-                            repository:
-                              type: string
-                            revision:
-                              type: string
-                          required:
-                          - repository
-                          type: object
-                        glusterfs:
-                          properties:
-                            endpoints:
-                              type: string
-                            path:
-                              type: string
-                            readOnly:
-                              type: boolean
-                          required:
-                          - endpoints
-                          - path
-                          type: object
-                        hostPath:
-                          properties:
-                            path:
-                              type: string
-                            type:
-                              type: string
-                          required:
-                          - path
-                          type: object
-                        iscsi:
-                          properties:
-                            chapAuthDiscovery:
-                              type: boolean
-                            chapAuthSession:
-                              type: boolean
-                            fsType:
-                              type: string
-                            initiatorName:
-                              type: string
-                            iqn:
-                              type: string
-                            iscsiInterface:
-                              type: string
-                            lun:
-                              format: int32
-                              type: integer
-                            portals:
-                              items:
-                                type: string
-                              type: array
-                            readOnly:
-                              type: boolean
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                            targetPortal:
-                              type: string
-                          required:
-                          - iqn
-                          - lun
-                          - targetPortal
-                          type: object
-                        name:
-                          type: string
-                        nfs:
-                          properties:
-                            path:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            server:
-                              type: string
-                          required:
-                          - path
-                          - server
-                          type: object
-                        persistentVolumeClaim:
-                          properties:
-                            claimName:
-                              type: string
-                            readOnly:
-                              type: boolean
-                          required:
-                          - claimName
-                          type: object
-                        photonPersistentDisk:
-                          properties:
-                            fsType:
-                              type: string
-                            pdID:
-                              type: string
-                          required:
-                          - pdID
-                          type: object
-                        portworxVolume:
-                          properties:
-                            fsType:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            volumeID:
-                              type: string
-                          required:
-                          - volumeID
-                          type: object
-                        projected:
-                          properties:
-                            defaultMode:
-                              format: int32
-                              type: integer
-                            sources:
+                            nodeSelectorTerms:
                               items:
                                 properties:
-                                  configMap:
-                                    properties:
-                                      items:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            mode:
-                                              format: int32
-                                              type: integer
-                                            path:
-                                              type: string
-                                          required:
-                                          - key
-                                          - path
-                                          type: object
-                                        type: array
-                                      name:
-                                        type: string
-                                      optional:
-                                        type: boolean
-                                    type: object
-                                  downwardAPI:
-                                    properties:
-                                      items:
-                                        items:
-                                          properties:
-                                            fieldRef:
-                                              properties:
-                                                apiVersion:
-                                                  type: string
-                                                fieldPath:
-                                                  type: string
-                                              required:
-                                              - fieldPath
-                                              type: object
-                                            mode:
-                                              format: int32
-                                              type: integer
-                                            path:
-                                              type: string
-                                            resourceFieldRef:
-                                              properties:
-                                                containerName:
-                                                  type: string
-                                                divisor:
-                                                  anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                  x-kubernetes-int-or-string: true
-                                                resource:
-                                                  type: string
-                                              required:
-                                              - resource
-                                              type: object
-                                          required:
-                                          - path
-                                          type: object
-                                        type: array
-                                    type: object
-                                  secret:
-                                    properties:
-                                      items:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            mode:
-                                              format: int32
-                                              type: integer
-                                            path:
-                                              type: string
-                                          required:
-                                          - key
-                                          - path
-                                          type: object
-                                        type: array
-                                      name:
-                                        type: string
-                                      optional:
-                                        type: boolean
-                                    type: object
-                                  serviceAccountToken:
-                                    properties:
-                                      audience:
-                                        type: string
-                                      expirationSeconds:
-                                        format: int64
-                                        type: integer
-                                      path:
-                                        type: string
-                                    required:
-                                    - path
-                                    type: object
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchFields:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
                                 type: object
                               type: array
-                          type: object
-                        quobyte:
-                          properties:
-                            group:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            registry:
-                              type: string
-                            tenant:
-                              type: string
-                            user:
-                              type: string
-                            volume:
-                              type: string
                           required:
-                          - registry
-                          - volume
+                          - nodeSelectorTerms
                           type: object
-                        rbd:
-                          properties:
-                            fsType:
-                              type: string
-                            image:
-                              type: string
-                            keyring:
-                              type: string
-                            monitors:
-                              items:
-                                type: string
-                              type: array
-                            pool:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                            user:
-                              type: string
-                          required:
-                          - image
-                          - monitors
-                          type: object
-                        scaleIO:
-                          properties:
-                            fsType:
-                              type: string
-                            gateway:
-                              type: string
-                            protectionDomain:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                            sslEnabled:
-                              type: boolean
-                            storageMode:
-                              type: string
-                            storagePool:
-                              type: string
-                            system:
-                              type: string
-                            volumeName:
-                              type: string
-                          required:
-                          - gateway
-                          - secretRef
-                          - system
-                          type: object
-                        secret:
-                          properties:
-                            defaultMode:
-                              format: int32
-                              type: integer
-                            items:
-                              items:
+                      type: object
+                    podAffinity:
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              podAffinityTerm:
                                 properties:
-                                  key:
-                                    type: string
-                                  mode:
-                                    format: int32
-                                    type: integer
-                                  path:
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
                                     type: string
                                 required:
-                                - key
-                                - path
+                                - topologyKey
                                 type: object
-                              type: array
-                            optional:
-                              type: boolean
-                            secretName:
-                              type: string
-                          type: object
-                        storageos:
-                          properties:
-                            fsType:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            secretRef:
-                              properties:
-                                name:
+                              weight:
+                                format: int32
+                                type: integer
+                            required:
+                            - podAffinityTerm
+                            - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              labelSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              namespaces:
+                                items:
                                   type: string
-                              type: object
-                            volumeName:
-                              type: string
-                            volumeNamespace:
-                              type: string
-                          type: object
-                        vsphereVolume:
-                          properties:
-                            fsType:
-                              type: string
-                            storagePolicyID:
-                              type: string
-                            storagePolicyName:
-                              type: string
-                            volumePath:
-                              type: string
-                          required:
-                          - volumePath
-                          type: object
-                      required:
-                      - name
+                                type: array
+                              topologyKey:
+                                type: string
+                            required:
+                            - topologyKey
+                            type: object
+                          type: array
                       type: object
-                    type: array
-                    x-kubernetes-list-type: atomic
-                type: object
-              annotations:
-                additionalProperties:
+                    podAntiAffinity:
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              podAffinityTerm:
+                                properties:
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              weight:
+                                format: int32
+                                type: integer
+                            required:
+                            - podAffinityTerm
+                            - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              labelSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              namespaces:
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                type: string
+                            required:
+                            - topologyKey
+                            type: object
+                          type: array
+                      type: object
+                  type: object
+                annotations:
+                  additionalProperties:
+                    type: string
+                  nullable: true
+                  type: object
+                config:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                dnsPolicy:
                   type: string
-                nullable: true
-                type: object
-              collector:
-                properties:
-                  affinity:
+                hostNetwork:
+                  type: boolean
+                image:
+                  type: string
+                imagePullSecrets:
+                  items:
                     properties:
-                      nodeAffinity:
-                        properties:
-                          preferredDuringSchedulingIgnoredDuringExecution:
-                            items:
-                              properties:
-                                preference:
-                                  properties:
-                                    matchExpressions:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchFields:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                  type: object
-                                weight:
-                                  format: int32
-                                  type: integer
-                              required:
-                              - preference
-                              - weight
-                              type: object
-                            type: array
-                          requiredDuringSchedulingIgnoredDuringExecution:
-                            properties:
-                              nodeSelectorTerms:
-                                items:
-                                  properties:
-                                    matchExpressions:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchFields:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                  type: object
-                                type: array
-                            required:
-                            - nodeSelectorTerms
-                            type: object
-                        type: object
-                      podAffinity:
-                        properties:
-                          preferredDuringSchedulingIgnoredDuringExecution:
-                            items:
-                              properties:
-                                podAffinityTerm:
-                                  properties:
-                                    labelSelector:
-                                      properties:
-                                        matchExpressions:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchLabels:
-                                          additionalProperties:
-                                            type: string
-                                          type: object
-                                      type: object
-                                    namespaces:
-                                      items:
-                                        type: string
-                                      type: array
-                                    topologyKey:
-                                      type: string
-                                  required:
-                                  - topologyKey
-                                  type: object
-                                weight:
-                                  format: int32
-                                  type: integer
-                              required:
-                              - podAffinityTerm
-                              - weight
-                              type: object
-                            type: array
-                          requiredDuringSchedulingIgnoredDuringExecution:
-                            items:
-                              properties:
-                                labelSelector:
-                                  properties:
-                                    matchExpressions:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      type: object
-                                  type: object
-                                namespaces:
-                                  items:
-                                    type: string
-                                  type: array
-                                topologyKey:
-                                  type: string
-                              required:
-                              - topologyKey
-                              type: object
-                            type: array
-                        type: object
-                      podAntiAffinity:
-                        properties:
-                          preferredDuringSchedulingIgnoredDuringExecution:
-                            items:
-                              properties:
-                                podAffinityTerm:
-                                  properties:
-                                    labelSelector:
-                                      properties:
-                                        matchExpressions:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchLabels:
-                                          additionalProperties:
-                                            type: string
-                                          type: object
-                                      type: object
-                                    namespaces:
-                                      items:
-                                        type: string
-                                      type: array
-                                    topologyKey:
-                                      type: string
-                                  required:
-                                  - topologyKey
-                                  type: object
-                                weight:
-                                  format: int32
-                                  type: integer
-                              required:
-                              - podAffinityTerm
-                              - weight
-                              type: object
-                            type: array
-                          requiredDuringSchedulingIgnoredDuringExecution:
-                            items:
-                              properties:
-                                labelSelector:
-                                  properties:
-                                    matchExpressions:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      type: object
-                                  type: object
-                                namespaces:
-                                  items:
-                                    type: string
-                                  type: array
-                                topologyKey:
-                                  type: string
-                              required:
-                              - topologyKey
-                              type: object
-                            type: array
-                        type: object
-                    type: object
-                  annotations:
-                    additionalProperties:
-                      type: string
-                    nullable: true
-                    type: object
-                  autoscale:
-                    type: boolean
-                  config:
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                  image:
-                    type: string
-                  labels:
-                    additionalProperties:
-                      type: string
-                    type: object
-                  maxReplicas:
-                    format: int32
-                    type: integer
-                  minReplicas:
-                    format: int32
-                    type: integer
-                  options:
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                  priorityClassName:
-                    type: string
-                  replicas:
-                    format: int32
-                    type: integer
-                  resources:
-                    nullable: true
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        type: object
-                    type: object
-                  securityContext:
-                    properties:
-                      fsGroup:
-                        format: int64
-                        type: integer
-                      fsGroupChangePolicy:
+                      name:
                         type: string
-                      runAsGroup:
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                labels:
+                  additionalProperties:
+                    type: string
+                  type: object
+                options:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                priorityClassName:
+                  type: string
+                resources:
+                  nullable: true
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      type: object
+                  type: object
+                securityContext:
+                  properties:
+                    fsGroup:
+                      format: int64
+                      type: integer
+                    fsGroupChangePolicy:
+                      type: string
+                    runAsGroup:
+                      format: int64
+                      type: integer
+                    runAsNonRoot:
+                      type: boolean
+                    runAsUser:
+                      format: int64
+                      type: integer
+                    seLinuxOptions:
+                      properties:
+                        level:
+                          type: string
+                        role:
+                          type: string
+                        type:
+                          type: string
+                        user:
+                          type: string
+                      type: object
+                    seccompProfile:
+                      properties:
+                        localhostProfile:
+                          type: string
+                        type:
+                          type: string
+                      required:
+                      - type
+                      type: object
+                    supplementalGroups:
+                      items:
                         format: int64
                         type: integer
-                      runAsNonRoot:
-                        type: boolean
-                      runAsUser:
-                        format: int64
-                        type: integer
-                      seLinuxOptions:
+                      type: array
+                    sysctls:
+                      items:
                         properties:
-                          level:
+                          name:
                             type: string
-                          role:
-                            type: string
-                          type:
-                            type: string
-                          user:
-                            type: string
-                        type: object
-                      seccompProfile:
-                        properties:
-                          localhostProfile:
-                            type: string
-                          type:
+                          value:
                             type: string
                         required:
-                        - type
+                        - name
+                        - value
                         type: object
-                      supplementalGroups:
-                        items:
-                          format: int64
-                          type: integer
-                        type: array
-                      sysctls:
-                        items:
-                          properties:
-                            name:
-                              type: string
-                            value:
-                              type: string
-                          required:
-                          - name
-                          - value
-                          type: object
-                        type: array
-                      windowsOptions:
-                        properties:
-                          gmsaCredentialSpec:
-                            type: string
-                          gmsaCredentialSpecName:
-                            type: string
-                          runAsUserName:
-                            type: string
-                        type: object
-                    type: object
-                  serviceAccount:
-                    type: string
-                  serviceType:
-                    type: string
-                  tolerations:
-                    items:
+                      type: array
+                    windowsOptions:
                       properties:
-                        effect:
+                        gmsaCredentialSpec:
                           type: string
-                        key:
+                        gmsaCredentialSpecName:
                           type: string
-                        operator:
-                          type: string
-                        tolerationSeconds:
-                          format: int64
-                          type: integer
-                        value:
+                        runAsUserName:
                           type: string
                       type: object
-                    type: array
-                    x-kubernetes-list-type: atomic
-                  volumeMounts:
-                    items:
+                  type: object
+                serviceAccount:
+                  type: string
+                sidecarSecurityContext:
+                  properties:
+                    allowPrivilegeEscalation:
+                      type: boolean
+                    capabilities:
                       properties:
-                        mountPath:
-                          type: string
-                        mountPropagation:
-                          type: string
-                        name:
-                          type: string
-                        readOnly:
-                          type: boolean
-                        subPath:
-                          type: string
-                        subPathExpr:
-                          type: string
-                      required:
-                      - mountPath
-                      - name
-                      type: object
-                    type: array
-                    x-kubernetes-list-type: atomic
-                  volumes:
-                    items:
-                      properties:
-                        awsElasticBlockStore:
-                          properties:
-                            fsType:
-                              type: string
-                            partition:
-                              format: int32
-                              type: integer
-                            readOnly:
-                              type: boolean
-                            volumeID:
-                              type: string
-                          required:
-                          - volumeID
-                          type: object
-                        azureDisk:
-                          properties:
-                            cachingMode:
-                              type: string
-                            diskName:
-                              type: string
-                            diskURI:
-                              type: string
-                            fsType:
-                              type: string
-                            kind:
-                              type: string
-                            readOnly:
-                              type: boolean
-                          required:
-                          - diskName
-                          - diskURI
-                          type: object
-                        azureFile:
-                          properties:
-                            readOnly:
-                              type: boolean
-                            secretName:
-                              type: string
-                            shareName:
-                              type: string
-                          required:
-                          - secretName
-                          - shareName
-                          type: object
-                        cephfs:
-                          properties:
-                            monitors:
-                              items:
-                                type: string
-                              type: array
-                            path:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            secretFile:
-                              type: string
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                            user:
-                              type: string
-                          required:
-                          - monitors
-                          type: object
-                        cinder:
-                          properties:
-                            fsType:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                            volumeID:
-                              type: string
-                          required:
-                          - volumeID
-                          type: object
-                        configMap:
-                          properties:
-                            defaultMode:
-                              format: int32
-                              type: integer
-                            items:
-                              items:
-                                properties:
-                                  key:
-                                    type: string
-                                  mode:
-                                    format: int32
-                                    type: integer
-                                  path:
-                                    type: string
-                                required:
-                                - key
-                                - path
-                                type: object
-                              type: array
-                            name:
-                              type: string
-                            optional:
-                              type: boolean
-                          type: object
-                        csi:
-                          properties:
-                            driver:
-                              type: string
-                            fsType:
-                              type: string
-                            nodePublishSecretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                            readOnly:
-                              type: boolean
-                            volumeAttributes:
-                              additionalProperties:
-                                type: string
-                              type: object
-                          required:
-                          - driver
-                          type: object
-                        downwardAPI:
-                          properties:
-                            defaultMode:
-                              format: int32
-                              type: integer
-                            items:
-                              items:
-                                properties:
-                                  fieldRef:
-                                    properties:
-                                      apiVersion:
-                                        type: string
-                                      fieldPath:
-                                        type: string
-                                    required:
-                                    - fieldPath
-                                    type: object
-                                  mode:
-                                    format: int32
-                                    type: integer
-                                  path:
-                                    type: string
-                                  resourceFieldRef:
-                                    properties:
-                                      containerName:
-                                        type: string
-                                      divisor:
-                                        anyOf:
-                                        - type: integer
-                                        - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      resource:
-                                        type: string
-                                    required:
-                                    - resource
-                                    type: object
-                                required:
-                                - path
-                                type: object
-                              type: array
-                          type: object
-                        emptyDir:
-                          properties:
-                            medium:
-                              type: string
-                            sizeLimit:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                          type: object
-                        ephemeral:
-                          properties:
-                            readOnly:
-                              type: boolean
-                            volumeClaimTemplate:
-                              properties:
-                                metadata:
-                                  type: object
-                                spec:
-                                  properties:
-                                    accessModes:
-                                      items:
-                                        type: string
-                                      type: array
-                                    dataSource:
-                                      properties:
-                                        apiGroup:
-                                          type: string
-                                        kind:
-                                          type: string
-                                        name:
-                                          type: string
-                                      required:
-                                      - kind
-                                      - name
-                                      type: object
-                                    resources:
-                                      properties:
-                                        limits:
-                                          additionalProperties:
-                                            anyOf:
-                                            - type: integer
-                                            - type: string
-                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                            x-kubernetes-int-or-string: true
-                                          type: object
-                                        requests:
-                                          additionalProperties:
-                                            anyOf:
-                                            - type: integer
-                                            - type: string
-                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                            x-kubernetes-int-or-string: true
-                                          type: object
-                                      type: object
-                                    selector:
-                                      properties:
-                                        matchExpressions:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchLabels:
-                                          additionalProperties:
-                                            type: string
-                                          type: object
-                                      type: object
-                                    storageClassName:
-                                      type: string
-                                    volumeMode:
-                                      type: string
-                                    volumeName:
-                                      type: string
-                                  type: object
-                              required:
-                              - spec
-                              type: object
-                          type: object
-                        fc:
-                          properties:
-                            fsType:
-                              type: string
-                            lun:
-                              format: int32
-                              type: integer
-                            readOnly:
-                              type: boolean
-                            targetWWNs:
-                              items:
-                                type: string
-                              type: array
-                            wwids:
-                              items:
-                                type: string
-                              type: array
-                          type: object
-                        flexVolume:
-                          properties:
-                            driver:
-                              type: string
-                            fsType:
-                              type: string
-                            options:
-                              additionalProperties:
-                                type: string
-                              type: object
-                            readOnly:
-                              type: boolean
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                          required:
-                          - driver
-                          type: object
-                        flocker:
-                          properties:
-                            datasetName:
-                              type: string
-                            datasetUUID:
-                              type: string
-                          type: object
-                        gcePersistentDisk:
-                          properties:
-                            fsType:
-                              type: string
-                            partition:
-                              format: int32
-                              type: integer
-                            pdName:
-                              type: string
-                            readOnly:
-                              type: boolean
-                          required:
-                          - pdName
-                          type: object
-                        gitRepo:
-                          properties:
-                            directory:
-                              type: string
-                            repository:
-                              type: string
-                            revision:
-                              type: string
-                          required:
-                          - repository
-                          type: object
-                        glusterfs:
-                          properties:
-                            endpoints:
-                              type: string
-                            path:
-                              type: string
-                            readOnly:
-                              type: boolean
-                          required:
-                          - endpoints
-                          - path
-                          type: object
-                        hostPath:
-                          properties:
-                            path:
-                              type: string
-                            type:
-                              type: string
-                          required:
-                          - path
-                          type: object
-                        iscsi:
-                          properties:
-                            chapAuthDiscovery:
-                              type: boolean
-                            chapAuthSession:
-                              type: boolean
-                            fsType:
-                              type: string
-                            initiatorName:
-                              type: string
-                            iqn:
-                              type: string
-                            iscsiInterface:
-                              type: string
-                            lun:
-                              format: int32
-                              type: integer
-                            portals:
-                              items:
-                                type: string
-                              type: array
-                            readOnly:
-                              type: boolean
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                            targetPortal:
-                              type: string
-                          required:
-                          - iqn
-                          - lun
-                          - targetPortal
-                          type: object
-                        name:
-                          type: string
-                        nfs:
-                          properties:
-                            path:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            server:
-                              type: string
-                          required:
-                          - path
-                          - server
-                          type: object
-                        persistentVolumeClaim:
-                          properties:
-                            claimName:
-                              type: string
-                            readOnly:
-                              type: boolean
-                          required:
-                          - claimName
-                          type: object
-                        photonPersistentDisk:
-                          properties:
-                            fsType:
-                              type: string
-                            pdID:
-                              type: string
-                          required:
-                          - pdID
-                          type: object
-                        portworxVolume:
-                          properties:
-                            fsType:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            volumeID:
-                              type: string
-                          required:
-                          - volumeID
-                          type: object
-                        projected:
-                          properties:
-                            defaultMode:
-                              format: int32
-                              type: integer
-                            sources:
-                              items:
-                                properties:
-                                  configMap:
-                                    properties:
-                                      items:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            mode:
-                                              format: int32
-                                              type: integer
-                                            path:
-                                              type: string
-                                          required:
-                                          - key
-                                          - path
-                                          type: object
-                                        type: array
-                                      name:
-                                        type: string
-                                      optional:
-                                        type: boolean
-                                    type: object
-                                  downwardAPI:
-                                    properties:
-                                      items:
-                                        items:
-                                          properties:
-                                            fieldRef:
-                                              properties:
-                                                apiVersion:
-                                                  type: string
-                                                fieldPath:
-                                                  type: string
-                                              required:
-                                              - fieldPath
-                                              type: object
-                                            mode:
-                                              format: int32
-                                              type: integer
-                                            path:
-                                              type: string
-                                            resourceFieldRef:
-                                              properties:
-                                                containerName:
-                                                  type: string
-                                                divisor:
-                                                  anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                  x-kubernetes-int-or-string: true
-                                                resource:
-                                                  type: string
-                                              required:
-                                              - resource
-                                              type: object
-                                          required:
-                                          - path
-                                          type: object
-                                        type: array
-                                    type: object
-                                  secret:
-                                    properties:
-                                      items:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            mode:
-                                              format: int32
-                                              type: integer
-                                            path:
-                                              type: string
-                                          required:
-                                          - key
-                                          - path
-                                          type: object
-                                        type: array
-                                      name:
-                                        type: string
-                                      optional:
-                                        type: boolean
-                                    type: object
-                                  serviceAccountToken:
-                                    properties:
-                                      audience:
-                                        type: string
-                                      expirationSeconds:
-                                        format: int64
-                                        type: integer
-                                      path:
-                                        type: string
-                                    required:
-                                    - path
-                                    type: object
-                                type: object
-                              type: array
-                          type: object
-                        quobyte:
-                          properties:
-                            group:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            registry:
-                              type: string
-                            tenant:
-                              type: string
-                            user:
-                              type: string
-                            volume:
-                              type: string
-                          required:
-                          - registry
-                          - volume
-                          type: object
-                        rbd:
-                          properties:
-                            fsType:
-                              type: string
-                            image:
-                              type: string
-                            keyring:
-                              type: string
-                            monitors:
-                              items:
-                                type: string
-                              type: array
-                            pool:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                            user:
-                              type: string
-                          required:
-                          - image
-                          - monitors
-                          type: object
-                        scaleIO:
-                          properties:
-                            fsType:
-                              type: string
-                            gateway:
-                              type: string
-                            protectionDomain:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                            sslEnabled:
-                              type: boolean
-                            storageMode:
-                              type: string
-                            storagePool:
-                              type: string
-                            system:
-                              type: string
-                            volumeName:
-                              type: string
-                          required:
-                          - gateway
-                          - secretRef
-                          - system
-                          type: object
-                        secret:
-                          properties:
-                            defaultMode:
-                              format: int32
-                              type: integer
-                            items:
-                              items:
-                                properties:
-                                  key:
-                                    type: string
-                                  mode:
-                                    format: int32
-                                    type: integer
-                                  path:
-                                    type: string
-                                required:
-                                - key
-                                - path
-                                type: object
-                              type: array
-                            optional:
-                              type: boolean
-                            secretName:
-                              type: string
-                          type: object
-                        storageos:
-                          properties:
-                            fsType:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                            volumeName:
-                              type: string
-                            volumeNamespace:
-                              type: string
-                          type: object
-                        vsphereVolume:
-                          properties:
-                            fsType:
-                              type: string
-                            storagePolicyID:
-                              type: string
-                            storagePolicyName:
-                              type: string
-                            volumePath:
-                              type: string
-                          required:
-                          - volumePath
-                          type: object
-                      required:
-                      - name
-                      type: object
-                    type: array
-                    x-kubernetes-list-type: atomic
-                type: object
-              ingester:
-                properties:
-                  affinity:
-                    properties:
-                      nodeAffinity:
-                        properties:
-                          preferredDuringSchedulingIgnoredDuringExecution:
-                            items:
-                              properties:
-                                preference:
-                                  properties:
-                                    matchExpressions:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchFields:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                  type: object
-                                weight:
-                                  format: int32
-                                  type: integer
-                              required:
-                              - preference
-                              - weight
-                              type: object
-                            type: array
-                          requiredDuringSchedulingIgnoredDuringExecution:
-                            properties:
-                              nodeSelectorTerms:
-                                items:
-                                  properties:
-                                    matchExpressions:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchFields:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                  type: object
-                                type: array
-                            required:
-                            - nodeSelectorTerms
-                            type: object
-                        type: object
-                      podAffinity:
-                        properties:
-                          preferredDuringSchedulingIgnoredDuringExecution:
-                            items:
-                              properties:
-                                podAffinityTerm:
-                                  properties:
-                                    labelSelector:
-                                      properties:
-                                        matchExpressions:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchLabels:
-                                          additionalProperties:
-                                            type: string
-                                          type: object
-                                      type: object
-                                    namespaces:
-                                      items:
-                                        type: string
-                                      type: array
-                                    topologyKey:
-                                      type: string
-                                  required:
-                                  - topologyKey
-                                  type: object
-                                weight:
-                                  format: int32
-                                  type: integer
-                              required:
-                              - podAffinityTerm
-                              - weight
-                              type: object
-                            type: array
-                          requiredDuringSchedulingIgnoredDuringExecution:
-                            items:
-                              properties:
-                                labelSelector:
-                                  properties:
-                                    matchExpressions:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      type: object
-                                  type: object
-                                namespaces:
-                                  items:
-                                    type: string
-                                  type: array
-                                topologyKey:
-                                  type: string
-                              required:
-                              - topologyKey
-                              type: object
-                            type: array
-                        type: object
-                      podAntiAffinity:
-                        properties:
-                          preferredDuringSchedulingIgnoredDuringExecution:
-                            items:
-                              properties:
-                                podAffinityTerm:
-                                  properties:
-                                    labelSelector:
-                                      properties:
-                                        matchExpressions:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchLabels:
-                                          additionalProperties:
-                                            type: string
-                                          type: object
-                                      type: object
-                                    namespaces:
-                                      items:
-                                        type: string
-                                      type: array
-                                    topologyKey:
-                                      type: string
-                                  required:
-                                  - topologyKey
-                                  type: object
-                                weight:
-                                  format: int32
-                                  type: integer
-                              required:
-                              - podAffinityTerm
-                              - weight
-                              type: object
-                            type: array
-                          requiredDuringSchedulingIgnoredDuringExecution:
-                            items:
-                              properties:
-                                labelSelector:
-                                  properties:
-                                    matchExpressions:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      type: object
-                                  type: object
-                                namespaces:
-                                  items:
-                                    type: string
-                                  type: array
-                                topologyKey:
-                                  type: string
-                              required:
-                              - topologyKey
-                              type: object
-                            type: array
-                        type: object
-                    type: object
-                  annotations:
-                    additionalProperties:
-                      type: string
-                    nullable: true
-                    type: object
-                  autoscale:
-                    type: boolean
-                  config:
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                  image:
-                    type: string
-                  labels:
-                    additionalProperties:
-                      type: string
-                    type: object
-                  maxReplicas:
-                    format: int32
-                    type: integer
-                  minReplicas:
-                    format: int32
-                    type: integer
-                  options:
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                  replicas:
-                    format: int32
-                    type: integer
-                  resources:
-                    nullable: true
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        type: object
-                    type: object
-                  securityContext:
-                    properties:
-                      fsGroup:
-                        format: int64
-                        type: integer
-                      fsGroupChangePolicy:
-                        type: string
-                      runAsGroup:
-                        format: int64
-                        type: integer
-                      runAsNonRoot:
-                        type: boolean
-                      runAsUser:
-                        format: int64
-                        type: integer
-                      seLinuxOptions:
-                        properties:
-                          level:
-                            type: string
-                          role:
-                            type: string
-                          type:
-                            type: string
-                          user:
-                            type: string
-                        type: object
-                      seccompProfile:
-                        properties:
-                          localhostProfile:
-                            type: string
-                          type:
-                            type: string
-                        required:
-                        - type
-                        type: object
-                      supplementalGroups:
-                        items:
-                          format: int64
-                          type: integer
-                        type: array
-                      sysctls:
-                        items:
-                          properties:
-                            name:
-                              type: string
-                            value:
-                              type: string
-                          required:
-                          - name
-                          - value
-                          type: object
-                        type: array
-                      windowsOptions:
-                        properties:
-                          gmsaCredentialSpec:
-                            type: string
-                          gmsaCredentialSpecName:
-                            type: string
-                          runAsUserName:
-                            type: string
-                        type: object
-                    type: object
-                  serviceAccount:
-                    type: string
-                  tolerations:
-                    items:
-                      properties:
-                        effect:
-                          type: string
-                        key:
-                          type: string
-                        operator:
-                          type: string
-                        tolerationSeconds:
-                          format: int64
-                          type: integer
-                        value:
-                          type: string
-                      type: object
-                    type: array
-                    x-kubernetes-list-type: atomic
-                  volumeMounts:
-                    items:
-                      properties:
-                        mountPath:
-                          type: string
-                        mountPropagation:
-                          type: string
-                        name:
-                          type: string
-                        readOnly:
-                          type: boolean
-                        subPath:
-                          type: string
-                        subPathExpr:
-                          type: string
-                      required:
-                      - mountPath
-                      - name
-                      type: object
-                    type: array
-                    x-kubernetes-list-type: atomic
-                  volumes:
-                    items:
-                      properties:
-                        awsElasticBlockStore:
-                          properties:
-                            fsType:
-                              type: string
-                            partition:
-                              format: int32
-                              type: integer
-                            readOnly:
-                              type: boolean
-                            volumeID:
-                              type: string
-                          required:
-                          - volumeID
-                          type: object
-                        azureDisk:
-                          properties:
-                            cachingMode:
-                              type: string
-                            diskName:
-                              type: string
-                            diskURI:
-                              type: string
-                            fsType:
-                              type: string
-                            kind:
-                              type: string
-                            readOnly:
-                              type: boolean
-                          required:
-                          - diskName
-                          - diskURI
-                          type: object
-                        azureFile:
-                          properties:
-                            readOnly:
-                              type: boolean
-                            secretName:
-                              type: string
-                            shareName:
-                              type: string
-                          required:
-                          - secretName
-                          - shareName
-                          type: object
-                        cephfs:
-                          properties:
-                            monitors:
-                              items:
-                                type: string
-                              type: array
-                            path:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            secretFile:
-                              type: string
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                            user:
-                              type: string
-                          required:
-                          - monitors
-                          type: object
-                        cinder:
-                          properties:
-                            fsType:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                            volumeID:
-                              type: string
-                          required:
-                          - volumeID
-                          type: object
-                        configMap:
-                          properties:
-                            defaultMode:
-                              format: int32
-                              type: integer
-                            items:
-                              items:
-                                properties:
-                                  key:
-                                    type: string
-                                  mode:
-                                    format: int32
-                                    type: integer
-                                  path:
-                                    type: string
-                                required:
-                                - key
-                                - path
-                                type: object
-                              type: array
-                            name:
-                              type: string
-                            optional:
-                              type: boolean
-                          type: object
-                        csi:
-                          properties:
-                            driver:
-                              type: string
-                            fsType:
-                              type: string
-                            nodePublishSecretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                            readOnly:
-                              type: boolean
-                            volumeAttributes:
-                              additionalProperties:
-                                type: string
-                              type: object
-                          required:
-                          - driver
-                          type: object
-                        downwardAPI:
-                          properties:
-                            defaultMode:
-                              format: int32
-                              type: integer
-                            items:
-                              items:
-                                properties:
-                                  fieldRef:
-                                    properties:
-                                      apiVersion:
-                                        type: string
-                                      fieldPath:
-                                        type: string
-                                    required:
-                                    - fieldPath
-                                    type: object
-                                  mode:
-                                    format: int32
-                                    type: integer
-                                  path:
-                                    type: string
-                                  resourceFieldRef:
-                                    properties:
-                                      containerName:
-                                        type: string
-                                      divisor:
-                                        anyOf:
-                                        - type: integer
-                                        - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      resource:
-                                        type: string
-                                    required:
-                                    - resource
-                                    type: object
-                                required:
-                                - path
-                                type: object
-                              type: array
-                          type: object
-                        emptyDir:
-                          properties:
-                            medium:
-                              type: string
-                            sizeLimit:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                          type: object
-                        ephemeral:
-                          properties:
-                            readOnly:
-                              type: boolean
-                            volumeClaimTemplate:
-                              properties:
-                                metadata:
-                                  type: object
-                                spec:
-                                  properties:
-                                    accessModes:
-                                      items:
-                                        type: string
-                                      type: array
-                                    dataSource:
-                                      properties:
-                                        apiGroup:
-                                          type: string
-                                        kind:
-                                          type: string
-                                        name:
-                                          type: string
-                                      required:
-                                      - kind
-                                      - name
-                                      type: object
-                                    resources:
-                                      properties:
-                                        limits:
-                                          additionalProperties:
-                                            anyOf:
-                                            - type: integer
-                                            - type: string
-                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                            x-kubernetes-int-or-string: true
-                                          type: object
-                                        requests:
-                                          additionalProperties:
-                                            anyOf:
-                                            - type: integer
-                                            - type: string
-                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                            x-kubernetes-int-or-string: true
-                                          type: object
-                                      type: object
-                                    selector:
-                                      properties:
-                                        matchExpressions:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchLabels:
-                                          additionalProperties:
-                                            type: string
-                                          type: object
-                                      type: object
-                                    storageClassName:
-                                      type: string
-                                    volumeMode:
-                                      type: string
-                                    volumeName:
-                                      type: string
-                                  type: object
-                              required:
-                              - spec
-                              type: object
-                          type: object
-                        fc:
-                          properties:
-                            fsType:
-                              type: string
-                            lun:
-                              format: int32
-                              type: integer
-                            readOnly:
-                              type: boolean
-                            targetWWNs:
-                              items:
-                                type: string
-                              type: array
-                            wwids:
-                              items:
-                                type: string
-                              type: array
-                          type: object
-                        flexVolume:
-                          properties:
-                            driver:
-                              type: string
-                            fsType:
-                              type: string
-                            options:
-                              additionalProperties:
-                                type: string
-                              type: object
-                            readOnly:
-                              type: boolean
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                          required:
-                          - driver
-                          type: object
-                        flocker:
-                          properties:
-                            datasetName:
-                              type: string
-                            datasetUUID:
-                              type: string
-                          type: object
-                        gcePersistentDisk:
-                          properties:
-                            fsType:
-                              type: string
-                            partition:
-                              format: int32
-                              type: integer
-                            pdName:
-                              type: string
-                            readOnly:
-                              type: boolean
-                          required:
-                          - pdName
-                          type: object
-                        gitRepo:
-                          properties:
-                            directory:
-                              type: string
-                            repository:
-                              type: string
-                            revision:
-                              type: string
-                          required:
-                          - repository
-                          type: object
-                        glusterfs:
-                          properties:
-                            endpoints:
-                              type: string
-                            path:
-                              type: string
-                            readOnly:
-                              type: boolean
-                          required:
-                          - endpoints
-                          - path
-                          type: object
-                        hostPath:
-                          properties:
-                            path:
-                              type: string
-                            type:
-                              type: string
-                          required:
-                          - path
-                          type: object
-                        iscsi:
-                          properties:
-                            chapAuthDiscovery:
-                              type: boolean
-                            chapAuthSession:
-                              type: boolean
-                            fsType:
-                              type: string
-                            initiatorName:
-                              type: string
-                            iqn:
-                              type: string
-                            iscsiInterface:
-                              type: string
-                            lun:
-                              format: int32
-                              type: integer
-                            portals:
-                              items:
-                                type: string
-                              type: array
-                            readOnly:
-                              type: boolean
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                            targetPortal:
-                              type: string
-                          required:
-                          - iqn
-                          - lun
-                          - targetPortal
-                          type: object
-                        name:
-                          type: string
-                        nfs:
-                          properties:
-                            path:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            server:
-                              type: string
-                          required:
-                          - path
-                          - server
-                          type: object
-                        persistentVolumeClaim:
-                          properties:
-                            claimName:
-                              type: string
-                            readOnly:
-                              type: boolean
-                          required:
-                          - claimName
-                          type: object
-                        photonPersistentDisk:
-                          properties:
-                            fsType:
-                              type: string
-                            pdID:
-                              type: string
-                          required:
-                          - pdID
-                          type: object
-                        portworxVolume:
-                          properties:
-                            fsType:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            volumeID:
-                              type: string
-                          required:
-                          - volumeID
-                          type: object
-                        projected:
-                          properties:
-                            defaultMode:
-                              format: int32
-                              type: integer
-                            sources:
-                              items:
-                                properties:
-                                  configMap:
-                                    properties:
-                                      items:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            mode:
-                                              format: int32
-                                              type: integer
-                                            path:
-                                              type: string
-                                          required:
-                                          - key
-                                          - path
-                                          type: object
-                                        type: array
-                                      name:
-                                        type: string
-                                      optional:
-                                        type: boolean
-                                    type: object
-                                  downwardAPI:
-                                    properties:
-                                      items:
-                                        items:
-                                          properties:
-                                            fieldRef:
-                                              properties:
-                                                apiVersion:
-                                                  type: string
-                                                fieldPath:
-                                                  type: string
-                                              required:
-                                              - fieldPath
-                                              type: object
-                                            mode:
-                                              format: int32
-                                              type: integer
-                                            path:
-                                              type: string
-                                            resourceFieldRef:
-                                              properties:
-                                                containerName:
-                                                  type: string
-                                                divisor:
-                                                  anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                  x-kubernetes-int-or-string: true
-                                                resource:
-                                                  type: string
-                                              required:
-                                              - resource
-                                              type: object
-                                          required:
-                                          - path
-                                          type: object
-                                        type: array
-                                    type: object
-                                  secret:
-                                    properties:
-                                      items:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            mode:
-                                              format: int32
-                                              type: integer
-                                            path:
-                                              type: string
-                                          required:
-                                          - key
-                                          - path
-                                          type: object
-                                        type: array
-                                      name:
-                                        type: string
-                                      optional:
-                                        type: boolean
-                                    type: object
-                                  serviceAccountToken:
-                                    properties:
-                                      audience:
-                                        type: string
-                                      expirationSeconds:
-                                        format: int64
-                                        type: integer
-                                      path:
-                                        type: string
-                                    required:
-                                    - path
-                                    type: object
-                                type: object
-                              type: array
-                          type: object
-                        quobyte:
-                          properties:
-                            group:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            registry:
-                              type: string
-                            tenant:
-                              type: string
-                            user:
-                              type: string
-                            volume:
-                              type: string
-                          required:
-                          - registry
-                          - volume
-                          type: object
-                        rbd:
-                          properties:
-                            fsType:
-                              type: string
-                            image:
-                              type: string
-                            keyring:
-                              type: string
-                            monitors:
-                              items:
-                                type: string
-                              type: array
-                            pool:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                            user:
-                              type: string
-                          required:
-                          - image
-                          - monitors
-                          type: object
-                        scaleIO:
-                          properties:
-                            fsType:
-                              type: string
-                            gateway:
-                              type: string
-                            protectionDomain:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                            sslEnabled:
-                              type: boolean
-                            storageMode:
-                              type: string
-                            storagePool:
-                              type: string
-                            system:
-                              type: string
-                            volumeName:
-                              type: string
-                          required:
-                          - gateway
-                          - secretRef
-                          - system
-                          type: object
-                        secret:
-                          properties:
-                            defaultMode:
-                              format: int32
-                              type: integer
-                            items:
-                              items:
-                                properties:
-                                  key:
-                                    type: string
-                                  mode:
-                                    format: int32
-                                    type: integer
-                                  path:
-                                    type: string
-                                required:
-                                - key
-                                - path
-                                type: object
-                              type: array
-                            optional:
-                              type: boolean
-                            secretName:
-                              type: string
-                          type: object
-                        storageos:
-                          properties:
-                            fsType:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                            volumeName:
-                              type: string
-                            volumeNamespace:
-                              type: string
-                          type: object
-                        vsphereVolume:
-                          properties:
-                            fsType:
-                              type: string
-                            storagePolicyID:
-                              type: string
-                            storagePolicyName:
-                              type: string
-                            volumePath:
-                              type: string
-                          required:
-                          - volumePath
-                          type: object
-                      required:
-                      - name
-                      type: object
-                    type: array
-                    x-kubernetes-list-type: atomic
-                type: object
-              ingress:
-                properties:
-                  affinity:
-                    properties:
-                      nodeAffinity:
-                        properties:
-                          preferredDuringSchedulingIgnoredDuringExecution:
-                            items:
-                              properties:
-                                preference:
-                                  properties:
-                                    matchExpressions:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchFields:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                  type: object
-                                weight:
-                                  format: int32
-                                  type: integer
-                              required:
-                              - preference
-                              - weight
-                              type: object
-                            type: array
-                          requiredDuringSchedulingIgnoredDuringExecution:
-                            properties:
-                              nodeSelectorTerms:
-                                items:
-                                  properties:
-                                    matchExpressions:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchFields:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                  type: object
-                                type: array
-                            required:
-                            - nodeSelectorTerms
-                            type: object
-                        type: object
-                      podAffinity:
-                        properties:
-                          preferredDuringSchedulingIgnoredDuringExecution:
-                            items:
-                              properties:
-                                podAffinityTerm:
-                                  properties:
-                                    labelSelector:
-                                      properties:
-                                        matchExpressions:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchLabels:
-                                          additionalProperties:
-                                            type: string
-                                          type: object
-                                      type: object
-                                    namespaces:
-                                      items:
-                                        type: string
-                                      type: array
-                                    topologyKey:
-                                      type: string
-                                  required:
-                                  - topologyKey
-                                  type: object
-                                weight:
-                                  format: int32
-                                  type: integer
-                              required:
-                              - podAffinityTerm
-                              - weight
-                              type: object
-                            type: array
-                          requiredDuringSchedulingIgnoredDuringExecution:
-                            items:
-                              properties:
-                                labelSelector:
-                                  properties:
-                                    matchExpressions:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      type: object
-                                  type: object
-                                namespaces:
-                                  items:
-                                    type: string
-                                  type: array
-                                topologyKey:
-                                  type: string
-                              required:
-                              - topologyKey
-                              type: object
-                            type: array
-                        type: object
-                      podAntiAffinity:
-                        properties:
-                          preferredDuringSchedulingIgnoredDuringExecution:
-                            items:
-                              properties:
-                                podAffinityTerm:
-                                  properties:
-                                    labelSelector:
-                                      properties:
-                                        matchExpressions:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchLabels:
-                                          additionalProperties:
-                                            type: string
-                                          type: object
-                                      type: object
-                                    namespaces:
-                                      items:
-                                        type: string
-                                      type: array
-                                    topologyKey:
-                                      type: string
-                                  required:
-                                  - topologyKey
-                                  type: object
-                                weight:
-                                  format: int32
-                                  type: integer
-                              required:
-                              - podAffinityTerm
-                              - weight
-                              type: object
-                            type: array
-                          requiredDuringSchedulingIgnoredDuringExecution:
-                            items:
-                              properties:
-                                labelSelector:
-                                  properties:
-                                    matchExpressions:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      type: object
-                                  type: object
-                                namespaces:
-                                  items:
-                                    type: string
-                                  type: array
-                                topologyKey:
-                                  type: string
-                              required:
-                              - topologyKey
-                              type: object
-                            type: array
-                        type: object
-                    type: object
-                  annotations:
-                    additionalProperties:
-                      type: string
-                    nullable: true
-                    type: object
-                  enabled:
-                    type: boolean
-                  hosts:
-                    items:
-                      type: string
-                    type: array
-                    x-kubernetes-list-type: atomic
-                  labels:
-                    additionalProperties:
-                      type: string
-                    type: object
-                  openshift:
-                    properties:
-                      delegateUrls:
-                        type: string
-                      htpasswdFile:
-                        type: string
-                      sar:
-                        type: string
-                      skipLogout:
-                        type: boolean
-                    type: object
-                  options:
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                  resources:
-                    nullable: true
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        type: object
-                    type: object
-                  secretName:
-                    type: string
-                  security:
-                    type: string
-                  securityContext:
-                    properties:
-                      fsGroup:
-                        format: int64
-                        type: integer
-                      fsGroupChangePolicy:
-                        type: string
-                      runAsGroup:
-                        format: int64
-                        type: integer
-                      runAsNonRoot:
-                        type: boolean
-                      runAsUser:
-                        format: int64
-                        type: integer
-                      seLinuxOptions:
-                        properties:
-                          level:
-                            type: string
-                          role:
-                            type: string
-                          type:
-                            type: string
-                          user:
-                            type: string
-                        type: object
-                      seccompProfile:
-                        properties:
-                          localhostProfile:
-                            type: string
-                          type:
-                            type: string
-                        required:
-                        - type
-                        type: object
-                      supplementalGroups:
-                        items:
-                          format: int64
-                          type: integer
-                        type: array
-                      sysctls:
-                        items:
-                          properties:
-                            name:
-                              type: string
-                            value:
-                              type: string
-                          required:
-                          - name
-                          - value
-                          type: object
-                        type: array
-                      windowsOptions:
-                        properties:
-                          gmsaCredentialSpec:
-                            type: string
-                          gmsaCredentialSpecName:
-                            type: string
-                          runAsUserName:
-                            type: string
-                        type: object
-                    type: object
-                  serviceAccount:
-                    type: string
-                  tls:
-                    items:
-                      properties:
-                        hosts:
+                        add:
                           items:
                             type: string
                           type: array
-                          x-kubernetes-list-type: atomic
-                        secretName:
-                          type: string
+                        drop:
+                          items:
+                            type: string
+                          type: array
                       type: object
-                    type: array
-                    x-kubernetes-list-type: atomic
-                  tolerations:
-                    items:
-                      properties:
-                        effect:
-                          type: string
-                        key:
-                          type: string
-                        operator:
-                          type: string
-                        tolerationSeconds:
-                          format: int64
-                          type: integer
-                        value:
-                          type: string
-                      type: object
-                    type: array
-                    x-kubernetes-list-type: atomic
-                  volumeMounts:
-                    items:
-                      properties:
-                        mountPath:
-                          type: string
-                        mountPropagation:
-                          type: string
-                        name:
-                          type: string
-                        readOnly:
-                          type: boolean
-                        subPath:
-                          type: string
-                        subPathExpr:
-                          type: string
-                      required:
-                      - mountPath
-                      - name
-                      type: object
-                    type: array
-                    x-kubernetes-list-type: atomic
-                  volumes:
-                    items:
-                      properties:
-                        awsElasticBlockStore:
-                          properties:
-                            fsType:
-                              type: string
-                            partition:
-                              format: int32
-                              type: integer
-                            readOnly:
-                              type: boolean
-                            volumeID:
-                              type: string
-                          required:
-                          - volumeID
-                          type: object
-                        azureDisk:
-                          properties:
-                            cachingMode:
-                              type: string
-                            diskName:
-                              type: string
-                            diskURI:
-                              type: string
-                            fsType:
-                              type: string
-                            kind:
-                              type: string
-                            readOnly:
-                              type: boolean
-                          required:
-                          - diskName
-                          - diskURI
-                          type: object
-                        azureFile:
-                          properties:
-                            readOnly:
-                              type: boolean
-                            secretName:
-                              type: string
-                            shareName:
-                              type: string
-                          required:
-                          - secretName
-                          - shareName
-                          type: object
-                        cephfs:
-                          properties:
-                            monitors:
-                              items:
-                                type: string
-                              type: array
-                            path:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            secretFile:
-                              type: string
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                            user:
-                              type: string
-                          required:
-                          - monitors
-                          type: object
-                        cinder:
-                          properties:
-                            fsType:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                            volumeID:
-                              type: string
-                          required:
-                          - volumeID
-                          type: object
-                        configMap:
-                          properties:
-                            defaultMode:
-                              format: int32
-                              type: integer
-                            items:
-                              items:
-                                properties:
-                                  key:
-                                    type: string
-                                  mode:
-                                    format: int32
-                                    type: integer
-                                  path:
-                                    type: string
-                                required:
-                                - key
-                                - path
-                                type: object
-                              type: array
-                            name:
-                              type: string
-                            optional:
-                              type: boolean
-                          type: object
-                        csi:
-                          properties:
-                            driver:
-                              type: string
-                            fsType:
-                              type: string
-                            nodePublishSecretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                            readOnly:
-                              type: boolean
-                            volumeAttributes:
-                              additionalProperties:
-                                type: string
-                              type: object
-                          required:
-                          - driver
-                          type: object
-                        downwardAPI:
-                          properties:
-                            defaultMode:
-                              format: int32
-                              type: integer
-                            items:
-                              items:
-                                properties:
-                                  fieldRef:
-                                    properties:
-                                      apiVersion:
-                                        type: string
-                                      fieldPath:
-                                        type: string
-                                    required:
-                                    - fieldPath
-                                    type: object
-                                  mode:
-                                    format: int32
-                                    type: integer
-                                  path:
-                                    type: string
-                                  resourceFieldRef:
-                                    properties:
-                                      containerName:
-                                        type: string
-                                      divisor:
-                                        anyOf:
-                                        - type: integer
-                                        - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      resource:
-                                        type: string
-                                    required:
-                                    - resource
-                                    type: object
-                                required:
-                                - path
-                                type: object
-                              type: array
-                          type: object
-                        emptyDir:
-                          properties:
-                            medium:
-                              type: string
-                            sizeLimit:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                          type: object
-                        ephemeral:
-                          properties:
-                            readOnly:
-                              type: boolean
-                            volumeClaimTemplate:
-                              properties:
-                                metadata:
-                                  type: object
-                                spec:
-                                  properties:
-                                    accessModes:
-                                      items:
-                                        type: string
-                                      type: array
-                                    dataSource:
-                                      properties:
-                                        apiGroup:
-                                          type: string
-                                        kind:
-                                          type: string
-                                        name:
-                                          type: string
-                                      required:
-                                      - kind
-                                      - name
-                                      type: object
-                                    resources:
-                                      properties:
-                                        limits:
-                                          additionalProperties:
-                                            anyOf:
-                                            - type: integer
-                                            - type: string
-                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                            x-kubernetes-int-or-string: true
-                                          type: object
-                                        requests:
-                                          additionalProperties:
-                                            anyOf:
-                                            - type: integer
-                                            - type: string
-                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                            x-kubernetes-int-or-string: true
-                                          type: object
-                                      type: object
-                                    selector:
-                                      properties:
-                                        matchExpressions:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchLabels:
-                                          additionalProperties:
-                                            type: string
-                                          type: object
-                                      type: object
-                                    storageClassName:
-                                      type: string
-                                    volumeMode:
-                                      type: string
-                                    volumeName:
-                                      type: string
-                                  type: object
-                              required:
-                              - spec
-                              type: object
-                          type: object
-                        fc:
-                          properties:
-                            fsType:
-                              type: string
-                            lun:
-                              format: int32
-                              type: integer
-                            readOnly:
-                              type: boolean
-                            targetWWNs:
-                              items:
-                                type: string
-                              type: array
-                            wwids:
-                              items:
-                                type: string
-                              type: array
-                          type: object
-                        flexVolume:
-                          properties:
-                            driver:
-                              type: string
-                            fsType:
-                              type: string
-                            options:
-                              additionalProperties:
-                                type: string
-                              type: object
-                            readOnly:
-                              type: boolean
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                          required:
-                          - driver
-                          type: object
-                        flocker:
-                          properties:
-                            datasetName:
-                              type: string
-                            datasetUUID:
-                              type: string
-                          type: object
-                        gcePersistentDisk:
-                          properties:
-                            fsType:
-                              type: string
-                            partition:
-                              format: int32
-                              type: integer
-                            pdName:
-                              type: string
-                            readOnly:
-                              type: boolean
-                          required:
-                          - pdName
-                          type: object
-                        gitRepo:
-                          properties:
-                            directory:
-                              type: string
-                            repository:
-                              type: string
-                            revision:
-                              type: string
-                          required:
-                          - repository
-                          type: object
-                        glusterfs:
-                          properties:
-                            endpoints:
-                              type: string
-                            path:
-                              type: string
-                            readOnly:
-                              type: boolean
-                          required:
-                          - endpoints
-                          - path
-                          type: object
-                        hostPath:
-                          properties:
-                            path:
-                              type: string
-                            type:
-                              type: string
-                          required:
-                          - path
-                          type: object
-                        iscsi:
-                          properties:
-                            chapAuthDiscovery:
-                              type: boolean
-                            chapAuthSession:
-                              type: boolean
-                            fsType:
-                              type: string
-                            initiatorName:
-                              type: string
-                            iqn:
-                              type: string
-                            iscsiInterface:
-                              type: string
-                            lun:
-                              format: int32
-                              type: integer
-                            portals:
-                              items:
-                                type: string
-                              type: array
-                            readOnly:
-                              type: boolean
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                            targetPortal:
-                              type: string
-                          required:
-                          - iqn
-                          - lun
-                          - targetPortal
-                          type: object
-                        name:
-                          type: string
-                        nfs:
-                          properties:
-                            path:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            server:
-                              type: string
-                          required:
-                          - path
-                          - server
-                          type: object
-                        persistentVolumeClaim:
-                          properties:
-                            claimName:
-                              type: string
-                            readOnly:
-                              type: boolean
-                          required:
-                          - claimName
-                          type: object
-                        photonPersistentDisk:
-                          properties:
-                            fsType:
-                              type: string
-                            pdID:
-                              type: string
-                          required:
-                          - pdID
-                          type: object
-                        portworxVolume:
-                          properties:
-                            fsType:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            volumeID:
-                              type: string
-                          required:
-                          - volumeID
-                          type: object
-                        projected:
-                          properties:
-                            defaultMode:
-                              format: int32
-                              type: integer
-                            sources:
-                              items:
-                                properties:
-                                  configMap:
-                                    properties:
-                                      items:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            mode:
-                                              format: int32
-                                              type: integer
-                                            path:
-                                              type: string
-                                          required:
-                                          - key
-                                          - path
-                                          type: object
-                                        type: array
-                                      name:
-                                        type: string
-                                      optional:
-                                        type: boolean
-                                    type: object
-                                  downwardAPI:
-                                    properties:
-                                      items:
-                                        items:
-                                          properties:
-                                            fieldRef:
-                                              properties:
-                                                apiVersion:
-                                                  type: string
-                                                fieldPath:
-                                                  type: string
-                                              required:
-                                              - fieldPath
-                                              type: object
-                                            mode:
-                                              format: int32
-                                              type: integer
-                                            path:
-                                              type: string
-                                            resourceFieldRef:
-                                              properties:
-                                                containerName:
-                                                  type: string
-                                                divisor:
-                                                  anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                  x-kubernetes-int-or-string: true
-                                                resource:
-                                                  type: string
-                                              required:
-                                              - resource
-                                              type: object
-                                          required:
-                                          - path
-                                          type: object
-                                        type: array
-                                    type: object
-                                  secret:
-                                    properties:
-                                      items:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            mode:
-                                              format: int32
-                                              type: integer
-                                            path:
-                                              type: string
-                                          required:
-                                          - key
-                                          - path
-                                          type: object
-                                        type: array
-                                      name:
-                                        type: string
-                                      optional:
-                                        type: boolean
-                                    type: object
-                                  serviceAccountToken:
-                                    properties:
-                                      audience:
-                                        type: string
-                                      expirationSeconds:
-                                        format: int64
-                                        type: integer
-                                      path:
-                                        type: string
-                                    required:
-                                    - path
-                                    type: object
-                                type: object
-                              type: array
-                          type: object
-                        quobyte:
-                          properties:
-                            group:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            registry:
-                              type: string
-                            tenant:
-                              type: string
-                            user:
-                              type: string
-                            volume:
-                              type: string
-                          required:
-                          - registry
-                          - volume
-                          type: object
-                        rbd:
-                          properties:
-                            fsType:
-                              type: string
-                            image:
-                              type: string
-                            keyring:
-                              type: string
-                            monitors:
-                              items:
-                                type: string
-                              type: array
-                            pool:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                            user:
-                              type: string
-                          required:
-                          - image
-                          - monitors
-                          type: object
-                        scaleIO:
-                          properties:
-                            fsType:
-                              type: string
-                            gateway:
-                              type: string
-                            protectionDomain:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                            sslEnabled:
-                              type: boolean
-                            storageMode:
-                              type: string
-                            storagePool:
-                              type: string
-                            system:
-                              type: string
-                            volumeName:
-                              type: string
-                          required:
-                          - gateway
-                          - secretRef
-                          - system
-                          type: object
-                        secret:
-                          properties:
-                            defaultMode:
-                              format: int32
-                              type: integer
-                            items:
-                              items:
-                                properties:
-                                  key:
-                                    type: string
-                                  mode:
-                                    format: int32
-                                    type: integer
-                                  path:
-                                    type: string
-                                required:
-                                - key
-                                - path
-                                type: object
-                              type: array
-                            optional:
-                              type: boolean
-                            secretName:
-                              type: string
-                          type: object
-                        storageos:
-                          properties:
-                            fsType:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                            volumeName:
-                              type: string
-                            volumeNamespace:
-                              type: string
-                          type: object
-                        vsphereVolume:
-                          properties:
-                            fsType:
-                              type: string
-                            storagePolicyID:
-                              type: string
-                            storagePolicyName:
-                              type: string
-                            volumePath:
-                              type: string
-                          required:
-                          - volumePath
-                          type: object
-                      required:
-                      - name
-                      type: object
-                    type: array
-                    x-kubernetes-list-type: atomic
-                type: object
-              labels:
-                additionalProperties:
-                  type: string
-                type: object
-              query:
-                properties:
-                  affinity:
-                    properties:
-                      nodeAffinity:
-                        properties:
-                          preferredDuringSchedulingIgnoredDuringExecution:
-                            items:
-                              properties:
-                                preference:
-                                  properties:
-                                    matchExpressions:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchFields:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                  type: object
-                                weight:
-                                  format: int32
-                                  type: integer
-                              required:
-                              - preference
-                              - weight
-                              type: object
-                            type: array
-                          requiredDuringSchedulingIgnoredDuringExecution:
-                            properties:
-                              nodeSelectorTerms:
-                                items:
-                                  properties:
-                                    matchExpressions:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchFields:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                  type: object
-                                type: array
-                            required:
-                            - nodeSelectorTerms
-                            type: object
-                        type: object
-                      podAffinity:
-                        properties:
-                          preferredDuringSchedulingIgnoredDuringExecution:
-                            items:
-                              properties:
-                                podAffinityTerm:
-                                  properties:
-                                    labelSelector:
-                                      properties:
-                                        matchExpressions:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchLabels:
-                                          additionalProperties:
-                                            type: string
-                                          type: object
-                                      type: object
-                                    namespaces:
-                                      items:
-                                        type: string
-                                      type: array
-                                    topologyKey:
-                                      type: string
-                                  required:
-                                  - topologyKey
-                                  type: object
-                                weight:
-                                  format: int32
-                                  type: integer
-                              required:
-                              - podAffinityTerm
-                              - weight
-                              type: object
-                            type: array
-                          requiredDuringSchedulingIgnoredDuringExecution:
-                            items:
-                              properties:
-                                labelSelector:
-                                  properties:
-                                    matchExpressions:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      type: object
-                                  type: object
-                                namespaces:
-                                  items:
-                                    type: string
-                                  type: array
-                                topologyKey:
-                                  type: string
-                              required:
-                              - topologyKey
-                              type: object
-                            type: array
-                        type: object
-                      podAntiAffinity:
-                        properties:
-                          preferredDuringSchedulingIgnoredDuringExecution:
-                            items:
-                              properties:
-                                podAffinityTerm:
-                                  properties:
-                                    labelSelector:
-                                      properties:
-                                        matchExpressions:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchLabels:
-                                          additionalProperties:
-                                            type: string
-                                          type: object
-                                      type: object
-                                    namespaces:
-                                      items:
-                                        type: string
-                                      type: array
-                                    topologyKey:
-                                      type: string
-                                  required:
-                                  - topologyKey
-                                  type: object
-                                weight:
-                                  format: int32
-                                  type: integer
-                              required:
-                              - podAffinityTerm
-                              - weight
-                              type: object
-                            type: array
-                          requiredDuringSchedulingIgnoredDuringExecution:
-                            items:
-                              properties:
-                                labelSelector:
-                                  properties:
-                                    matchExpressions:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          operator:
-                                            type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      type: object
-                                  type: object
-                                namespaces:
-                                  items:
-                                    type: string
-                                  type: array
-                                topologyKey:
-                                  type: string
-                              required:
-                              - topologyKey
-                              type: object
-                            type: array
-                        type: object
-                    type: object
-                  annotations:
-                    additionalProperties:
+                    privileged:
+                      type: boolean
+                    procMount:
                       type: string
-                    nullable: true
-                    type: object
-                  image:
-                    type: string
-                  labels:
-                    additionalProperties:
-                      type: string
-                    type: object
-                  nodePort:
-                    format: int32
-                    type: integer
-                  options:
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                  priorityClassName:
-                    type: string
-                  replicas:
-                    format: int32
-                    type: integer
-                  resources:
-                    nullable: true
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        type: object
-                    type: object
-                  securityContext:
-                    properties:
-                      fsGroup:
-                        format: int64
-                        type: integer
-                      fsGroupChangePolicy:
-                        type: string
-                      runAsGroup:
-                        format: int64
-                        type: integer
-                      runAsNonRoot:
-                        type: boolean
-                      runAsUser:
-                        format: int64
-                        type: integer
-                      seLinuxOptions:
-                        properties:
-                          level:
-                            type: string
-                          role:
-                            type: string
-                          type:
-                            type: string
-                          user:
-                            type: string
-                        type: object
-                      seccompProfile:
-                        properties:
-                          localhostProfile:
-                            type: string
-                          type:
-                            type: string
-                        required:
-                        - type
-                        type: object
-                      supplementalGroups:
-                        items:
-                          format: int64
-                          type: integer
-                        type: array
-                      sysctls:
-                        items:
-                          properties:
-                            name:
-                              type: string
-                            value:
-                              type: string
-                          required:
-                          - name
-                          - value
-                          type: object
-                        type: array
-                      windowsOptions:
-                        properties:
-                          gmsaCredentialSpec:
-                            type: string
-                          gmsaCredentialSpecName:
-                            type: string
-                          runAsUserName:
-                            type: string
-                        type: object
-                    type: object
-                  serviceAccount:
-                    type: string
-                  serviceType:
-                    type: string
-                  tolerations:
-                    items:
-                      properties:
-                        effect:
-                          type: string
-                        key:
-                          type: string
-                        operator:
-                          type: string
-                        tolerationSeconds:
-                          format: int64
-                          type: integer
-                        value:
-                          type: string
-                      type: object
-                    type: array
-                    x-kubernetes-list-type: atomic
-                  tracingEnabled:
-                    type: boolean
-                  volumeMounts:
-                    items:
-                      properties:
-                        mountPath:
-                          type: string
-                        mountPropagation:
-                          type: string
-                        name:
-                          type: string
-                        readOnly:
-                          type: boolean
-                        subPath:
-                          type: string
-                        subPathExpr:
-                          type: string
-                      required:
-                      - mountPath
-                      - name
-                      type: object
-                    type: array
-                    x-kubernetes-list-type: atomic
-                  volumes:
-                    items:
-                      properties:
-                        awsElasticBlockStore:
-                          properties:
-                            fsType:
-                              type: string
-                            partition:
-                              format: int32
-                              type: integer
-                            readOnly:
-                              type: boolean
-                            volumeID:
-                              type: string
-                          required:
-                          - volumeID
-                          type: object
-                        azureDisk:
-                          properties:
-                            cachingMode:
-                              type: string
-                            diskName:
-                              type: string
-                            diskURI:
-                              type: string
-                            fsType:
-                              type: string
-                            kind:
-                              type: string
-                            readOnly:
-                              type: boolean
-                          required:
-                          - diskName
-                          - diskURI
-                          type: object
-                        azureFile:
-                          properties:
-                            readOnly:
-                              type: boolean
-                            secretName:
-                              type: string
-                            shareName:
-                              type: string
-                          required:
-                          - secretName
-                          - shareName
-                          type: object
-                        cephfs:
-                          properties:
-                            monitors:
-                              items:
-                                type: string
-                              type: array
-                            path:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            secretFile:
-                              type: string
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                            user:
-                              type: string
-                          required:
-                          - monitors
-                          type: object
-                        cinder:
-                          properties:
-                            fsType:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                            volumeID:
-                              type: string
-                          required:
-                          - volumeID
-                          type: object
-                        configMap:
-                          properties:
-                            defaultMode:
-                              format: int32
-                              type: integer
-                            items:
-                              items:
-                                properties:
-                                  key:
-                                    type: string
-                                  mode:
-                                    format: int32
-                                    type: integer
-                                  path:
-                                    type: string
-                                required:
-                                - key
-                                - path
-                                type: object
-                              type: array
-                            name:
-                              type: string
-                            optional:
-                              type: boolean
-                          type: object
-                        csi:
-                          properties:
-                            driver:
-                              type: string
-                            fsType:
-                              type: string
-                            nodePublishSecretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                            readOnly:
-                              type: boolean
-                            volumeAttributes:
-                              additionalProperties:
-                                type: string
-                              type: object
-                          required:
-                          - driver
-                          type: object
-                        downwardAPI:
-                          properties:
-                            defaultMode:
-                              format: int32
-                              type: integer
-                            items:
-                              items:
-                                properties:
-                                  fieldRef:
-                                    properties:
-                                      apiVersion:
-                                        type: string
-                                      fieldPath:
-                                        type: string
-                                    required:
-                                    - fieldPath
-                                    type: object
-                                  mode:
-                                    format: int32
-                                    type: integer
-                                  path:
-                                    type: string
-                                  resourceFieldRef:
-                                    properties:
-                                      containerName:
-                                        type: string
-                                      divisor:
-                                        anyOf:
-                                        - type: integer
-                                        - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      resource:
-                                        type: string
-                                    required:
-                                    - resource
-                                    type: object
-                                required:
-                                - path
-                                type: object
-                              type: array
-                          type: object
-                        emptyDir:
-                          properties:
-                            medium:
-                              type: string
-                            sizeLimit:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                          type: object
-                        ephemeral:
-                          properties:
-                            readOnly:
-                              type: boolean
-                            volumeClaimTemplate:
-                              properties:
-                                metadata:
-                                  type: object
-                                spec:
-                                  properties:
-                                    accessModes:
-                                      items:
-                                        type: string
-                                      type: array
-                                    dataSource:
-                                      properties:
-                                        apiGroup:
-                                          type: string
-                                        kind:
-                                          type: string
-                                        name:
-                                          type: string
-                                      required:
-                                      - kind
-                                      - name
-                                      type: object
-                                    resources:
-                                      properties:
-                                        limits:
-                                          additionalProperties:
-                                            anyOf:
-                                            - type: integer
-                                            - type: string
-                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                            x-kubernetes-int-or-string: true
-                                          type: object
-                                        requests:
-                                          additionalProperties:
-                                            anyOf:
-                                            - type: integer
-                                            - type: string
-                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                            x-kubernetes-int-or-string: true
-                                          type: object
-                                      type: object
-                                    selector:
-                                      properties:
-                                        matchExpressions:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchLabels:
-                                          additionalProperties:
-                                            type: string
-                                          type: object
-                                      type: object
-                                    storageClassName:
-                                      type: string
-                                    volumeMode:
-                                      type: string
-                                    volumeName:
-                                      type: string
-                                  type: object
-                              required:
-                              - spec
-                              type: object
-                          type: object
-                        fc:
-                          properties:
-                            fsType:
-                              type: string
-                            lun:
-                              format: int32
-                              type: integer
-                            readOnly:
-                              type: boolean
-                            targetWWNs:
-                              items:
-                                type: string
-                              type: array
-                            wwids:
-                              items:
-                                type: string
-                              type: array
-                          type: object
-                        flexVolume:
-                          properties:
-                            driver:
-                              type: string
-                            fsType:
-                              type: string
-                            options:
-                              additionalProperties:
-                                type: string
-                              type: object
-                            readOnly:
-                              type: boolean
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                          required:
-                          - driver
-                          type: object
-                        flocker:
-                          properties:
-                            datasetName:
-                              type: string
-                            datasetUUID:
-                              type: string
-                          type: object
-                        gcePersistentDisk:
-                          properties:
-                            fsType:
-                              type: string
-                            partition:
-                              format: int32
-                              type: integer
-                            pdName:
-                              type: string
-                            readOnly:
-                              type: boolean
-                          required:
-                          - pdName
-                          type: object
-                        gitRepo:
-                          properties:
-                            directory:
-                              type: string
-                            repository:
-                              type: string
-                            revision:
-                              type: string
-                          required:
-                          - repository
-                          type: object
-                        glusterfs:
-                          properties:
-                            endpoints:
-                              type: string
-                            path:
-                              type: string
-                            readOnly:
-                              type: boolean
-                          required:
-                          - endpoints
-                          - path
-                          type: object
-                        hostPath:
-                          properties:
-                            path:
-                              type: string
-                            type:
-                              type: string
-                          required:
-                          - path
-                          type: object
-                        iscsi:
-                          properties:
-                            chapAuthDiscovery:
-                              type: boolean
-                            chapAuthSession:
-                              type: boolean
-                            fsType:
-                              type: string
-                            initiatorName:
-                              type: string
-                            iqn:
-                              type: string
-                            iscsiInterface:
-                              type: string
-                            lun:
-                              format: int32
-                              type: integer
-                            portals:
-                              items:
-                                type: string
-                              type: array
-                            readOnly:
-                              type: boolean
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                            targetPortal:
-                              type: string
-                          required:
-                          - iqn
-                          - lun
-                          - targetPortal
-                          type: object
-                        name:
-                          type: string
-                        nfs:
-                          properties:
-                            path:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            server:
-                              type: string
-                          required:
-                          - path
-                          - server
-                          type: object
-                        persistentVolumeClaim:
-                          properties:
-                            claimName:
-                              type: string
-                            readOnly:
-                              type: boolean
-                          required:
-                          - claimName
-                          type: object
-                        photonPersistentDisk:
-                          properties:
-                            fsType:
-                              type: string
-                            pdID:
-                              type: string
-                          required:
-                          - pdID
-                          type: object
-                        portworxVolume:
-                          properties:
-                            fsType:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            volumeID:
-                              type: string
-                          required:
-                          - volumeID
-                          type: object
-                        projected:
-                          properties:
-                            defaultMode:
-                              format: int32
-                              type: integer
-                            sources:
-                              items:
-                                properties:
-                                  configMap:
-                                    properties:
-                                      items:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            mode:
-                                              format: int32
-                                              type: integer
-                                            path:
-                                              type: string
-                                          required:
-                                          - key
-                                          - path
-                                          type: object
-                                        type: array
-                                      name:
-                                        type: string
-                                      optional:
-                                        type: boolean
-                                    type: object
-                                  downwardAPI:
-                                    properties:
-                                      items:
-                                        items:
-                                          properties:
-                                            fieldRef:
-                                              properties:
-                                                apiVersion:
-                                                  type: string
-                                                fieldPath:
-                                                  type: string
-                                              required:
-                                              - fieldPath
-                                              type: object
-                                            mode:
-                                              format: int32
-                                              type: integer
-                                            path:
-                                              type: string
-                                            resourceFieldRef:
-                                              properties:
-                                                containerName:
-                                                  type: string
-                                                divisor:
-                                                  anyOf:
-                                                  - type: integer
-                                                  - type: string
-                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                  x-kubernetes-int-or-string: true
-                                                resource:
-                                                  type: string
-                                              required:
-                                              - resource
-                                              type: object
-                                          required:
-                                          - path
-                                          type: object
-                                        type: array
-                                    type: object
-                                  secret:
-                                    properties:
-                                      items:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            mode:
-                                              format: int32
-                                              type: integer
-                                            path:
-                                              type: string
-                                          required:
-                                          - key
-                                          - path
-                                          type: object
-                                        type: array
-                                      name:
-                                        type: string
-                                      optional:
-                                        type: boolean
-                                    type: object
-                                  serviceAccountToken:
-                                    properties:
-                                      audience:
-                                        type: string
-                                      expirationSeconds:
-                                        format: int64
-                                        type: integer
-                                      path:
-                                        type: string
-                                    required:
-                                    - path
-                                    type: object
-                                type: object
-                              type: array
-                          type: object
-                        quobyte:
-                          properties:
-                            group:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            registry:
-                              type: string
-                            tenant:
-                              type: string
-                            user:
-                              type: string
-                            volume:
-                              type: string
-                          required:
-                          - registry
-                          - volume
-                          type: object
-                        rbd:
-                          properties:
-                            fsType:
-                              type: string
-                            image:
-                              type: string
-                            keyring:
-                              type: string
-                            monitors:
-                              items:
-                                type: string
-                              type: array
-                            pool:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                            user:
-                              type: string
-                          required:
-                          - image
-                          - monitors
-                          type: object
-                        scaleIO:
-                          properties:
-                            fsType:
-                              type: string
-                            gateway:
-                              type: string
-                            protectionDomain:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                            sslEnabled:
-                              type: boolean
-                            storageMode:
-                              type: string
-                            storagePool:
-                              type: string
-                            system:
-                              type: string
-                            volumeName:
-                              type: string
-                          required:
-                          - gateway
-                          - secretRef
-                          - system
-                          type: object
-                        secret:
-                          properties:
-                            defaultMode:
-                              format: int32
-                              type: integer
-                            items:
-                              items:
-                                properties:
-                                  key:
-                                    type: string
-                                  mode:
-                                    format: int32
-                                    type: integer
-                                  path:
-                                    type: string
-                                required:
-                                - key
-                                - path
-                                type: object
-                              type: array
-                            optional:
-                              type: boolean
-                            secretName:
-                              type: string
-                          type: object
-                        storageos:
-                          properties:
-                            fsType:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                              type: object
-                            volumeName:
-                              type: string
-                            volumeNamespace:
-                              type: string
-                          type: object
-                        vsphereVolume:
-                          properties:
-                            fsType:
-                              type: string
-                            storagePolicyID:
-                              type: string
-                            storagePolicyName:
-                              type: string
-                            volumePath:
-                              type: string
-                          required:
-                          - volumePath
-                          type: object
-                      required:
-                      - name
-                      type: object
-                    type: array
-                    x-kubernetes-list-type: atomic
-                type: object
-              resources:
-                nullable: true
-                properties:
-                  limits:
-                    additionalProperties:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      x-kubernetes-int-or-string: true
-                    type: object
-                  requests:
-                    additionalProperties:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                      x-kubernetes-int-or-string: true
-                    type: object
-                type: object
-              sampling:
-                properties:
-                  options:
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                type: object
-              securityContext:
-                properties:
-                  fsGroup:
-                    format: int64
-                    type: integer
-                  fsGroupChangePolicy:
-                    type: string
-                  runAsGroup:
-                    format: int64
-                    type: integer
-                  runAsNonRoot:
-                    type: boolean
-                  runAsUser:
-                    format: int64
-                    type: integer
-                  seLinuxOptions:
-                    properties:
-                      level:
-                        type: string
-                      role:
-                        type: string
-                      type:
-                        type: string
-                      user:
-                        type: string
-                    type: object
-                  seccompProfile:
-                    properties:
-                      localhostProfile:
-                        type: string
-                      type:
-                        type: string
-                    required:
-                    - type
-                    type: object
-                  supplementalGroups:
-                    items:
+                    readOnlyRootFilesystem:
+                      type: boolean
+                    runAsGroup:
                       format: int64
                       type: integer
-                    type: array
-                  sysctls:
-                    items:
+                    runAsNonRoot:
+                      type: boolean
+                    runAsUser:
+                      format: int64
+                      type: integer
+                    seLinuxOptions:
                       properties:
-                        name:
+                        level:
                           type: string
-                        value:
+                        role:
+                          type: string
+                        type:
+                          type: string
+                        user:
+                          type: string
+                      type: object
+                    seccompProfile:
+                      properties:
+                        localhostProfile:
+                          type: string
+                        type:
                           type: string
                       required:
-                      - name
-                      - value
+                      - type
                       type: object
-                    type: array
-                  windowsOptions:
+                    windowsOptions:
+                      properties:
+                        gmsaCredentialSpec:
+                          type: string
+                        gmsaCredentialSpecName:
+                          type: string
+                        runAsUserName:
+                          type: string
+                      type: object
+                  type: object
+                strategy:
+                  type: string
+                tolerations:
+                  items:
                     properties:
-                      gmsaCredentialSpec:
+                      effect:
                         type: string
-                      gmsaCredentialSpecName:
+                      key:
                         type: string
-                      runAsUserName:
+                      operator:
                         type: string
-                    type: object
-                type: object
-              serviceAccount:
-                type: string
-              storage:
-                properties:
-                  cassandraCreateSchema:
-                    properties:
-                      datacenter:
-                        type: string
-                      enabled:
-                        type: boolean
-                      image:
-                        type: string
-                      mode:
-                        type: string
-                      timeout:
-                        type: string
-                      traceTTL:
-                        type: string
-                      ttlSecondsAfterFinished:
-                        format: int32
+                      tolerationSeconds:
+                        format: int64
                         type: integer
+                      value:
+                        type: string
                     type: object
-                  dependencies:
+                  type: array
+                  x-kubernetes-list-type: atomic
+                volumeMounts:
+                  items:
                     properties:
-                      affinity:
-                        properties:
-                          nodeAffinity:
-                            properties:
-                              preferredDuringSchedulingIgnoredDuringExecution:
-                                items:
-                                  properties:
-                                    preference:
-                                      properties:
-                                        matchExpressions:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchFields:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                      type: object
-                                    weight:
-                                      format: int32
-                                      type: integer
-                                  required:
-                                  - preference
-                                  - weight
-                                  type: object
-                                type: array
-                              requiredDuringSchedulingIgnoredDuringExecution:
-                                properties:
-                                  nodeSelectorTerms:
-                                    items:
-                                      properties:
-                                        matchExpressions:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchFields:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                      type: object
-                                    type: array
-                                required:
-                                - nodeSelectorTerms
-                                type: object
-                            type: object
-                          podAffinity:
-                            properties:
-                              preferredDuringSchedulingIgnoredDuringExecution:
-                                items:
-                                  properties:
-                                    podAffinityTerm:
-                                      properties:
-                                        labelSelector:
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                - key
-                                                - operator
-                                                type: object
-                                              type: array
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                          type: object
-                                        namespaces:
-                                          items:
-                                            type: string
-                                          type: array
-                                        topologyKey:
-                                          type: string
-                                      required:
-                                      - topologyKey
-                                      type: object
-                                    weight:
-                                      format: int32
-                                      type: integer
-                                  required:
-                                  - podAffinityTerm
-                                  - weight
-                                  type: object
-                                type: array
-                              requiredDuringSchedulingIgnoredDuringExecution:
-                                items:
-                                  properties:
-                                    labelSelector:
-                                      properties:
-                                        matchExpressions:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchLabels:
-                                          additionalProperties:
-                                            type: string
-                                          type: object
-                                      type: object
-                                    namespaces:
-                                      items:
-                                        type: string
-                                      type: array
-                                    topologyKey:
-                                      type: string
-                                  required:
-                                  - topologyKey
-                                  type: object
-                                type: array
-                            type: object
-                          podAntiAffinity:
-                            properties:
-                              preferredDuringSchedulingIgnoredDuringExecution:
-                                items:
-                                  properties:
-                                    podAffinityTerm:
-                                      properties:
-                                        labelSelector:
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                - key
-                                                - operator
-                                                type: object
-                                              type: array
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                          type: object
-                                        namespaces:
-                                          items:
-                                            type: string
-                                          type: array
-                                        topologyKey:
-                                          type: string
-                                      required:
-                                      - topologyKey
-                                      type: object
-                                    weight:
-                                      format: int32
-                                      type: integer
-                                  required:
-                                  - podAffinityTerm
-                                  - weight
-                                  type: object
-                                type: array
-                              requiredDuringSchedulingIgnoredDuringExecution:
-                                items:
-                                  properties:
-                                    labelSelector:
-                                      properties:
-                                        matchExpressions:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchLabels:
-                                          additionalProperties:
-                                            type: string
-                                          type: object
-                                      type: object
-                                    namespaces:
-                                      items:
-                                        type: string
-                                      type: array
-                                    topologyKey:
-                                      type: string
-                                  required:
-                                  - topologyKey
-                                  type: object
-                                type: array
-                            type: object
-                        type: object
-                      annotations:
-                        additionalProperties:
-                          type: string
-                        nullable: true
-                        type: object
-                      cassandraClientAuthEnabled:
-                        type: boolean
-                      elasticsearchClientNodeOnly:
-                        type: boolean
-                      elasticsearchNodesWanOnly:
-                        type: boolean
-                      enabled:
-                        type: boolean
-                      image:
+                      mountPath:
                         type: string
-                      javaOpts:
+                      mountPropagation:
                         type: string
-                      labels:
-                        additionalProperties:
-                          type: string
-                        type: object
-                      resources:
-                        nullable: true
-                        properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            type: object
-                        type: object
-                      schedule:
+                      name:
                         type: string
-                      securityContext:
+                      readOnly:
+                        type: boolean
+                      subPath:
+                        type: string
+                      subPathExpr:
+                        type: string
+                    required:
+                    - mountPath
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                volumes:
+                  items:
+                    properties:
+                      awsElasticBlockStore:
                         properties:
-                          fsGroup:
-                            format: int64
-                            type: integer
-                          fsGroupChangePolicy:
+                          fsType:
                             type: string
-                          runAsGroup:
-                            format: int64
+                          partition:
+                            format: int32
                             type: integer
-                          runAsNonRoot:
+                          readOnly:
                             type: boolean
-                          runAsUser:
-                            format: int64
+                          volumeID:
+                            type: string
+                        required:
+                        - volumeID
+                        type: object
+                      azureDisk:
+                        properties:
+                          cachingMode:
+                            type: string
+                          diskName:
+                            type: string
+                          diskURI:
+                            type: string
+                          fsType:
+                            type: string
+                          kind:
+                            type: string
+                          readOnly:
+                            type: boolean
+                        required:
+                        - diskName
+                        - diskURI
+                        type: object
+                      azureFile:
+                        properties:
+                          readOnly:
+                            type: boolean
+                          secretName:
+                            type: string
+                          shareName:
+                            type: string
+                        required:
+                        - secretName
+                        - shareName
+                        type: object
+                      cephfs:
+                        properties:
+                          monitors:
+                            items:
+                              type: string
+                            type: array
+                          path:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          secretFile:
+                            type: string
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          user:
+                            type: string
+                        required:
+                        - monitors
+                        type: object
+                      cinder:
+                        properties:
+                          fsType:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          volumeID:
+                            type: string
+                        required:
+                        - volumeID
+                        type: object
+                      configMap:
+                        properties:
+                          defaultMode:
+                            format: int32
                             type: integer
-                          seLinuxOptions:
-                            properties:
-                              level:
-                                type: string
-                              role:
-                                type: string
-                              type:
-                                type: string
-                              user:
-                                type: string
-                            type: object
-                          seccompProfile:
-                            properties:
-                              localhostProfile:
-                                type: string
-                              type:
-                                type: string
-                            required:
-                            - type
-                            type: object
-                          supplementalGroups:
-                            items:
-                              format: int64
-                              type: integer
-                            type: array
-                          sysctls:
+                          items:
                             items:
                               properties:
-                                name:
+                                key:
                                   type: string
-                                value:
-                                  type: string
-                              required:
-                              - name
-                              - value
-                              type: object
-                            type: array
-                          windowsOptions:
-                            properties:
-                              gmsaCredentialSpec:
-                                type: string
-                              gmsaCredentialSpecName:
-                                type: string
-                              runAsUserName:
-                                type: string
-                            type: object
-                        type: object
-                      serviceAccount:
-                        type: string
-                      sparkMaster:
-                        type: string
-                      successfulJobsHistoryLimit:
-                        format: int32
-                        type: integer
-                      tolerations:
-                        items:
-                          properties:
-                            effect:
-                              type: string
-                            key:
-                              type: string
-                            operator:
-                              type: string
-                            tolerationSeconds:
-                              format: int64
-                              type: integer
-                            value:
-                              type: string
-                          type: object
-                        type: array
-                        x-kubernetes-list-type: atomic
-                      ttlSecondsAfterFinished:
-                        format: int32
-                        type: integer
-                      volumeMounts:
-                        items:
-                          properties:
-                            mountPath:
-                              type: string
-                            mountPropagation:
-                              type: string
-                            name:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            subPath:
-                              type: string
-                            subPathExpr:
-                              type: string
-                          required:
-                          - mountPath
-                          - name
-                          type: object
-                        type: array
-                        x-kubernetes-list-type: atomic
-                      volumes:
-                        items:
-                          properties:
-                            awsElasticBlockStore:
-                              properties:
-                                fsType:
-                                  type: string
-                                partition:
+                                mode:
                                   format: int32
                                   type: integer
-                                readOnly:
-                                  type: boolean
-                                volumeID:
-                                  type: string
-                              required:
-                              - volumeID
-                              type: object
-                            azureDisk:
-                              properties:
-                                cachingMode:
-                                  type: string
-                                diskName:
-                                  type: string
-                                diskURI:
-                                  type: string
-                                fsType:
-                                  type: string
-                                kind:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                              required:
-                              - diskName
-                              - diskURI
-                              type: object
-                            azureFile:
-                              properties:
-                                readOnly:
-                                  type: boolean
-                                secretName:
-                                  type: string
-                                shareName:
-                                  type: string
-                              required:
-                              - secretName
-                              - shareName
-                              type: object
-                            cephfs:
-                              properties:
-                                monitors:
-                                  items:
-                                    type: string
-                                  type: array
                                 path:
                                   type: string
-                                readOnly:
-                                  type: boolean
-                                secretFile:
-                                  type: string
-                                secretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                                user:
-                                  type: string
                               required:
-                              - monitors
+                              - key
+                              - path
                               type: object
-                            cinder:
+                            type: array
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        type: object
+                      csi:
+                        properties:
+                          driver:
+                            type: string
+                          fsType:
+                            type: string
+                          nodePublishSecretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          readOnly:
+                            type: boolean
+                          volumeAttributes:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        required:
+                        - driver
+                        type: object
+                      downwardAPI:
+                        properties:
+                          defaultMode:
+                            format: int32
+                            type: integer
+                          items:
+                            items:
                               properties:
-                                fsType:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                secretRef:
+                                fieldRef:
                                   properties:
-                                    name:
+                                    apiVersion:
                                       type: string
-                                  type: object
-                                volumeID:
-                                  type: string
-                              required:
-                              - volumeID
-                              type: object
-                            configMap:
-                              properties:
-                                defaultMode:
-                                  format: int32
-                                  type: integer
-                                items:
-                                  items:
-                                    properties:
-                                      key:
-                                        type: string
-                                      mode:
-                                        format: int32
-                                        type: integer
-                                      path:
-                                        type: string
-                                    required:
-                                    - key
-                                    - path
-                                    type: object
-                                  type: array
-                                name:
-                                  type: string
-                                optional:
-                                  type: boolean
-                              type: object
-                            csi:
-                              properties:
-                                driver:
-                                  type: string
-                                fsType:
-                                  type: string
-                                nodePublishSecretRef:
-                                  properties:
-                                    name:
+                                    fieldPath:
                                       type: string
-                                  type: object
-                                readOnly:
-                                  type: boolean
-                                volumeAttributes:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                              required:
-                              - driver
-                              type: object
-                            downwardAPI:
-                              properties:
-                                defaultMode:
-                                  format: int32
-                                  type: integer
-                                items:
-                                  items:
-                                    properties:
-                                      fieldRef:
-                                        properties:
-                                          apiVersion:
-                                            type: string
-                                          fieldPath:
-                                            type: string
-                                        required:
-                                        - fieldPath
-                                        type: object
-                                      mode:
-                                        format: int32
-                                        type: integer
-                                      path:
-                                        type: string
-                                      resourceFieldRef:
-                                        properties:
-                                          containerName:
-                                            type: string
-                                          divisor:
-                                            anyOf:
-                                            - type: integer
-                                            - type: string
-                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                            x-kubernetes-int-or-string: true
-                                          resource:
-                                            type: string
-                                        required:
-                                        - resource
-                                        type: object
-                                    required:
-                                    - path
-                                    type: object
-                                  type: array
-                              type: object
-                            emptyDir:
-                              properties:
-                                medium:
-                                  type: string
-                                sizeLimit:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                              type: object
-                            ephemeral:
-                              properties:
-                                readOnly:
-                                  type: boolean
-                                volumeClaimTemplate:
-                                  properties:
-                                    metadata:
-                                      type: object
-                                    spec:
-                                      properties:
-                                        accessModes:
-                                          items:
-                                            type: string
-                                          type: array
-                                        dataSource:
-                                          properties:
-                                            apiGroup:
-                                              type: string
-                                            kind:
-                                              type: string
-                                            name:
-                                              type: string
-                                          required:
-                                          - kind
-                                          - name
-                                          type: object
-                                        resources:
-                                          properties:
-                                            limits:
-                                              additionalProperties:
-                                                anyOf:
-                                                - type: integer
-                                                - type: string
-                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                x-kubernetes-int-or-string: true
-                                              type: object
-                                            requests:
-                                              additionalProperties:
-                                                anyOf:
-                                                - type: integer
-                                                - type: string
-                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                x-kubernetes-int-or-string: true
-                                              type: object
-                                          type: object
-                                        selector:
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                - key
-                                                - operator
-                                                type: object
-                                              type: array
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                          type: object
-                                        storageClassName:
-                                          type: string
-                                        volumeMode:
-                                          type: string
-                                        volumeName:
-                                          type: string
-                                      type: object
                                   required:
-                                  - spec
+                                  - fieldPath
                                   type: object
-                              type: object
-                            fc:
-                              properties:
-                                fsType:
-                                  type: string
-                                lun:
+                                mode:
                                   format: int32
                                   type: integer
-                                readOnly:
-                                  type: boolean
-                                targetWWNs:
-                                  items:
-                                    type: string
-                                  type: array
-                                wwids:
-                                  items:
-                                    type: string
-                                  type: array
-                              type: object
-                            flexVolume:
-                              properties:
-                                driver:
+                                path:
                                   type: string
-                                fsType:
-                                  type: string
-                                options:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                                readOnly:
-                                  type: boolean
-                                secretRef:
+                                resourceFieldRef:
                                   properties:
-                                    name:
+                                    containerName:
                                       type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      type: string
+                                  required:
+                                  - resource
                                   type: object
-                              required:
-                              - driver
-                              type: object
-                            flocker:
-                              properties:
-                                datasetName:
-                                  type: string
-                                datasetUUID:
-                                  type: string
-                              type: object
-                            gcePersistentDisk:
-                              properties:
-                                fsType:
-                                  type: string
-                                partition:
-                                  format: int32
-                                  type: integer
-                                pdName:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                              required:
-                              - pdName
-                              type: object
-                            gitRepo:
-                              properties:
-                                directory:
-                                  type: string
-                                repository:
-                                  type: string
-                                revision:
-                                  type: string
-                              required:
-                              - repository
-                              type: object
-                            glusterfs:
-                              properties:
-                                endpoints:
-                                  type: string
-                                path:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                              required:
-                              - endpoints
-                              - path
-                              type: object
-                            hostPath:
-                              properties:
-                                path:
-                                  type: string
-                                type:
-                                  type: string
                               required:
                               - path
                               type: object
-                            iscsi:
-                              properties:
-                                chapAuthDiscovery:
-                                  type: boolean
-                                chapAuthSession:
-                                  type: boolean
-                                fsType:
-                                  type: string
-                                initiatorName:
-                                  type: string
-                                iqn:
-                                  type: string
-                                iscsiInterface:
-                                  type: string
-                                lun:
-                                  format: int32
-                                  type: integer
-                                portals:
-                                  items:
-                                    type: string
-                                  type: array
-                                readOnly:
-                                  type: boolean
-                                secretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                                targetPortal:
-                                  type: string
-                              required:
-                              - iqn
-                              - lun
-                              - targetPortal
-                              type: object
-                            name:
-                              type: string
-                            nfs:
-                              properties:
-                                path:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                server:
-                                  type: string
-                              required:
-                              - path
-                              - server
-                              type: object
-                            persistentVolumeClaim:
-                              properties:
-                                claimName:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                              required:
-                              - claimName
-                              type: object
-                            photonPersistentDisk:
-                              properties:
-                                fsType:
-                                  type: string
-                                pdID:
-                                  type: string
-                              required:
-                              - pdID
-                              type: object
-                            portworxVolume:
-                              properties:
-                                fsType:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                volumeID:
-                                  type: string
-                              required:
-                              - volumeID
-                              type: object
-                            projected:
-                              properties:
-                                defaultMode:
-                                  format: int32
-                                  type: integer
-                                sources:
-                                  items:
-                                    properties:
-                                      configMap:
-                                        properties:
-                                          items:
-                                            items:
-                                              properties:
-                                                key:
-                                                  type: string
-                                                mode:
-                                                  format: int32
-                                                  type: integer
-                                                path:
-                                                  type: string
-                                              required:
-                                              - key
-                                              - path
-                                              type: object
-                                            type: array
-                                          name:
-                                            type: string
-                                          optional:
-                                            type: boolean
-                                        type: object
-                                      downwardAPI:
-                                        properties:
-                                          items:
-                                            items:
-                                              properties:
-                                                fieldRef:
-                                                  properties:
-                                                    apiVersion:
-                                                      type: string
-                                                    fieldPath:
-                                                      type: string
-                                                  required:
-                                                  - fieldPath
-                                                  type: object
-                                                mode:
-                                                  format: int32
-                                                  type: integer
-                                                path:
-                                                  type: string
-                                                resourceFieldRef:
-                                                  properties:
-                                                    containerName:
-                                                      type: string
-                                                    divisor:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                      x-kubernetes-int-or-string: true
-                                                    resource:
-                                                      type: string
-                                                  required:
-                                                  - resource
-                                                  type: object
-                                              required:
-                                              - path
-                                              type: object
-                                            type: array
-                                        type: object
-                                      secret:
-                                        properties:
-                                          items:
-                                            items:
-                                              properties:
-                                                key:
-                                                  type: string
-                                                mode:
-                                                  format: int32
-                                                  type: integer
-                                                path:
-                                                  type: string
-                                              required:
-                                              - key
-                                              - path
-                                              type: object
-                                            type: array
-                                          name:
-                                            type: string
-                                          optional:
-                                            type: boolean
-                                        type: object
-                                      serviceAccountToken:
-                                        properties:
-                                          audience:
-                                            type: string
-                                          expirationSeconds:
-                                            format: int64
-                                            type: integer
-                                          path:
-                                            type: string
-                                        required:
-                                        - path
-                                        type: object
-                                    type: object
-                                  type: array
-                              type: object
-                            quobyte:
-                              properties:
-                                group:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                registry:
-                                  type: string
-                                tenant:
-                                  type: string
-                                user:
-                                  type: string
-                                volume:
-                                  type: string
-                              required:
-                              - registry
-                              - volume
-                              type: object
-                            rbd:
-                              properties:
-                                fsType:
-                                  type: string
-                                image:
-                                  type: string
-                                keyring:
-                                  type: string
-                                monitors:
-                                  items:
-                                    type: string
-                                  type: array
-                                pool:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                secretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                                user:
-                                  type: string
-                              required:
-                              - image
-                              - monitors
-                              type: object
-                            scaleIO:
-                              properties:
-                                fsType:
-                                  type: string
-                                gateway:
-                                  type: string
-                                protectionDomain:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                secretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                                sslEnabled:
-                                  type: boolean
-                                storageMode:
-                                  type: string
-                                storagePool:
-                                  type: string
-                                system:
-                                  type: string
-                                volumeName:
-                                  type: string
-                              required:
-                              - gateway
-                              - secretRef
-                              - system
-                              type: object
-                            secret:
-                              properties:
-                                defaultMode:
-                                  format: int32
-                                  type: integer
-                                items:
-                                  items:
-                                    properties:
-                                      key:
-                                        type: string
-                                      mode:
-                                        format: int32
-                                        type: integer
-                                      path:
-                                        type: string
-                                    required:
-                                    - key
-                                    - path
-                                    type: object
-                                  type: array
-                                optional:
-                                  type: boolean
-                                secretName:
-                                  type: string
-                              type: object
-                            storageos:
-                              properties:
-                                fsType:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                secretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                                volumeName:
-                                  type: string
-                                volumeNamespace:
-                                  type: string
-                              type: object
-                            vsphereVolume:
-                              properties:
-                                fsType:
-                                  type: string
-                                storagePolicyID:
-                                  type: string
-                                storagePolicyName:
-                                  type: string
-                                volumePath:
-                                  type: string
-                              required:
-                              - volumePath
-                              type: object
-                          required:
-                          - name
-                          type: object
-                        type: array
-                        x-kubernetes-list-type: atomic
-                    type: object
-                  elasticsearch:
-                    properties:
-                      image:
-                        type: string
-                      nodeCount:
-                        format: int32
-                        type: integer
-                      nodeSelector:
-                        additionalProperties:
-                          type: string
+                            type: array
                         type: object
-                      redundancyPolicy:
-                        type: string
-                      resources:
+                      emptyDir:
                         properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            type: object
-                        type: object
-                      storage:
-                        properties:
-                          size:
+                          medium:
+                            type: string
+                          sizeLimit:
                             anyOf:
                             - type: integer
                             - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          storageClassName:
-                            type: string
                         type: object
-                      tolerations:
-                        items:
-                          properties:
-                            effect:
-                              type: string
-                            key:
-                              type: string
-                            operator:
-                              type: string
-                            tolerationSeconds:
-                              format: int64
-                              type: integer
-                            value:
-                              type: string
-                          type: object
-                        type: array
-                        x-kubernetes-list-type: atomic
-                    type: object
-                  esIndexCleaner:
-                    properties:
-                      affinity:
+                      ephemeral:
                         properties:
-                          nodeAffinity:
-                            properties:
-                              preferredDuringSchedulingIgnoredDuringExecution:
-                                items:
-                                  properties:
-                                    preference:
-                                      properties:
-                                        matchExpressions:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchFields:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                      type: object
-                                    weight:
-                                      format: int32
-                                      type: integer
-                                  required:
-                                  - preference
-                                  - weight
-                                  type: object
-                                type: array
-                              requiredDuringSchedulingIgnoredDuringExecution:
-                                properties:
-                                  nodeSelectorTerms:
-                                    items:
-                                      properties:
-                                        matchExpressions:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchFields:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                      type: object
-                                    type: array
-                                required:
-                                - nodeSelectorTerms
-                                type: object
-                            type: object
-                          podAffinity:
-                            properties:
-                              preferredDuringSchedulingIgnoredDuringExecution:
-                                items:
-                                  properties:
-                                    podAffinityTerm:
-                                      properties:
-                                        labelSelector:
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                - key
-                                                - operator
-                                                type: object
-                                              type: array
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                          type: object
-                                        namespaces:
-                                          items:
-                                            type: string
-                                          type: array
-                                        topologyKey:
-                                          type: string
-                                      required:
-                                      - topologyKey
-                                      type: object
-                                    weight:
-                                      format: int32
-                                      type: integer
-                                  required:
-                                  - podAffinityTerm
-                                  - weight
-                                  type: object
-                                type: array
-                              requiredDuringSchedulingIgnoredDuringExecution:
-                                items:
-                                  properties:
-                                    labelSelector:
-                                      properties:
-                                        matchExpressions:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchLabels:
-                                          additionalProperties:
-                                            type: string
-                                          type: object
-                                      type: object
-                                    namespaces:
-                                      items:
-                                        type: string
-                                      type: array
-                                    topologyKey:
-                                      type: string
-                                  required:
-                                  - topologyKey
-                                  type: object
-                                type: array
-                            type: object
-                          podAntiAffinity:
-                            properties:
-                              preferredDuringSchedulingIgnoredDuringExecution:
-                                items:
-                                  properties:
-                                    podAffinityTerm:
-                                      properties:
-                                        labelSelector:
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                - key
-                                                - operator
-                                                type: object
-                                              type: array
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                          type: object
-                                        namespaces:
-                                          items:
-                                            type: string
-                                          type: array
-                                        topologyKey:
-                                          type: string
-                                      required:
-                                      - topologyKey
-                                      type: object
-                                    weight:
-                                      format: int32
-                                      type: integer
-                                  required:
-                                  - podAffinityTerm
-                                  - weight
-                                  type: object
-                                type: array
-                              requiredDuringSchedulingIgnoredDuringExecution:
-                                items:
-                                  properties:
-                                    labelSelector:
-                                      properties:
-                                        matchExpressions:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchLabels:
-                                          additionalProperties:
-                                            type: string
-                                          type: object
-                                      type: object
-                                    namespaces:
-                                      items:
-                                        type: string
-                                      type: array
-                                    topologyKey:
-                                      type: string
-                                  required:
-                                  - topologyKey
-                                  type: object
-                                type: array
-                            type: object
-                        type: object
-                      annotations:
-                        additionalProperties:
-                          type: string
-                        nullable: true
-                        type: object
-                      enabled:
-                        type: boolean
-                      image:
-                        type: string
-                      labels:
-                        additionalProperties:
-                          type: string
-                        type: object
-                      numberOfDays:
-                        type: integer
-                      resources:
-                        nullable: true
-                        properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            type: object
-                        type: object
-                      schedule:
-                        type: string
-                      securityContext:
-                        properties:
-                          fsGroup:
-                            format: int64
-                            type: integer
-                          fsGroupChangePolicy:
-                            type: string
-                          runAsGroup:
-                            format: int64
-                            type: integer
-                          runAsNonRoot:
+                          readOnly:
                             type: boolean
-                          runAsUser:
-                            format: int64
-                            type: integer
-                          seLinuxOptions:
+                          volumeClaimTemplate:
                             properties:
-                              level:
-                                type: string
-                              role:
-                                type: string
-                              type:
-                                type: string
-                              user:
-                                type: string
-                            type: object
-                          seccompProfile:
-                            properties:
-                              localhostProfile:
-                                type: string
-                              type:
-                                type: string
-                            required:
-                            - type
-                            type: object
-                          supplementalGroups:
-                            items:
-                              format: int64
-                              type: integer
-                            type: array
-                          sysctls:
-                            items:
-                              properties:
-                                name:
-                                  type: string
-                                value:
-                                  type: string
-                              required:
-                              - name
-                              - value
-                              type: object
-                            type: array
-                          windowsOptions:
-                            properties:
-                              gmsaCredentialSpec:
-                                type: string
-                              gmsaCredentialSpecName:
-                                type: string
-                              runAsUserName:
-                                type: string
-                            type: object
-                        type: object
-                      serviceAccount:
-                        type: string
-                      successfulJobsHistoryLimit:
-                        format: int32
-                        type: integer
-                      tolerations:
-                        items:
-                          properties:
-                            effect:
-                              type: string
-                            key:
-                              type: string
-                            operator:
-                              type: string
-                            tolerationSeconds:
-                              format: int64
-                              type: integer
-                            value:
-                              type: string
-                          type: object
-                        type: array
-                        x-kubernetes-list-type: atomic
-                      ttlSecondsAfterFinished:
-                        format: int32
-                        type: integer
-                      volumeMounts:
-                        items:
-                          properties:
-                            mountPath:
-                              type: string
-                            mountPropagation:
-                              type: string
-                            name:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            subPath:
-                              type: string
-                            subPathExpr:
-                              type: string
-                          required:
-                          - mountPath
-                          - name
-                          type: object
-                        type: array
-                        x-kubernetes-list-type: atomic
-                      volumes:
-                        items:
-                          properties:
-                            awsElasticBlockStore:
-                              properties:
-                                fsType:
-                                  type: string
-                                partition:
-                                  format: int32
-                                  type: integer
-                                readOnly:
-                                  type: boolean
-                                volumeID:
-                                  type: string
-                              required:
-                              - volumeID
-                              type: object
-                            azureDisk:
-                              properties:
-                                cachingMode:
-                                  type: string
-                                diskName:
-                                  type: string
-                                diskURI:
-                                  type: string
-                                fsType:
-                                  type: string
-                                kind:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                              required:
-                              - diskName
-                              - diskURI
-                              type: object
-                            azureFile:
-                              properties:
-                                readOnly:
-                                  type: boolean
-                                secretName:
-                                  type: string
-                                shareName:
-                                  type: string
-                              required:
-                              - secretName
-                              - shareName
-                              type: object
-                            cephfs:
-                              properties:
-                                monitors:
-                                  items:
-                                    type: string
-                                  type: array
-                                path:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                secretFile:
-                                  type: string
-                                secretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                                user:
-                                  type: string
-                              required:
-                              - monitors
-                              type: object
-                            cinder:
-                              properties:
-                                fsType:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                secretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                                volumeID:
-                                  type: string
-                              required:
-                              - volumeID
-                              type: object
-                            configMap:
-                              properties:
-                                defaultMode:
-                                  format: int32
-                                  type: integer
-                                items:
-                                  items:
-                                    properties:
-                                      key:
-                                        type: string
-                                      mode:
-                                        format: int32
-                                        type: integer
-                                      path:
-                                        type: string
-                                    required:
-                                    - key
-                                    - path
-                                    type: object
-                                  type: array
-                                name:
-                                  type: string
-                                optional:
-                                  type: boolean
-                              type: object
-                            csi:
-                              properties:
-                                driver:
-                                  type: string
-                                fsType:
-                                  type: string
-                                nodePublishSecretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                                readOnly:
-                                  type: boolean
-                                volumeAttributes:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                              required:
-                              - driver
-                              type: object
-                            downwardAPI:
-                              properties:
-                                defaultMode:
-                                  format: int32
-                                  type: integer
-                                items:
-                                  items:
-                                    properties:
-                                      fieldRef:
-                                        properties:
-                                          apiVersion:
-                                            type: string
-                                          fieldPath:
-                                            type: string
-                                        required:
-                                        - fieldPath
-                                        type: object
-                                      mode:
-                                        format: int32
-                                        type: integer
-                                      path:
-                                        type: string
-                                      resourceFieldRef:
-                                        properties:
-                                          containerName:
-                                            type: string
-                                          divisor:
-                                            anyOf:
-                                            - type: integer
-                                            - type: string
-                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                            x-kubernetes-int-or-string: true
-                                          resource:
-                                            type: string
-                                        required:
-                                        - resource
-                                        type: object
-                                    required:
-                                    - path
-                                    type: object
-                                  type: array
-                              type: object
-                            emptyDir:
-                              properties:
-                                medium:
-                                  type: string
-                                sizeLimit:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                              type: object
-                            ephemeral:
-                              properties:
-                                readOnly:
-                                  type: boolean
-                                volumeClaimTemplate:
-                                  properties:
-                                    metadata:
-                                      type: object
-                                    spec:
-                                      properties:
-                                        accessModes:
-                                          items:
-                                            type: string
-                                          type: array
-                                        dataSource:
-                                          properties:
-                                            apiGroup:
-                                              type: string
-                                            kind:
-                                              type: string
-                                            name:
-                                              type: string
-                                          required:
-                                          - kind
-                                          - name
-                                          type: object
-                                        resources:
-                                          properties:
-                                            limits:
-                                              additionalProperties:
-                                                anyOf:
-                                                - type: integer
-                                                - type: string
-                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                x-kubernetes-int-or-string: true
-                                              type: object
-                                            requests:
-                                              additionalProperties:
-                                                anyOf:
-                                                - type: integer
-                                                - type: string
-                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                x-kubernetes-int-or-string: true
-                                              type: object
-                                          type: object
-                                        selector:
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                - key
-                                                - operator
-                                                type: object
-                                              type: array
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                          type: object
-                                        storageClassName:
-                                          type: string
-                                        volumeMode:
-                                          type: string
-                                        volumeName:
-                                          type: string
-                                      type: object
-                                  required:
-                                  - spec
-                                  type: object
-                              type: object
-                            fc:
-                              properties:
-                                fsType:
-                                  type: string
-                                lun:
-                                  format: int32
-                                  type: integer
-                                readOnly:
-                                  type: boolean
-                                targetWWNs:
-                                  items:
-                                    type: string
-                                  type: array
-                                wwids:
-                                  items:
-                                    type: string
-                                  type: array
-                              type: object
-                            flexVolume:
-                              properties:
-                                driver:
-                                  type: string
-                                fsType:
-                                  type: string
-                                options:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                                readOnly:
-                                  type: boolean
-                                secretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                              required:
-                              - driver
-                              type: object
-                            flocker:
-                              properties:
-                                datasetName:
-                                  type: string
-                                datasetUUID:
-                                  type: string
-                              type: object
-                            gcePersistentDisk:
-                              properties:
-                                fsType:
-                                  type: string
-                                partition:
-                                  format: int32
-                                  type: integer
-                                pdName:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                              required:
-                              - pdName
-                              type: object
-                            gitRepo:
-                              properties:
-                                directory:
-                                  type: string
-                                repository:
-                                  type: string
-                                revision:
-                                  type: string
-                              required:
-                              - repository
-                              type: object
-                            glusterfs:
-                              properties:
-                                endpoints:
-                                  type: string
-                                path:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                              required:
-                              - endpoints
-                              - path
-                              type: object
-                            hostPath:
-                              properties:
-                                path:
-                                  type: string
-                                type:
-                                  type: string
-                              required:
-                              - path
-                              type: object
-                            iscsi:
-                              properties:
-                                chapAuthDiscovery:
-                                  type: boolean
-                                chapAuthSession:
-                                  type: boolean
-                                fsType:
-                                  type: string
-                                initiatorName:
-                                  type: string
-                                iqn:
-                                  type: string
-                                iscsiInterface:
-                                  type: string
-                                lun:
-                                  format: int32
-                                  type: integer
-                                portals:
-                                  items:
-                                    type: string
-                                  type: array
-                                readOnly:
-                                  type: boolean
-                                secretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                                targetPortal:
-                                  type: string
-                              required:
-                              - iqn
-                              - lun
-                              - targetPortal
-                              type: object
-                            name:
-                              type: string
-                            nfs:
-                              properties:
-                                path:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                server:
-                                  type: string
-                              required:
-                              - path
-                              - server
-                              type: object
-                            persistentVolumeClaim:
-                              properties:
-                                claimName:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                              required:
-                              - claimName
-                              type: object
-                            photonPersistentDisk:
-                              properties:
-                                fsType:
-                                  type: string
-                                pdID:
-                                  type: string
-                              required:
-                              - pdID
-                              type: object
-                            portworxVolume:
-                              properties:
-                                fsType:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                volumeID:
-                                  type: string
-                              required:
-                              - volumeID
-                              type: object
-                            projected:
-                              properties:
-                                defaultMode:
-                                  format: int32
-                                  type: integer
-                                sources:
-                                  items:
-                                    properties:
-                                      configMap:
-                                        properties:
-                                          items:
-                                            items:
-                                              properties:
-                                                key:
-                                                  type: string
-                                                mode:
-                                                  format: int32
-                                                  type: integer
-                                                path:
-                                                  type: string
-                                              required:
-                                              - key
-                                              - path
-                                              type: object
-                                            type: array
-                                          name:
-                                            type: string
-                                          optional:
-                                            type: boolean
-                                        type: object
-                                      downwardAPI:
-                                        properties:
-                                          items:
-                                            items:
-                                              properties:
-                                                fieldRef:
-                                                  properties:
-                                                    apiVersion:
-                                                      type: string
-                                                    fieldPath:
-                                                      type: string
-                                                  required:
-                                                  - fieldPath
-                                                  type: object
-                                                mode:
-                                                  format: int32
-                                                  type: integer
-                                                path:
-                                                  type: string
-                                                resourceFieldRef:
-                                                  properties:
-                                                    containerName:
-                                                      type: string
-                                                    divisor:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                      x-kubernetes-int-or-string: true
-                                                    resource:
-                                                      type: string
-                                                  required:
-                                                  - resource
-                                                  type: object
-                                              required:
-                                              - path
-                                              type: object
-                                            type: array
-                                        type: object
-                                      secret:
-                                        properties:
-                                          items:
-                                            items:
-                                              properties:
-                                                key:
-                                                  type: string
-                                                mode:
-                                                  format: int32
-                                                  type: integer
-                                                path:
-                                                  type: string
-                                              required:
-                                              - key
-                                              - path
-                                              type: object
-                                            type: array
-                                          name:
-                                            type: string
-                                          optional:
-                                            type: boolean
-                                        type: object
-                                      serviceAccountToken:
-                                        properties:
-                                          audience:
-                                            type: string
-                                          expirationSeconds:
-                                            format: int64
-                                            type: integer
-                                          path:
-                                            type: string
-                                        required:
-                                        - path
-                                        type: object
-                                    type: object
-                                  type: array
-                              type: object
-                            quobyte:
-                              properties:
-                                group:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                registry:
-                                  type: string
-                                tenant:
-                                  type: string
-                                user:
-                                  type: string
-                                volume:
-                                  type: string
-                              required:
-                              - registry
-                              - volume
-                              type: object
-                            rbd:
-                              properties:
-                                fsType:
-                                  type: string
-                                image:
-                                  type: string
-                                keyring:
-                                  type: string
-                                monitors:
-                                  items:
-                                    type: string
-                                  type: array
-                                pool:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                secretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                                user:
-                                  type: string
-                              required:
-                              - image
-                              - monitors
-                              type: object
-                            scaleIO:
-                              properties:
-                                fsType:
-                                  type: string
-                                gateway:
-                                  type: string
-                                protectionDomain:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                secretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                                sslEnabled:
-                                  type: boolean
-                                storageMode:
-                                  type: string
-                                storagePool:
-                                  type: string
-                                system:
-                                  type: string
-                                volumeName:
-                                  type: string
-                              required:
-                              - gateway
-                              - secretRef
-                              - system
-                              type: object
-                            secret:
-                              properties:
-                                defaultMode:
-                                  format: int32
-                                  type: integer
-                                items:
-                                  items:
-                                    properties:
-                                      key:
-                                        type: string
-                                      mode:
-                                        format: int32
-                                        type: integer
-                                      path:
-                                        type: string
-                                    required:
-                                    - key
-                                    - path
-                                    type: object
-                                  type: array
-                                optional:
-                                  type: boolean
-                                secretName:
-                                  type: string
-                              type: object
-                            storageos:
-                              properties:
-                                fsType:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                secretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                                volumeName:
-                                  type: string
-                                volumeNamespace:
-                                  type: string
-                              type: object
-                            vsphereVolume:
-                              properties:
-                                fsType:
-                                  type: string
-                                storagePolicyID:
-                                  type: string
-                                storagePolicyName:
-                                  type: string
-                                volumePath:
-                                  type: string
-                              required:
-                              - volumePath
-                              type: object
-                          required:
-                          - name
-                          type: object
-                        type: array
-                        x-kubernetes-list-type: atomic
-                    type: object
-                  esRollover:
-                    properties:
-                      affinity:
-                        properties:
-                          nodeAffinity:
-                            properties:
-                              preferredDuringSchedulingIgnoredDuringExecution:
-                                items:
-                                  properties:
-                                    preference:
-                                      properties:
-                                        matchExpressions:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchFields:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                      type: object
-                                    weight:
-                                      format: int32
-                                      type: integer
-                                  required:
-                                  - preference
-                                  - weight
-                                  type: object
-                                type: array
-                              requiredDuringSchedulingIgnoredDuringExecution:
+                              metadata:
+                                type: object
+                              spec:
                                 properties:
-                                  nodeSelectorTerms:
+                                  accessModes:
                                     items:
-                                      properties:
-                                        matchExpressions:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchFields:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                      type: object
+                                      type: string
                                     type: array
-                                required:
-                                - nodeSelectorTerms
-                                type: object
-                            type: object
-                          podAffinity:
-                            properties:
-                              preferredDuringSchedulingIgnoredDuringExecution:
-                                items:
-                                  properties:
-                                    podAffinityTerm:
-                                      properties:
-                                        labelSelector:
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                - key
-                                                - operator
-                                                type: object
-                                              type: array
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                          type: object
-                                        namespaces:
-                                          items:
-                                            type: string
-                                          type: array
-                                        topologyKey:
-                                          type: string
-                                      required:
-                                      - topologyKey
-                                      type: object
-                                    weight:
-                                      format: int32
-                                      type: integer
-                                  required:
-                                  - podAffinityTerm
-                                  - weight
-                                  type: object
-                                type: array
-                              requiredDuringSchedulingIgnoredDuringExecution:
-                                items:
-                                  properties:
-                                    labelSelector:
-                                      properties:
-                                        matchExpressions:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchLabels:
-                                          additionalProperties:
-                                            type: string
-                                          type: object
-                                      type: object
-                                    namespaces:
-                                      items:
-                                        type: string
-                                      type: array
-                                    topologyKey:
-                                      type: string
-                                  required:
-                                  - topologyKey
-                                  type: object
-                                type: array
-                            type: object
-                          podAntiAffinity:
-                            properties:
-                              preferredDuringSchedulingIgnoredDuringExecution:
-                                items:
-                                  properties:
-                                    podAffinityTerm:
-                                      properties:
-                                        labelSelector:
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                - key
-                                                - operator
-                                                type: object
-                                              type: array
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                          type: object
-                                        namespaces:
-                                          items:
-                                            type: string
-                                          type: array
-                                        topologyKey:
-                                          type: string
-                                      required:
-                                      - topologyKey
-                                      type: object
-                                    weight:
-                                      format: int32
-                                      type: integer
-                                  required:
-                                  - podAffinityTerm
-                                  - weight
-                                  type: object
-                                type: array
-                              requiredDuringSchedulingIgnoredDuringExecution:
-                                items:
-                                  properties:
-                                    labelSelector:
-                                      properties:
-                                        matchExpressions:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchLabels:
-                                          additionalProperties:
-                                            type: string
-                                          type: object
-                                      type: object
-                                    namespaces:
-                                      items:
-                                        type: string
-                                      type: array
-                                    topologyKey:
-                                      type: string
-                                  required:
-                                  - topologyKey
-                                  type: object
-                                type: array
-                            type: object
-                        type: object
-                      annotations:
-                        additionalProperties:
-                          type: string
-                        nullable: true
-                        type: object
-                      conditions:
-                        type: string
-                      image:
-                        type: string
-                      labels:
-                        additionalProperties:
-                          type: string
-                        type: object
-                      readTTL:
-                        type: string
-                      resources:
-                        nullable: true
-                        properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            type: object
-                        type: object
-                      schedule:
-                        type: string
-                      securityContext:
-                        properties:
-                          fsGroup:
-                            format: int64
-                            type: integer
-                          fsGroupChangePolicy:
-                            type: string
-                          runAsGroup:
-                            format: int64
-                            type: integer
-                          runAsNonRoot:
-                            type: boolean
-                          runAsUser:
-                            format: int64
-                            type: integer
-                          seLinuxOptions:
-                            properties:
-                              level:
-                                type: string
-                              role:
-                                type: string
-                              type:
-                                type: string
-                              user:
-                                type: string
-                            type: object
-                          seccompProfile:
-                            properties:
-                              localhostProfile:
-                                type: string
-                              type:
-                                type: string
-                            required:
-                            - type
-                            type: object
-                          supplementalGroups:
-                            items:
-                              format: int64
-                              type: integer
-                            type: array
-                          sysctls:
-                            items:
-                              properties:
-                                name:
-                                  type: string
-                                value:
-                                  type: string
-                              required:
-                              - name
-                              - value
-                              type: object
-                            type: array
-                          windowsOptions:
-                            properties:
-                              gmsaCredentialSpec:
-                                type: string
-                              gmsaCredentialSpecName:
-                                type: string
-                              runAsUserName:
-                                type: string
-                            type: object
-                        type: object
-                      serviceAccount:
-                        type: string
-                      successfulJobsHistoryLimit:
-                        format: int32
-                        type: integer
-                      tolerations:
-                        items:
-                          properties:
-                            effect:
-                              type: string
-                            key:
-                              type: string
-                            operator:
-                              type: string
-                            tolerationSeconds:
-                              format: int64
-                              type: integer
-                            value:
-                              type: string
-                          type: object
-                        type: array
-                        x-kubernetes-list-type: atomic
-                      ttlSecondsAfterFinished:
-                        format: int32
-                        type: integer
-                      volumeMounts:
-                        items:
-                          properties:
-                            mountPath:
-                              type: string
-                            mountPropagation:
-                              type: string
-                            name:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            subPath:
-                              type: string
-                            subPathExpr:
-                              type: string
-                          required:
-                          - mountPath
-                          - name
-                          type: object
-                        type: array
-                        x-kubernetes-list-type: atomic
-                      volumes:
-                        items:
-                          properties:
-                            awsElasticBlockStore:
-                              properties:
-                                fsType:
-                                  type: string
-                                partition:
-                                  format: int32
-                                  type: integer
-                                readOnly:
-                                  type: boolean
-                                volumeID:
-                                  type: string
-                              required:
-                              - volumeID
-                              type: object
-                            azureDisk:
-                              properties:
-                                cachingMode:
-                                  type: string
-                                diskName:
-                                  type: string
-                                diskURI:
-                                  type: string
-                                fsType:
-                                  type: string
-                                kind:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                              required:
-                              - diskName
-                              - diskURI
-                              type: object
-                            azureFile:
-                              properties:
-                                readOnly:
-                                  type: boolean
-                                secretName:
-                                  type: string
-                                shareName:
-                                  type: string
-                              required:
-                              - secretName
-                              - shareName
-                              type: object
-                            cephfs:
-                              properties:
-                                monitors:
-                                  items:
-                                    type: string
-                                  type: array
-                                path:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                secretFile:
-                                  type: string
-                                secretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                                user:
-                                  type: string
-                              required:
-                              - monitors
-                              type: object
-                            cinder:
-                              properties:
-                                fsType:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                secretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                                volumeID:
-                                  type: string
-                              required:
-                              - volumeID
-                              type: object
-                            configMap:
-                              properties:
-                                defaultMode:
-                                  format: int32
-                                  type: integer
-                                items:
-                                  items:
+                                  dataSource:
                                     properties:
-                                      key:
+                                      apiGroup:
                                         type: string
-                                      mode:
-                                        format: int32
-                                        type: integer
-                                      path:
+                                      kind:
+                                        type: string
+                                      name:
                                         type: string
                                     required:
-                                    - key
-                                    - path
+                                    - kind
+                                    - name
                                     type: object
-                                  type: array
-                                name:
-                                  type: string
-                                optional:
-                                  type: boolean
-                              type: object
-                            csi:
-                              properties:
-                                driver:
-                                  type: string
-                                fsType:
-                                  type: string
-                                nodePublishSecretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                                readOnly:
-                                  type: boolean
-                                volumeAttributes:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                              required:
-                              - driver
-                              type: object
-                            downwardAPI:
-                              properties:
-                                defaultMode:
-                                  format: int32
-                                  type: integer
-                                items:
-                                  items:
+                                  resources:
                                     properties:
-                                      fieldRef:
-                                        properties:
-                                          apiVersion:
-                                            type: string
-                                          fieldPath:
-                                            type: string
-                                        required:
-                                        - fieldPath
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
                                         type: object
-                                      mode:
-                                        format: int32
-                                        type: integer
-                                      path:
-                                        type: string
-                                      resourceFieldRef:
-                                        properties:
-                                          containerName:
-                                            type: string
-                                          divisor:
-                                            anyOf:
-                                            - type: integer
-                                            - type: string
-                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                            x-kubernetes-int-or-string: true
-                                          resource:
-                                            type: string
-                                        required:
-                                        - resource
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
                                         type: object
-                                    required:
-                                    - path
                                     type: object
-                                  type: array
-                              type: object
-                            emptyDir:
-                              properties:
-                                medium:
-                                  type: string
-                                sizeLimit:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                              type: object
-                            ephemeral:
-                              properties:
-                                readOnly:
-                                  type: boolean
-                                volumeClaimTemplate:
-                                  properties:
-                                    metadata:
-                                      type: object
-                                    spec:
-                                      properties:
-                                        accessModes:
-                                          items:
-                                            type: string
-                                          type: array
-                                        dataSource:
+                                  selector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
                                           properties:
-                                            apiGroup:
+                                            key:
                                               type: string
-                                            kind:
+                                            operator:
                                               type: string
-                                            name:
-                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
                                           required:
-                                          - kind
-                                          - name
+                                          - key
+                                          - operator
                                           type: object
-                                        resources:
-                                          properties:
-                                            limits:
-                                              additionalProperties:
-                                                anyOf:
-                                                - type: integer
-                                                - type: string
-                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                x-kubernetes-int-or-string: true
-                                              type: object
-                                            requests:
-                                              additionalProperties:
-                                                anyOf:
-                                                - type: integer
-                                                - type: string
-                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                x-kubernetes-int-or-string: true
-                                              type: object
-                                          type: object
-                                        selector:
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                - key
-                                                - operator
-                                                type: object
-                                              type: array
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                          type: object
-                                        storageClassName:
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
                                           type: string
-                                        volumeMode:
-                                          type: string
-                                        volumeName:
-                                          type: string
-                                      type: object
-                                  required:
-                                  - spec
-                                  type: object
-                              type: object
-                            fc:
-                              properties:
-                                fsType:
-                                  type: string
-                                lun:
-                                  format: int32
-                                  type: integer
-                                readOnly:
-                                  type: boolean
-                                targetWWNs:
-                                  items:
-                                    type: string
-                                  type: array
-                                wwids:
-                                  items:
-                                    type: string
-                                  type: array
-                              type: object
-                            flexVolume:
-                              properties:
-                                driver:
-                                  type: string
-                                fsType:
-                                  type: string
-                                options:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                                readOnly:
-                                  type: boolean
-                                secretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                              required:
-                              - driver
-                              type: object
-                            flocker:
-                              properties:
-                                datasetName:
-                                  type: string
-                                datasetUUID:
-                                  type: string
-                              type: object
-                            gcePersistentDisk:
-                              properties:
-                                fsType:
-                                  type: string
-                                partition:
-                                  format: int32
-                                  type: integer
-                                pdName:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                              required:
-                              - pdName
-                              type: object
-                            gitRepo:
-                              properties:
-                                directory:
-                                  type: string
-                                repository:
-                                  type: string
-                                revision:
-                                  type: string
-                              required:
-                              - repository
-                              type: object
-                            glusterfs:
-                              properties:
-                                endpoints:
-                                  type: string
-                                path:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                              required:
-                              - endpoints
-                              - path
-                              type: object
-                            hostPath:
-                              properties:
-                                path:
-                                  type: string
-                                type:
-                                  type: string
-                              required:
-                              - path
-                              type: object
-                            iscsi:
-                              properties:
-                                chapAuthDiscovery:
-                                  type: boolean
-                                chapAuthSession:
-                                  type: boolean
-                                fsType:
-                                  type: string
-                                initiatorName:
-                                  type: string
-                                iqn:
-                                  type: string
-                                iscsiInterface:
-                                  type: string
-                                lun:
-                                  format: int32
-                                  type: integer
-                                portals:
-                                  items:
-                                    type: string
-                                  type: array
-                                readOnly:
-                                  type: boolean
-                                secretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                                targetPortal:
-                                  type: string
-                              required:
-                              - iqn
-                              - lun
-                              - targetPortal
-                              type: object
-                            name:
-                              type: string
-                            nfs:
-                              properties:
-                                path:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                server:
-                                  type: string
-                              required:
-                              - path
-                              - server
-                              type: object
-                            persistentVolumeClaim:
-                              properties:
-                                claimName:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                              required:
-                              - claimName
-                              type: object
-                            photonPersistentDisk:
-                              properties:
-                                fsType:
-                                  type: string
-                                pdID:
-                                  type: string
-                              required:
-                              - pdID
-                              type: object
-                            portworxVolume:
-                              properties:
-                                fsType:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                volumeID:
-                                  type: string
-                              required:
-                              - volumeID
-                              type: object
-                            projected:
-                              properties:
-                                defaultMode:
-                                  format: int32
-                                  type: integer
-                                sources:
-                                  items:
-                                    properties:
-                                      configMap:
-                                        properties:
-                                          items:
-                                            items:
-                                              properties:
-                                                key:
-                                                  type: string
-                                                mode:
-                                                  format: int32
-                                                  type: integer
-                                                path:
-                                                  type: string
-                                              required:
-                                              - key
-                                              - path
-                                              type: object
-                                            type: array
-                                          name:
-                                            type: string
-                                          optional:
-                                            type: boolean
-                                        type: object
-                                      downwardAPI:
-                                        properties:
-                                          items:
-                                            items:
-                                              properties:
-                                                fieldRef:
-                                                  properties:
-                                                    apiVersion:
-                                                      type: string
-                                                    fieldPath:
-                                                      type: string
-                                                  required:
-                                                  - fieldPath
-                                                  type: object
-                                                mode:
-                                                  format: int32
-                                                  type: integer
-                                                path:
-                                                  type: string
-                                                resourceFieldRef:
-                                                  properties:
-                                                    containerName:
-                                                      type: string
-                                                    divisor:
-                                                      anyOf:
-                                                      - type: integer
-                                                      - type: string
-                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                                      x-kubernetes-int-or-string: true
-                                                    resource:
-                                                      type: string
-                                                  required:
-                                                  - resource
-                                                  type: object
-                                              required:
-                                              - path
-                                              type: object
-                                            type: array
-                                        type: object
-                                      secret:
-                                        properties:
-                                          items:
-                                            items:
-                                              properties:
-                                                key:
-                                                  type: string
-                                                mode:
-                                                  format: int32
-                                                  type: integer
-                                                path:
-                                                  type: string
-                                              required:
-                                              - key
-                                              - path
-                                              type: object
-                                            type: array
-                                          name:
-                                            type: string
-                                          optional:
-                                            type: boolean
-                                        type: object
-                                      serviceAccountToken:
-                                        properties:
-                                          audience:
-                                            type: string
-                                          expirationSeconds:
-                                            format: int64
-                                            type: integer
-                                          path:
-                                            type: string
-                                        required:
-                                        - path
                                         type: object
                                     type: object
-                                  type: array
-                              type: object
-                            quobyte:
-                              properties:
-                                group:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                registry:
-                                  type: string
-                                tenant:
-                                  type: string
-                                user:
-                                  type: string
-                                volume:
-                                  type: string
-                              required:
-                              - registry
-                              - volume
-                              type: object
-                            rbd:
-                              properties:
-                                fsType:
-                                  type: string
-                                image:
-                                  type: string
-                                keyring:
-                                  type: string
-                                monitors:
-                                  items:
+                                  storageClassName:
                                     type: string
-                                  type: array
-                                pool:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                secretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                                user:
-                                  type: string
-                              required:
-                              - image
-                              - monitors
-                              type: object
-                            scaleIO:
-                              properties:
-                                fsType:
-                                  type: string
-                                gateway:
-                                  type: string
-                                protectionDomain:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                secretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                                sslEnabled:
-                                  type: boolean
-                                storageMode:
-                                  type: string
-                                storagePool:
-                                  type: string
-                                system:
-                                  type: string
-                                volumeName:
-                                  type: string
-                              required:
-                              - gateway
-                              - secretRef
-                              - system
-                              type: object
-                            secret:
-                              properties:
-                                defaultMode:
-                                  format: int32
-                                  type: integer
-                                items:
-                                  items:
-                                    properties:
-                                      key:
-                                        type: string
-                                      mode:
-                                        format: int32
-                                        type: integer
-                                      path:
-                                        type: string
-                                    required:
-                                    - key
-                                    - path
-                                    type: object
-                                  type: array
-                                optional:
-                                  type: boolean
-                                secretName:
-                                  type: string
-                              type: object
-                            storageos:
-                              properties:
-                                fsType:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                secretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                                volumeName:
-                                  type: string
-                                volumeNamespace:
-                                  type: string
-                              type: object
-                            vsphereVolume:
-                              properties:
-                                fsType:
-                                  type: string
-                                storagePolicyID:
-                                  type: string
-                                storagePolicyName:
-                                  type: string
-                                volumePath:
-                                  type: string
-                              required:
-                              - volumePath
-                              type: object
-                          required:
-                          - name
-                          type: object
-                        type: array
-                        x-kubernetes-list-type: atomic
-                    type: object
-                  options:
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                  secretName:
-                    type: string
-                  type:
-                    type: string
-                type: object
-              strategy:
-                type: string
-              tolerations:
-                items:
-                  properties:
-                    effect:
-                      type: string
-                    key:
-                      type: string
-                    operator:
-                      type: string
-                    tolerationSeconds:
-                      format: int64
-                      type: integer
-                    value:
-                      type: string
-                  type: object
-                type: array
-                x-kubernetes-list-type: atomic
-              ui:
-                properties:
-                  options:
-                    type: object
-                    x-kubernetes-preserve-unknown-fields: true
-                type: object
-              volumeMounts:
-                items:
-                  properties:
-                    mountPath:
-                      type: string
-                    mountPropagation:
-                      type: string
-                    name:
-                      type: string
-                    readOnly:
-                      type: boolean
-                    subPath:
-                      type: string
-                    subPathExpr:
-                      type: string
-                  required:
-                  - mountPath
-                  - name
-                  type: object
-                type: array
-                x-kubernetes-list-type: atomic
-              volumes:
-                items:
-                  properties:
-                    awsElasticBlockStore:
-                      properties:
-                        fsType:
-                          type: string
-                        partition:
-                          format: int32
-                          type: integer
-                        readOnly:
-                          type: boolean
-                        volumeID:
-                          type: string
-                      required:
-                      - volumeID
-                      type: object
-                    azureDisk:
-                      properties:
-                        cachingMode:
-                          type: string
-                        diskName:
-                          type: string
-                        diskURI:
-                          type: string
-                        fsType:
-                          type: string
-                        kind:
-                          type: string
-                        readOnly:
-                          type: boolean
-                      required:
-                      - diskName
-                      - diskURI
-                      type: object
-                    azureFile:
-                      properties:
-                        readOnly:
-                          type: boolean
-                        secretName:
-                          type: string
-                        shareName:
-                          type: string
-                      required:
-                      - secretName
-                      - shareName
-                      type: object
-                    cephfs:
-                      properties:
-                        monitors:
-                          items:
-                            type: string
-                          type: array
-                        path:
-                          type: string
-                        readOnly:
-                          type: boolean
-                        secretFile:
-                          type: string
-                        secretRef:
-                          properties:
-                            name:
-                              type: string
-                          type: object
-                        user:
-                          type: string
-                      required:
-                      - monitors
-                      type: object
-                    cinder:
-                      properties:
-                        fsType:
-                          type: string
-                        readOnly:
-                          type: boolean
-                        secretRef:
-                          properties:
-                            name:
-                              type: string
-                          type: object
-                        volumeID:
-                          type: string
-                      required:
-                      - volumeID
-                      type: object
-                    configMap:
-                      properties:
-                        defaultMode:
-                          format: int32
-                          type: integer
-                        items:
-                          items:
-                            properties:
-                              key:
-                                type: string
-                              mode:
-                                format: int32
-                                type: integer
-                              path:
-                                type: string
-                            required:
-                            - key
-                            - path
-                            type: object
-                          type: array
-                        name:
-                          type: string
-                        optional:
-                          type: boolean
-                      type: object
-                    csi:
-                      properties:
-                        driver:
-                          type: string
-                        fsType:
-                          type: string
-                        nodePublishSecretRef:
-                          properties:
-                            name:
-                              type: string
-                          type: object
-                        readOnly:
-                          type: boolean
-                        volumeAttributes:
-                          additionalProperties:
-                            type: string
-                          type: object
-                      required:
-                      - driver
-                      type: object
-                    downwardAPI:
-                      properties:
-                        defaultMode:
-                          format: int32
-                          type: integer
-                        items:
-                          items:
-                            properties:
-                              fieldRef:
-                                properties:
-                                  apiVersion:
+                                  volumeMode:
                                     type: string
-                                  fieldPath:
+                                  volumeName:
                                     type: string
-                                required:
-                                - fieldPath
-                                type: object
-                              mode:
-                                format: int32
-                                type: integer
-                              path:
-                                type: string
-                              resourceFieldRef:
-                                properties:
-                                  containerName:
-                                    type: string
-                                  divisor:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                    x-kubernetes-int-or-string: true
-                                  resource:
-                                    type: string
-                                required:
-                                - resource
                                 type: object
                             required:
-                            - path
+                            - spec
                             type: object
-                          type: array
-                      type: object
-                    emptyDir:
-                      properties:
-                        medium:
-                          type: string
-                        sizeLimit:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                      type: object
-                    ephemeral:
-                      properties:
-                        readOnly:
-                          type: boolean
-                        volumeClaimTemplate:
-                          properties:
-                            metadata:
-                              type: object
-                            spec:
+                        type: object
+                      fc:
+                        properties:
+                          fsType:
+                            type: string
+                          lun:
+                            format: int32
+                            type: integer
+                          readOnly:
+                            type: boolean
+                          targetWWNs:
+                            items:
+                              type: string
+                            type: array
+                          wwids:
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      flexVolume:
+                        properties:
+                          driver:
+                            type: string
+                          fsType:
+                            type: string
+                          options:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          readOnly:
+                            type: boolean
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                        required:
+                        - driver
+                        type: object
+                      flocker:
+                        properties:
+                          datasetName:
+                            type: string
+                          datasetUUID:
+                            type: string
+                        type: object
+                      gcePersistentDisk:
+                        properties:
+                          fsType:
+                            type: string
+                          partition:
+                            format: int32
+                            type: integer
+                          pdName:
+                            type: string
+                          readOnly:
+                            type: boolean
+                        required:
+                        - pdName
+                        type: object
+                      gitRepo:
+                        properties:
+                          directory:
+                            type: string
+                          repository:
+                            type: string
+                          revision:
+                            type: string
+                        required:
+                        - repository
+                        type: object
+                      glusterfs:
+                        properties:
+                          endpoints:
+                            type: string
+                          path:
+                            type: string
+                          readOnly:
+                            type: boolean
+                        required:
+                        - endpoints
+                        - path
+                        type: object
+                      hostPath:
+                        properties:
+                          path:
+                            type: string
+                          type:
+                            type: string
+                        required:
+                        - path
+                        type: object
+                      iscsi:
+                        properties:
+                          chapAuthDiscovery:
+                            type: boolean
+                          chapAuthSession:
+                            type: boolean
+                          fsType:
+                            type: string
+                          initiatorName:
+                            type: string
+                          iqn:
+                            type: string
+                          iscsiInterface:
+                            type: string
+                          lun:
+                            format: int32
+                            type: integer
+                          portals:
+                            items:
+                              type: string
+                            type: array
+                          readOnly:
+                            type: boolean
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          targetPortal:
+                            type: string
+                        required:
+                        - iqn
+                        - lun
+                        - targetPortal
+                        type: object
+                      name:
+                        type: string
+                      nfs:
+                        properties:
+                          path:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          server:
+                            type: string
+                        required:
+                        - path
+                        - server
+                        type: object
+                      persistentVolumeClaim:
+                        properties:
+                          claimName:
+                            type: string
+                          readOnly:
+                            type: boolean
+                        required:
+                        - claimName
+                        type: object
+                      photonPersistentDisk:
+                        properties:
+                          fsType:
+                            type: string
+                          pdID:
+                            type: string
+                        required:
+                        - pdID
+                        type: object
+                      portworxVolume:
+                        properties:
+                          fsType:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          volumeID:
+                            type: string
+                        required:
+                        - volumeID
+                        type: object
+                      projected:
+                        properties:
+                          defaultMode:
+                            format: int32
+                            type: integer
+                          sources:
+                            items:
                               properties:
-                                accessModes:
-                                  items:
-                                    type: string
-                                  type: array
-                                dataSource:
+                                configMap:
                                   properties:
-                                    apiGroup:
-                                      type: string
-                                    kind:
-                                      type: string
-                                    name:
-                                      type: string
-                                  required:
-                                  - kind
-                                  - name
-                                  type: object
-                                resources:
-                                  properties:
-                                    limits:
-                                      additionalProperties:
-                                        anyOf:
-                                        - type: integer
-                                        - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      type: object
-                                    requests:
-                                      additionalProperties:
-                                        anyOf:
-                                        - type: integer
-                                        - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      type: object
-                                  type: object
-                                selector:
-                                  properties:
-                                    matchExpressions:
+                                    items:
                                       items:
                                         properties:
                                           key:
                                             type: string
-                                          operator:
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
                                             type: string
-                                          values:
-                                            items:
-                                              type: string
-                                            type: array
                                         required:
                                         - key
-                                        - operator
+                                        - path
                                         type: object
                                       type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      type: object
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
                                   type: object
-                                storageClassName:
-                                  type: string
-                                volumeMode:
-                                  type: string
-                                volumeName:
-                                  type: string
+                                downwardAPI:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          fieldRef:
+                                            properties:
+                                              apiVersion:
+                                                type: string
+                                              fieldPath:
+                                                type: string
+                                            required:
+                                            - fieldPath
+                                            type: object
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                          resourceFieldRef:
+                                            properties:
+                                              containerName:
+                                                type: string
+                                              divisor:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              resource:
+                                                type: string
+                                            required:
+                                            - resource
+                                            type: object
+                                        required:
+                                        - path
+                                        type: object
+                                      type: array
+                                  type: object
+                                secret:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        type: object
+                                      type: array
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  type: object
+                                serviceAccountToken:
+                                  properties:
+                                    audience:
+                                      type: string
+                                    expirationSeconds:
+                                      format: int64
+                                      type: integer
+                                    path:
+                                      type: string
+                                  required:
+                                  - path
+                                  type: object
                               type: object
-                          required:
-                          - spec
-                          type: object
-                      type: object
-                    fc:
-                      properties:
-                        fsType:
-                          type: string
-                        lun:
-                          format: int32
-                          type: integer
-                        readOnly:
-                          type: boolean
-                        targetWWNs:
-                          items:
+                            type: array
+                        type: object
+                      quobyte:
+                        properties:
+                          group:
                             type: string
-                          type: array
-                        wwids:
-                          items:
+                          readOnly:
+                            type: boolean
+                          registry:
                             type: string
-                          type: array
-                      type: object
-                    flexVolume:
-                      properties:
-                        driver:
-                          type: string
-                        fsType:
-                          type: string
-                        options:
-                          additionalProperties:
+                          tenant:
                             type: string
-                          type: object
-                        readOnly:
-                          type: boolean
-                        secretRef:
-                          properties:
-                            name:
+                          user:
+                            type: string
+                          volume:
+                            type: string
+                        required:
+                        - registry
+                        - volume
+                        type: object
+                      rbd:
+                        properties:
+                          fsType:
+                            type: string
+                          image:
+                            type: string
+                          keyring:
+                            type: string
+                          monitors:
+                            items:
                               type: string
-                          type: object
-                      required:
-                      - driver
-                      type: object
-                    flocker:
-                      properties:
-                        datasetName:
-                          type: string
-                        datasetUUID:
-                          type: string
-                      type: object
-                    gcePersistentDisk:
-                      properties:
-                        fsType:
-                          type: string
-                        partition:
-                          format: int32
-                          type: integer
-                        pdName:
-                          type: string
-                        readOnly:
-                          type: boolean
-                      required:
-                      - pdName
-                      type: object
-                    gitRepo:
-                      properties:
-                        directory:
-                          type: string
-                        repository:
-                          type: string
-                        revision:
-                          type: string
-                      required:
-                      - repository
-                      type: object
-                    glusterfs:
-                      properties:
-                        endpoints:
-                          type: string
-                        path:
-                          type: string
-                        readOnly:
-                          type: boolean
-                      required:
-                      - endpoints
-                      - path
-                      type: object
-                    hostPath:
-                      properties:
-                        path:
-                          type: string
-                        type:
-                          type: string
-                      required:
-                      - path
-                      type: object
-                    iscsi:
-                      properties:
-                        chapAuthDiscovery:
-                          type: boolean
-                        chapAuthSession:
-                          type: boolean
-                        fsType:
-                          type: string
-                        initiatorName:
-                          type: string
-                        iqn:
-                          type: string
-                        iscsiInterface:
-                          type: string
-                        lun:
-                          format: int32
-                          type: integer
-                        portals:
-                          items:
+                            type: array
+                          pool:
                             type: string
-                          type: array
-                        readOnly:
-                          type: boolean
-                        secretRef:
-                          properties:
-                            name:
-                              type: string
-                          type: object
-                        targetPortal:
-                          type: string
-                      required:
-                      - iqn
-                      - lun
-                      - targetPortal
-                      type: object
-                    name:
-                      type: string
-                    nfs:
+                          readOnly:
+                            type: boolean
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          user:
+                            type: string
+                        required:
+                        - image
+                        - monitors
+                        type: object
+                      scaleIO:
+                        properties:
+                          fsType:
+                            type: string
+                          gateway:
+                            type: string
+                          protectionDomain:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          sslEnabled:
+                            type: boolean
+                          storageMode:
+                            type: string
+                          storagePool:
+                            type: string
+                          system:
+                            type: string
+                          volumeName:
+                            type: string
+                        required:
+                        - gateway
+                        - secretRef
+                        - system
+                        type: object
+                      secret:
+                        properties:
+                          defaultMode:
+                            format: int32
+                            type: integer
+                          items:
+                            items:
+                              properties:
+                                key:
+                                  type: string
+                                mode:
+                                  format: int32
+                                  type: integer
+                                path:
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              type: object
+                            type: array
+                          optional:
+                            type: boolean
+                          secretName:
+                            type: string
+                        type: object
+                      storageos:
+                        properties:
+                          fsType:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          volumeName:
+                            type: string
+                          volumeNamespace:
+                            type: string
+                        type: object
+                      vsphereVolume:
+                        properties:
+                          fsType:
+                            type: string
+                          storagePolicyID:
+                            type: string
+                          storagePolicyName:
+                            type: string
+                          volumePath:
+                            type: string
+                        required:
+                        - volumePath
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+              type: object
+            allInOne:
+              properties:
+                affinity:
+                  properties:
+                    nodeAffinity:
                       properties:
-                        path:
-                          type: string
-                        readOnly:
-                          type: boolean
-                        server:
-                          type: string
-                      required:
-                      - path
-                      - server
-                      type: object
-                    persistentVolumeClaim:
-                      properties:
-                        claimName:
-                          type: string
-                        readOnly:
-                          type: boolean
-                      required:
-                      - claimName
-                      type: object
-                    photonPersistentDisk:
-                      properties:
-                        fsType:
-                          type: string
-                        pdID:
-                          type: string
-                      required:
-                      - pdID
-                      type: object
-                    portworxVolume:
-                      properties:
-                        fsType:
-                          type: string
-                        readOnly:
-                          type: boolean
-                        volumeID:
-                          type: string
-                      required:
-                      - volumeID
-                      type: object
-                    projected:
-                      properties:
-                        defaultMode:
-                          format: int32
-                          type: integer
-                        sources:
+                        preferredDuringSchedulingIgnoredDuringExecution:
                           items:
                             properties:
-                              configMap:
+                              preference:
                                 properties:
-                                  items:
+                                  matchExpressions:
                                     items:
                                       properties:
                                         key:
                                           type: string
-                                        mode:
-                                          format: int32
-                                          type: integer
-                                        path:
+                                        operator:
                                           type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
                                       required:
                                       - key
-                                      - path
+                                      - operator
                                       type: object
                                     type: array
-                                  name:
-                                    type: string
-                                  optional:
-                                    type: boolean
-                                type: object
-                              downwardAPI:
-                                properties:
-                                  items:
+                                  matchFields:
                                     items:
                                       properties:
-                                        fieldRef:
-                                          properties:
-                                            apiVersion:
-                                              type: string
-                                            fieldPath:
-                                              type: string
-                                          required:
-                                          - fieldPath
-                                          type: object
-                                        mode:
-                                          format: int32
-                                          type: integer
-                                        path:
+                                        key:
                                           type: string
-                                        resourceFieldRef:
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                type: object
+                              weight:
+                                format: int32
+                                type: integer
+                            required:
+                            - preference
+                            - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          properties:
+                            nodeSelectorTerms:
+                              items:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchFields:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                type: object
+                              type: array
+                          required:
+                          - nodeSelectorTerms
+                          type: object
+                      type: object
+                    podAffinity:
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              podAffinityTerm:
+                                properties:
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
                                           properties:
-                                            containerName:
+                                            key:
                                               type: string
-                                            divisor:
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              weight:
+                                format: int32
+                                type: integer
+                            required:
+                            - podAffinityTerm
+                            - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              labelSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              namespaces:
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                type: string
+                            required:
+                            - topologyKey
+                            type: object
+                          type: array
+                      type: object
+                    podAntiAffinity:
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              podAffinityTerm:
+                                properties:
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              weight:
+                                format: int32
+                                type: integer
+                            required:
+                            - podAffinityTerm
+                            - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              labelSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              namespaces:
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                type: string
+                            required:
+                            - topologyKey
+                            type: object
+                          type: array
+                      type: object
+                  type: object
+                annotations:
+                  additionalProperties:
+                    type: string
+                  nullable: true
+                  type: object
+                config:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                image:
+                  type: string
+                labels:
+                  additionalProperties:
+                    type: string
+                  type: object
+                options:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                resources:
+                  nullable: true
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      type: object
+                  type: object
+                securityContext:
+                  properties:
+                    fsGroup:
+                      format: int64
+                      type: integer
+                    fsGroupChangePolicy:
+                      type: string
+                    runAsGroup:
+                      format: int64
+                      type: integer
+                    runAsNonRoot:
+                      type: boolean
+                    runAsUser:
+                      format: int64
+                      type: integer
+                    seLinuxOptions:
+                      properties:
+                        level:
+                          type: string
+                        role:
+                          type: string
+                        type:
+                          type: string
+                        user:
+                          type: string
+                      type: object
+                    seccompProfile:
+                      properties:
+                        localhostProfile:
+                          type: string
+                        type:
+                          type: string
+                      required:
+                      - type
+                      type: object
+                    supplementalGroups:
+                      items:
+                        format: int64
+                        type: integer
+                      type: array
+                    sysctls:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                        required:
+                        - name
+                        - value
+                        type: object
+                      type: array
+                    windowsOptions:
+                      properties:
+                        gmsaCredentialSpec:
+                          type: string
+                        gmsaCredentialSpecName:
+                          type: string
+                        runAsUserName:
+                          type: string
+                      type: object
+                  type: object
+                serviceAccount:
+                  type: string
+                tolerations:
+                  items:
+                    properties:
+                      effect:
+                        type: string
+                      key:
+                        type: string
+                      operator:
+                        type: string
+                      tolerationSeconds:
+                        format: int64
+                        type: integer
+                      value:
+                        type: string
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                tracingEnabled:
+                  type: boolean
+                volumeMounts:
+                  items:
+                    properties:
+                      mountPath:
+                        type: string
+                      mountPropagation:
+                        type: string
+                      name:
+                        type: string
+                      readOnly:
+                        type: boolean
+                      subPath:
+                        type: string
+                      subPathExpr:
+                        type: string
+                    required:
+                    - mountPath
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                volumes:
+                  items:
+                    properties:
+                      awsElasticBlockStore:
+                        properties:
+                          fsType:
+                            type: string
+                          partition:
+                            format: int32
+                            type: integer
+                          readOnly:
+                            type: boolean
+                          volumeID:
+                            type: string
+                        required:
+                        - volumeID
+                        type: object
+                      azureDisk:
+                        properties:
+                          cachingMode:
+                            type: string
+                          diskName:
+                            type: string
+                          diskURI:
+                            type: string
+                          fsType:
+                            type: string
+                          kind:
+                            type: string
+                          readOnly:
+                            type: boolean
+                        required:
+                        - diskName
+                        - diskURI
+                        type: object
+                      azureFile:
+                        properties:
+                          readOnly:
+                            type: boolean
+                          secretName:
+                            type: string
+                          shareName:
+                            type: string
+                        required:
+                        - secretName
+                        - shareName
+                        type: object
+                      cephfs:
+                        properties:
+                          monitors:
+                            items:
+                              type: string
+                            type: array
+                          path:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          secretFile:
+                            type: string
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          user:
+                            type: string
+                        required:
+                        - monitors
+                        type: object
+                      cinder:
+                        properties:
+                          fsType:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          volumeID:
+                            type: string
+                        required:
+                        - volumeID
+                        type: object
+                      configMap:
+                        properties:
+                          defaultMode:
+                            format: int32
+                            type: integer
+                          items:
+                            items:
+                              properties:
+                                key:
+                                  type: string
+                                mode:
+                                  format: int32
+                                  type: integer
+                                path:
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              type: object
+                            type: array
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        type: object
+                      csi:
+                        properties:
+                          driver:
+                            type: string
+                          fsType:
+                            type: string
+                          nodePublishSecretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          readOnly:
+                            type: boolean
+                          volumeAttributes:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        required:
+                        - driver
+                        type: object
+                      downwardAPI:
+                        properties:
+                          defaultMode:
+                            format: int32
+                            type: integer
+                          items:
+                            items:
+                              properties:
+                                fieldRef:
+                                  properties:
+                                    apiVersion:
+                                      type: string
+                                    fieldPath:
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                mode:
+                                  format: int32
+                                  type: integer
+                                path:
+                                  type: string
+                                resourceFieldRef:
+                                  properties:
+                                    containerName:
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                              required:
+                              - path
+                              type: object
+                            type: array
+                        type: object
+                      emptyDir:
+                        properties:
+                          medium:
+                            type: string
+                          sizeLimit:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      ephemeral:
+                        properties:
+                          readOnly:
+                            type: boolean
+                          volumeClaimTemplate:
+                            properties:
+                              metadata:
+                                type: object
+                              spec:
+                                properties:
+                                  accessModes:
+                                    items:
+                                      type: string
+                                    type: array
+                                  dataSource:
+                                    properties:
+                                      apiGroup:
+                                        type: string
+                                      kind:
+                                        type: string
+                                      name:
+                                        type: string
+                                    required:
+                                    - kind
+                                    - name
+                                    type: object
+                                  resources:
+                                    properties:
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                    type: object
+                                  selector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  storageClassName:
+                                    type: string
+                                  volumeMode:
+                                    type: string
+                                  volumeName:
+                                    type: string
+                                type: object
+                            required:
+                            - spec
+                            type: object
+                        type: object
+                      fc:
+                        properties:
+                          fsType:
+                            type: string
+                          lun:
+                            format: int32
+                            type: integer
+                          readOnly:
+                            type: boolean
+                          targetWWNs:
+                            items:
+                              type: string
+                            type: array
+                          wwids:
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      flexVolume:
+                        properties:
+                          driver:
+                            type: string
+                          fsType:
+                            type: string
+                          options:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          readOnly:
+                            type: boolean
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                        required:
+                        - driver
+                        type: object
+                      flocker:
+                        properties:
+                          datasetName:
+                            type: string
+                          datasetUUID:
+                            type: string
+                        type: object
+                      gcePersistentDisk:
+                        properties:
+                          fsType:
+                            type: string
+                          partition:
+                            format: int32
+                            type: integer
+                          pdName:
+                            type: string
+                          readOnly:
+                            type: boolean
+                        required:
+                        - pdName
+                        type: object
+                      gitRepo:
+                        properties:
+                          directory:
+                            type: string
+                          repository:
+                            type: string
+                          revision:
+                            type: string
+                        required:
+                        - repository
+                        type: object
+                      glusterfs:
+                        properties:
+                          endpoints:
+                            type: string
+                          path:
+                            type: string
+                          readOnly:
+                            type: boolean
+                        required:
+                        - endpoints
+                        - path
+                        type: object
+                      hostPath:
+                        properties:
+                          path:
+                            type: string
+                          type:
+                            type: string
+                        required:
+                        - path
+                        type: object
+                      iscsi:
+                        properties:
+                          chapAuthDiscovery:
+                            type: boolean
+                          chapAuthSession:
+                            type: boolean
+                          fsType:
+                            type: string
+                          initiatorName:
+                            type: string
+                          iqn:
+                            type: string
+                          iscsiInterface:
+                            type: string
+                          lun:
+                            format: int32
+                            type: integer
+                          portals:
+                            items:
+                              type: string
+                            type: array
+                          readOnly:
+                            type: boolean
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          targetPortal:
+                            type: string
+                        required:
+                        - iqn
+                        - lun
+                        - targetPortal
+                        type: object
+                      name:
+                        type: string
+                      nfs:
+                        properties:
+                          path:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          server:
+                            type: string
+                        required:
+                        - path
+                        - server
+                        type: object
+                      persistentVolumeClaim:
+                        properties:
+                          claimName:
+                            type: string
+                          readOnly:
+                            type: boolean
+                        required:
+                        - claimName
+                        type: object
+                      photonPersistentDisk:
+                        properties:
+                          fsType:
+                            type: string
+                          pdID:
+                            type: string
+                        required:
+                        - pdID
+                        type: object
+                      portworxVolume:
+                        properties:
+                          fsType:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          volumeID:
+                            type: string
+                        required:
+                        - volumeID
+                        type: object
+                      projected:
+                        properties:
+                          defaultMode:
+                            format: int32
+                            type: integer
+                          sources:
+                            items:
+                              properties:
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        type: object
+                                      type: array
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  type: object
+                                downwardAPI:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          fieldRef:
+                                            properties:
+                                              apiVersion:
+                                                type: string
+                                              fieldPath:
+                                                type: string
+                                            required:
+                                            - fieldPath
+                                            type: object
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                          resourceFieldRef:
+                                            properties:
+                                              containerName:
+                                                type: string
+                                              divisor:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              resource:
+                                                type: string
+                                            required:
+                                            - resource
+                                            type: object
+                                        required:
+                                        - path
+                                        type: object
+                                      type: array
+                                  type: object
+                                secret:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        type: object
+                                      type: array
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  type: object
+                                serviceAccountToken:
+                                  properties:
+                                    audience:
+                                      type: string
+                                    expirationSeconds:
+                                      format: int64
+                                      type: integer
+                                    path:
+                                      type: string
+                                  required:
+                                  - path
+                                  type: object
+                              type: object
+                            type: array
+                        type: object
+                      quobyte:
+                        properties:
+                          group:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          registry:
+                            type: string
+                          tenant:
+                            type: string
+                          user:
+                            type: string
+                          volume:
+                            type: string
+                        required:
+                        - registry
+                        - volume
+                        type: object
+                      rbd:
+                        properties:
+                          fsType:
+                            type: string
+                          image:
+                            type: string
+                          keyring:
+                            type: string
+                          monitors:
+                            items:
+                              type: string
+                            type: array
+                          pool:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          user:
+                            type: string
+                        required:
+                        - image
+                        - monitors
+                        type: object
+                      scaleIO:
+                        properties:
+                          fsType:
+                            type: string
+                          gateway:
+                            type: string
+                          protectionDomain:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          sslEnabled:
+                            type: boolean
+                          storageMode:
+                            type: string
+                          storagePool:
+                            type: string
+                          system:
+                            type: string
+                          volumeName:
+                            type: string
+                        required:
+                        - gateway
+                        - secretRef
+                        - system
+                        type: object
+                      secret:
+                        properties:
+                          defaultMode:
+                            format: int32
+                            type: integer
+                          items:
+                            items:
+                              properties:
+                                key:
+                                  type: string
+                                mode:
+                                  format: int32
+                                  type: integer
+                                path:
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              type: object
+                            type: array
+                          optional:
+                            type: boolean
+                          secretName:
+                            type: string
+                        type: object
+                      storageos:
+                        properties:
+                          fsType:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          volumeName:
+                            type: string
+                          volumeNamespace:
+                            type: string
+                        type: object
+                      vsphereVolume:
+                        properties:
+                          fsType:
+                            type: string
+                          storagePolicyID:
+                            type: string
+                          storagePolicyName:
+                            type: string
+                          volumePath:
+                            type: string
+                        required:
+                        - volumePath
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+              type: object
+            annotations:
+              additionalProperties:
+                type: string
+              nullable: true
+              type: object
+            collector:
+              properties:
+                affinity:
+                  properties:
+                    nodeAffinity:
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              preference:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchFields:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                type: object
+                              weight:
+                                format: int32
+                                type: integer
+                            required:
+                            - preference
+                            - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          properties:
+                            nodeSelectorTerms:
+                              items:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchFields:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                type: object
+                              type: array
+                          required:
+                          - nodeSelectorTerms
+                          type: object
+                      type: object
+                    podAffinity:
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              podAffinityTerm:
+                                properties:
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              weight:
+                                format: int32
+                                type: integer
+                            required:
+                            - podAffinityTerm
+                            - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              labelSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              namespaces:
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                type: string
+                            required:
+                            - topologyKey
+                            type: object
+                          type: array
+                      type: object
+                    podAntiAffinity:
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              podAffinityTerm:
+                                properties:
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              weight:
+                                format: int32
+                                type: integer
+                            required:
+                            - podAffinityTerm
+                            - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              labelSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              namespaces:
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                type: string
+                            required:
+                            - topologyKey
+                            type: object
+                          type: array
+                      type: object
+                  type: object
+                annotations:
+                  additionalProperties:
+                    type: string
+                  nullable: true
+                  type: object
+                autoscale:
+                  type: boolean
+                config:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                image:
+                  type: string
+                labels:
+                  additionalProperties:
+                    type: string
+                  type: object
+                maxReplicas:
+                  format: int32
+                  type: integer
+                minReplicas:
+                  format: int32
+                  type: integer
+                options:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                priorityClassName:
+                  type: string
+                replicas:
+                  format: int32
+                  type: integer
+                resources:
+                  nullable: true
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      type: object
+                  type: object
+                securityContext:
+                  properties:
+                    fsGroup:
+                      format: int64
+                      type: integer
+                    fsGroupChangePolicy:
+                      type: string
+                    runAsGroup:
+                      format: int64
+                      type: integer
+                    runAsNonRoot:
+                      type: boolean
+                    runAsUser:
+                      format: int64
+                      type: integer
+                    seLinuxOptions:
+                      properties:
+                        level:
+                          type: string
+                        role:
+                          type: string
+                        type:
+                          type: string
+                        user:
+                          type: string
+                      type: object
+                    seccompProfile:
+                      properties:
+                        localhostProfile:
+                          type: string
+                        type:
+                          type: string
+                      required:
+                      - type
+                      type: object
+                    supplementalGroups:
+                      items:
+                        format: int64
+                        type: integer
+                      type: array
+                    sysctls:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                        required:
+                        - name
+                        - value
+                        type: object
+                      type: array
+                    windowsOptions:
+                      properties:
+                        gmsaCredentialSpec:
+                          type: string
+                        gmsaCredentialSpecName:
+                          type: string
+                        runAsUserName:
+                          type: string
+                      type: object
+                  type: object
+                serviceAccount:
+                  type: string
+                serviceType:
+                  type: string
+                tolerations:
+                  items:
+                    properties:
+                      effect:
+                        type: string
+                      key:
+                        type: string
+                      operator:
+                        type: string
+                      tolerationSeconds:
+                        format: int64
+                        type: integer
+                      value:
+                        type: string
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                volumeMounts:
+                  items:
+                    properties:
+                      mountPath:
+                        type: string
+                      mountPropagation:
+                        type: string
+                      name:
+                        type: string
+                      readOnly:
+                        type: boolean
+                      subPath:
+                        type: string
+                      subPathExpr:
+                        type: string
+                    required:
+                    - mountPath
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                volumes:
+                  items:
+                    properties:
+                      awsElasticBlockStore:
+                        properties:
+                          fsType:
+                            type: string
+                          partition:
+                            format: int32
+                            type: integer
+                          readOnly:
+                            type: boolean
+                          volumeID:
+                            type: string
+                        required:
+                        - volumeID
+                        type: object
+                      azureDisk:
+                        properties:
+                          cachingMode:
+                            type: string
+                          diskName:
+                            type: string
+                          diskURI:
+                            type: string
+                          fsType:
+                            type: string
+                          kind:
+                            type: string
+                          readOnly:
+                            type: boolean
+                        required:
+                        - diskName
+                        - diskURI
+                        type: object
+                      azureFile:
+                        properties:
+                          readOnly:
+                            type: boolean
+                          secretName:
+                            type: string
+                          shareName:
+                            type: string
+                        required:
+                        - secretName
+                        - shareName
+                        type: object
+                      cephfs:
+                        properties:
+                          monitors:
+                            items:
+                              type: string
+                            type: array
+                          path:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          secretFile:
+                            type: string
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          user:
+                            type: string
+                        required:
+                        - monitors
+                        type: object
+                      cinder:
+                        properties:
+                          fsType:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          volumeID:
+                            type: string
+                        required:
+                        - volumeID
+                        type: object
+                      configMap:
+                        properties:
+                          defaultMode:
+                            format: int32
+                            type: integer
+                          items:
+                            items:
+                              properties:
+                                key:
+                                  type: string
+                                mode:
+                                  format: int32
+                                  type: integer
+                                path:
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              type: object
+                            type: array
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        type: object
+                      csi:
+                        properties:
+                          driver:
+                            type: string
+                          fsType:
+                            type: string
+                          nodePublishSecretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          readOnly:
+                            type: boolean
+                          volumeAttributes:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        required:
+                        - driver
+                        type: object
+                      downwardAPI:
+                        properties:
+                          defaultMode:
+                            format: int32
+                            type: integer
+                          items:
+                            items:
+                              properties:
+                                fieldRef:
+                                  properties:
+                                    apiVersion:
+                                      type: string
+                                    fieldPath:
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                mode:
+                                  format: int32
+                                  type: integer
+                                path:
+                                  type: string
+                                resourceFieldRef:
+                                  properties:
+                                    containerName:
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                              required:
+                              - path
+                              type: object
+                            type: array
+                        type: object
+                      emptyDir:
+                        properties:
+                          medium:
+                            type: string
+                          sizeLimit:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      ephemeral:
+                        properties:
+                          readOnly:
+                            type: boolean
+                          volumeClaimTemplate:
+                            properties:
+                              metadata:
+                                type: object
+                              spec:
+                                properties:
+                                  accessModes:
+                                    items:
+                                      type: string
+                                    type: array
+                                  dataSource:
+                                    properties:
+                                      apiGroup:
+                                        type: string
+                                      kind:
+                                        type: string
+                                      name:
+                                        type: string
+                                    required:
+                                    - kind
+                                    - name
+                                    type: object
+                                  resources:
+                                    properties:
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                    type: object
+                                  selector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  storageClassName:
+                                    type: string
+                                  volumeMode:
+                                    type: string
+                                  volumeName:
+                                    type: string
+                                type: object
+                            required:
+                            - spec
+                            type: object
+                        type: object
+                      fc:
+                        properties:
+                          fsType:
+                            type: string
+                          lun:
+                            format: int32
+                            type: integer
+                          readOnly:
+                            type: boolean
+                          targetWWNs:
+                            items:
+                              type: string
+                            type: array
+                          wwids:
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      flexVolume:
+                        properties:
+                          driver:
+                            type: string
+                          fsType:
+                            type: string
+                          options:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          readOnly:
+                            type: boolean
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                        required:
+                        - driver
+                        type: object
+                      flocker:
+                        properties:
+                          datasetName:
+                            type: string
+                          datasetUUID:
+                            type: string
+                        type: object
+                      gcePersistentDisk:
+                        properties:
+                          fsType:
+                            type: string
+                          partition:
+                            format: int32
+                            type: integer
+                          pdName:
+                            type: string
+                          readOnly:
+                            type: boolean
+                        required:
+                        - pdName
+                        type: object
+                      gitRepo:
+                        properties:
+                          directory:
+                            type: string
+                          repository:
+                            type: string
+                          revision:
+                            type: string
+                        required:
+                        - repository
+                        type: object
+                      glusterfs:
+                        properties:
+                          endpoints:
+                            type: string
+                          path:
+                            type: string
+                          readOnly:
+                            type: boolean
+                        required:
+                        - endpoints
+                        - path
+                        type: object
+                      hostPath:
+                        properties:
+                          path:
+                            type: string
+                          type:
+                            type: string
+                        required:
+                        - path
+                        type: object
+                      iscsi:
+                        properties:
+                          chapAuthDiscovery:
+                            type: boolean
+                          chapAuthSession:
+                            type: boolean
+                          fsType:
+                            type: string
+                          initiatorName:
+                            type: string
+                          iqn:
+                            type: string
+                          iscsiInterface:
+                            type: string
+                          lun:
+                            format: int32
+                            type: integer
+                          portals:
+                            items:
+                              type: string
+                            type: array
+                          readOnly:
+                            type: boolean
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          targetPortal:
+                            type: string
+                        required:
+                        - iqn
+                        - lun
+                        - targetPortal
+                        type: object
+                      name:
+                        type: string
+                      nfs:
+                        properties:
+                          path:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          server:
+                            type: string
+                        required:
+                        - path
+                        - server
+                        type: object
+                      persistentVolumeClaim:
+                        properties:
+                          claimName:
+                            type: string
+                          readOnly:
+                            type: boolean
+                        required:
+                        - claimName
+                        type: object
+                      photonPersistentDisk:
+                        properties:
+                          fsType:
+                            type: string
+                          pdID:
+                            type: string
+                        required:
+                        - pdID
+                        type: object
+                      portworxVolume:
+                        properties:
+                          fsType:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          volumeID:
+                            type: string
+                        required:
+                        - volumeID
+                        type: object
+                      projected:
+                        properties:
+                          defaultMode:
+                            format: int32
+                            type: integer
+                          sources:
+                            items:
+                              properties:
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        type: object
+                                      type: array
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  type: object
+                                downwardAPI:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          fieldRef:
+                                            properties:
+                                              apiVersion:
+                                                type: string
+                                              fieldPath:
+                                                type: string
+                                            required:
+                                            - fieldPath
+                                            type: object
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                          resourceFieldRef:
+                                            properties:
+                                              containerName:
+                                                type: string
+                                              divisor:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              resource:
+                                                type: string
+                                            required:
+                                            - resource
+                                            type: object
+                                        required:
+                                        - path
+                                        type: object
+                                      type: array
+                                  type: object
+                                secret:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        type: object
+                                      type: array
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  type: object
+                                serviceAccountToken:
+                                  properties:
+                                    audience:
+                                      type: string
+                                    expirationSeconds:
+                                      format: int64
+                                      type: integer
+                                    path:
+                                      type: string
+                                  required:
+                                  - path
+                                  type: object
+                              type: object
+                            type: array
+                        type: object
+                      quobyte:
+                        properties:
+                          group:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          registry:
+                            type: string
+                          tenant:
+                            type: string
+                          user:
+                            type: string
+                          volume:
+                            type: string
+                        required:
+                        - registry
+                        - volume
+                        type: object
+                      rbd:
+                        properties:
+                          fsType:
+                            type: string
+                          image:
+                            type: string
+                          keyring:
+                            type: string
+                          monitors:
+                            items:
+                              type: string
+                            type: array
+                          pool:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          user:
+                            type: string
+                        required:
+                        - image
+                        - monitors
+                        type: object
+                      scaleIO:
+                        properties:
+                          fsType:
+                            type: string
+                          gateway:
+                            type: string
+                          protectionDomain:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          sslEnabled:
+                            type: boolean
+                          storageMode:
+                            type: string
+                          storagePool:
+                            type: string
+                          system:
+                            type: string
+                          volumeName:
+                            type: string
+                        required:
+                        - gateway
+                        - secretRef
+                        - system
+                        type: object
+                      secret:
+                        properties:
+                          defaultMode:
+                            format: int32
+                            type: integer
+                          items:
+                            items:
+                              properties:
+                                key:
+                                  type: string
+                                mode:
+                                  format: int32
+                                  type: integer
+                                path:
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              type: object
+                            type: array
+                          optional:
+                            type: boolean
+                          secretName:
+                            type: string
+                        type: object
+                      storageos:
+                        properties:
+                          fsType:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          volumeName:
+                            type: string
+                          volumeNamespace:
+                            type: string
+                        type: object
+                      vsphereVolume:
+                        properties:
+                          fsType:
+                            type: string
+                          storagePolicyID:
+                            type: string
+                          storagePolicyName:
+                            type: string
+                          volumePath:
+                            type: string
+                        required:
+                        - volumePath
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+              type: object
+            ingester:
+              properties:
+                affinity:
+                  properties:
+                    nodeAffinity:
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              preference:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchFields:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                type: object
+                              weight:
+                                format: int32
+                                type: integer
+                            required:
+                            - preference
+                            - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          properties:
+                            nodeSelectorTerms:
+                              items:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchFields:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                type: object
+                              type: array
+                          required:
+                          - nodeSelectorTerms
+                          type: object
+                      type: object
+                    podAffinity:
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              podAffinityTerm:
+                                properties:
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              weight:
+                                format: int32
+                                type: integer
+                            required:
+                            - podAffinityTerm
+                            - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              labelSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              namespaces:
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                type: string
+                            required:
+                            - topologyKey
+                            type: object
+                          type: array
+                      type: object
+                    podAntiAffinity:
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              podAffinityTerm:
+                                properties:
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              weight:
+                                format: int32
+                                type: integer
+                            required:
+                            - podAffinityTerm
+                            - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              labelSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              namespaces:
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                type: string
+                            required:
+                            - topologyKey
+                            type: object
+                          type: array
+                      type: object
+                  type: object
+                annotations:
+                  additionalProperties:
+                    type: string
+                  nullable: true
+                  type: object
+                autoscale:
+                  type: boolean
+                config:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                image:
+                  type: string
+                labels:
+                  additionalProperties:
+                    type: string
+                  type: object
+                maxReplicas:
+                  format: int32
+                  type: integer
+                minReplicas:
+                  format: int32
+                  type: integer
+                options:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                replicas:
+                  format: int32
+                  type: integer
+                resources:
+                  nullable: true
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      type: object
+                  type: object
+                securityContext:
+                  properties:
+                    fsGroup:
+                      format: int64
+                      type: integer
+                    fsGroupChangePolicy:
+                      type: string
+                    runAsGroup:
+                      format: int64
+                      type: integer
+                    runAsNonRoot:
+                      type: boolean
+                    runAsUser:
+                      format: int64
+                      type: integer
+                    seLinuxOptions:
+                      properties:
+                        level:
+                          type: string
+                        role:
+                          type: string
+                        type:
+                          type: string
+                        user:
+                          type: string
+                      type: object
+                    seccompProfile:
+                      properties:
+                        localhostProfile:
+                          type: string
+                        type:
+                          type: string
+                      required:
+                      - type
+                      type: object
+                    supplementalGroups:
+                      items:
+                        format: int64
+                        type: integer
+                      type: array
+                    sysctls:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                        required:
+                        - name
+                        - value
+                        type: object
+                      type: array
+                    windowsOptions:
+                      properties:
+                        gmsaCredentialSpec:
+                          type: string
+                        gmsaCredentialSpecName:
+                          type: string
+                        runAsUserName:
+                          type: string
+                      type: object
+                  type: object
+                serviceAccount:
+                  type: string
+                tolerations:
+                  items:
+                    properties:
+                      effect:
+                        type: string
+                      key:
+                        type: string
+                      operator:
+                        type: string
+                      tolerationSeconds:
+                        format: int64
+                        type: integer
+                      value:
+                        type: string
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                volumeMounts:
+                  items:
+                    properties:
+                      mountPath:
+                        type: string
+                      mountPropagation:
+                        type: string
+                      name:
+                        type: string
+                      readOnly:
+                        type: boolean
+                      subPath:
+                        type: string
+                      subPathExpr:
+                        type: string
+                    required:
+                    - mountPath
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                volumes:
+                  items:
+                    properties:
+                      awsElasticBlockStore:
+                        properties:
+                          fsType:
+                            type: string
+                          partition:
+                            format: int32
+                            type: integer
+                          readOnly:
+                            type: boolean
+                          volumeID:
+                            type: string
+                        required:
+                        - volumeID
+                        type: object
+                      azureDisk:
+                        properties:
+                          cachingMode:
+                            type: string
+                          diskName:
+                            type: string
+                          diskURI:
+                            type: string
+                          fsType:
+                            type: string
+                          kind:
+                            type: string
+                          readOnly:
+                            type: boolean
+                        required:
+                        - diskName
+                        - diskURI
+                        type: object
+                      azureFile:
+                        properties:
+                          readOnly:
+                            type: boolean
+                          secretName:
+                            type: string
+                          shareName:
+                            type: string
+                        required:
+                        - secretName
+                        - shareName
+                        type: object
+                      cephfs:
+                        properties:
+                          monitors:
+                            items:
+                              type: string
+                            type: array
+                          path:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          secretFile:
+                            type: string
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          user:
+                            type: string
+                        required:
+                        - monitors
+                        type: object
+                      cinder:
+                        properties:
+                          fsType:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          volumeID:
+                            type: string
+                        required:
+                        - volumeID
+                        type: object
+                      configMap:
+                        properties:
+                          defaultMode:
+                            format: int32
+                            type: integer
+                          items:
+                            items:
+                              properties:
+                                key:
+                                  type: string
+                                mode:
+                                  format: int32
+                                  type: integer
+                                path:
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              type: object
+                            type: array
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        type: object
+                      csi:
+                        properties:
+                          driver:
+                            type: string
+                          fsType:
+                            type: string
+                          nodePublishSecretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          readOnly:
+                            type: boolean
+                          volumeAttributes:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        required:
+                        - driver
+                        type: object
+                      downwardAPI:
+                        properties:
+                          defaultMode:
+                            format: int32
+                            type: integer
+                          items:
+                            items:
+                              properties:
+                                fieldRef:
+                                  properties:
+                                    apiVersion:
+                                      type: string
+                                    fieldPath:
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                mode:
+                                  format: int32
+                                  type: integer
+                                path:
+                                  type: string
+                                resourceFieldRef:
+                                  properties:
+                                    containerName:
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                              required:
+                              - path
+                              type: object
+                            type: array
+                        type: object
+                      emptyDir:
+                        properties:
+                          medium:
+                            type: string
+                          sizeLimit:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      ephemeral:
+                        properties:
+                          readOnly:
+                            type: boolean
+                          volumeClaimTemplate:
+                            properties:
+                              metadata:
+                                type: object
+                              spec:
+                                properties:
+                                  accessModes:
+                                    items:
+                                      type: string
+                                    type: array
+                                  dataSource:
+                                    properties:
+                                      apiGroup:
+                                        type: string
+                                      kind:
+                                        type: string
+                                      name:
+                                        type: string
+                                    required:
+                                    - kind
+                                    - name
+                                    type: object
+                                  resources:
+                                    properties:
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                    type: object
+                                  selector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  storageClassName:
+                                    type: string
+                                  volumeMode:
+                                    type: string
+                                  volumeName:
+                                    type: string
+                                type: object
+                            required:
+                            - spec
+                            type: object
+                        type: object
+                      fc:
+                        properties:
+                          fsType:
+                            type: string
+                          lun:
+                            format: int32
+                            type: integer
+                          readOnly:
+                            type: boolean
+                          targetWWNs:
+                            items:
+                              type: string
+                            type: array
+                          wwids:
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      flexVolume:
+                        properties:
+                          driver:
+                            type: string
+                          fsType:
+                            type: string
+                          options:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          readOnly:
+                            type: boolean
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                        required:
+                        - driver
+                        type: object
+                      flocker:
+                        properties:
+                          datasetName:
+                            type: string
+                          datasetUUID:
+                            type: string
+                        type: object
+                      gcePersistentDisk:
+                        properties:
+                          fsType:
+                            type: string
+                          partition:
+                            format: int32
+                            type: integer
+                          pdName:
+                            type: string
+                          readOnly:
+                            type: boolean
+                        required:
+                        - pdName
+                        type: object
+                      gitRepo:
+                        properties:
+                          directory:
+                            type: string
+                          repository:
+                            type: string
+                          revision:
+                            type: string
+                        required:
+                        - repository
+                        type: object
+                      glusterfs:
+                        properties:
+                          endpoints:
+                            type: string
+                          path:
+                            type: string
+                          readOnly:
+                            type: boolean
+                        required:
+                        - endpoints
+                        - path
+                        type: object
+                      hostPath:
+                        properties:
+                          path:
+                            type: string
+                          type:
+                            type: string
+                        required:
+                        - path
+                        type: object
+                      iscsi:
+                        properties:
+                          chapAuthDiscovery:
+                            type: boolean
+                          chapAuthSession:
+                            type: boolean
+                          fsType:
+                            type: string
+                          initiatorName:
+                            type: string
+                          iqn:
+                            type: string
+                          iscsiInterface:
+                            type: string
+                          lun:
+                            format: int32
+                            type: integer
+                          portals:
+                            items:
+                              type: string
+                            type: array
+                          readOnly:
+                            type: boolean
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          targetPortal:
+                            type: string
+                        required:
+                        - iqn
+                        - lun
+                        - targetPortal
+                        type: object
+                      name:
+                        type: string
+                      nfs:
+                        properties:
+                          path:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          server:
+                            type: string
+                        required:
+                        - path
+                        - server
+                        type: object
+                      persistentVolumeClaim:
+                        properties:
+                          claimName:
+                            type: string
+                          readOnly:
+                            type: boolean
+                        required:
+                        - claimName
+                        type: object
+                      photonPersistentDisk:
+                        properties:
+                          fsType:
+                            type: string
+                          pdID:
+                            type: string
+                        required:
+                        - pdID
+                        type: object
+                      portworxVolume:
+                        properties:
+                          fsType:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          volumeID:
+                            type: string
+                        required:
+                        - volumeID
+                        type: object
+                      projected:
+                        properties:
+                          defaultMode:
+                            format: int32
+                            type: integer
+                          sources:
+                            items:
+                              properties:
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        type: object
+                                      type: array
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  type: object
+                                downwardAPI:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          fieldRef:
+                                            properties:
+                                              apiVersion:
+                                                type: string
+                                              fieldPath:
+                                                type: string
+                                            required:
+                                            - fieldPath
+                                            type: object
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                          resourceFieldRef:
+                                            properties:
+                                              containerName:
+                                                type: string
+                                              divisor:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              resource:
+                                                type: string
+                                            required:
+                                            - resource
+                                            type: object
+                                        required:
+                                        - path
+                                        type: object
+                                      type: array
+                                  type: object
+                                secret:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        type: object
+                                      type: array
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  type: object
+                                serviceAccountToken:
+                                  properties:
+                                    audience:
+                                      type: string
+                                    expirationSeconds:
+                                      format: int64
+                                      type: integer
+                                    path:
+                                      type: string
+                                  required:
+                                  - path
+                                  type: object
+                              type: object
+                            type: array
+                        type: object
+                      quobyte:
+                        properties:
+                          group:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          registry:
+                            type: string
+                          tenant:
+                            type: string
+                          user:
+                            type: string
+                          volume:
+                            type: string
+                        required:
+                        - registry
+                        - volume
+                        type: object
+                      rbd:
+                        properties:
+                          fsType:
+                            type: string
+                          image:
+                            type: string
+                          keyring:
+                            type: string
+                          monitors:
+                            items:
+                              type: string
+                            type: array
+                          pool:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          user:
+                            type: string
+                        required:
+                        - image
+                        - monitors
+                        type: object
+                      scaleIO:
+                        properties:
+                          fsType:
+                            type: string
+                          gateway:
+                            type: string
+                          protectionDomain:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          sslEnabled:
+                            type: boolean
+                          storageMode:
+                            type: string
+                          storagePool:
+                            type: string
+                          system:
+                            type: string
+                          volumeName:
+                            type: string
+                        required:
+                        - gateway
+                        - secretRef
+                        - system
+                        type: object
+                      secret:
+                        properties:
+                          defaultMode:
+                            format: int32
+                            type: integer
+                          items:
+                            items:
+                              properties:
+                                key:
+                                  type: string
+                                mode:
+                                  format: int32
+                                  type: integer
+                                path:
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              type: object
+                            type: array
+                          optional:
+                            type: boolean
+                          secretName:
+                            type: string
+                        type: object
+                      storageos:
+                        properties:
+                          fsType:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          volumeName:
+                            type: string
+                          volumeNamespace:
+                            type: string
+                        type: object
+                      vsphereVolume:
+                        properties:
+                          fsType:
+                            type: string
+                          storagePolicyID:
+                            type: string
+                          storagePolicyName:
+                            type: string
+                          volumePath:
+                            type: string
+                        required:
+                        - volumePath
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+              type: object
+            ingress:
+              properties:
+                affinity:
+                  properties:
+                    nodeAffinity:
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              preference:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchFields:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                type: object
+                              weight:
+                                format: int32
+                                type: integer
+                            required:
+                            - preference
+                            - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          properties:
+                            nodeSelectorTerms:
+                              items:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchFields:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                type: object
+                              type: array
+                          required:
+                          - nodeSelectorTerms
+                          type: object
+                      type: object
+                    podAffinity:
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              podAffinityTerm:
+                                properties:
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              weight:
+                                format: int32
+                                type: integer
+                            required:
+                            - podAffinityTerm
+                            - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              labelSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              namespaces:
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                type: string
+                            required:
+                            - topologyKey
+                            type: object
+                          type: array
+                      type: object
+                    podAntiAffinity:
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              podAffinityTerm:
+                                properties:
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              weight:
+                                format: int32
+                                type: integer
+                            required:
+                            - podAffinityTerm
+                            - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              labelSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              namespaces:
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                type: string
+                            required:
+                            - topologyKey
+                            type: object
+                          type: array
+                      type: object
+                  type: object
+                annotations:
+                  additionalProperties:
+                    type: string
+                  nullable: true
+                  type: object
+                enabled:
+                  type: boolean
+                hosts:
+                  items:
+                    type: string
+                  type: array
+                  x-kubernetes-list-type: atomic
+                labels:
+                  additionalProperties:
+                    type: string
+                  type: object
+                openshift:
+                  properties:
+                    delegateUrls:
+                      type: string
+                    htpasswdFile:
+                      type: string
+                    sar:
+                      type: string
+                    skipLogout:
+                      type: boolean
+                  type: object
+                options:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                resources:
+                  nullable: true
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      type: object
+                  type: object
+                secretName:
+                  type: string
+                security:
+                  type: string
+                securityContext:
+                  properties:
+                    fsGroup:
+                      format: int64
+                      type: integer
+                    fsGroupChangePolicy:
+                      type: string
+                    runAsGroup:
+                      format: int64
+                      type: integer
+                    runAsNonRoot:
+                      type: boolean
+                    runAsUser:
+                      format: int64
+                      type: integer
+                    seLinuxOptions:
+                      properties:
+                        level:
+                          type: string
+                        role:
+                          type: string
+                        type:
+                          type: string
+                        user:
+                          type: string
+                      type: object
+                    seccompProfile:
+                      properties:
+                        localhostProfile:
+                          type: string
+                        type:
+                          type: string
+                      required:
+                      - type
+                      type: object
+                    supplementalGroups:
+                      items:
+                        format: int64
+                        type: integer
+                      type: array
+                    sysctls:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                        required:
+                        - name
+                        - value
+                        type: object
+                      type: array
+                    windowsOptions:
+                      properties:
+                        gmsaCredentialSpec:
+                          type: string
+                        gmsaCredentialSpecName:
+                          type: string
+                        runAsUserName:
+                          type: string
+                      type: object
+                  type: object
+                serviceAccount:
+                  type: string
+                tls:
+                  items:
+                    properties:
+                      hosts:
+                        items:
+                          type: string
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      secretName:
+                        type: string
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                tolerations:
+                  items:
+                    properties:
+                      effect:
+                        type: string
+                      key:
+                        type: string
+                      operator:
+                        type: string
+                      tolerationSeconds:
+                        format: int64
+                        type: integer
+                      value:
+                        type: string
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                volumeMounts:
+                  items:
+                    properties:
+                      mountPath:
+                        type: string
+                      mountPropagation:
+                        type: string
+                      name:
+                        type: string
+                      readOnly:
+                        type: boolean
+                      subPath:
+                        type: string
+                      subPathExpr:
+                        type: string
+                    required:
+                    - mountPath
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                volumes:
+                  items:
+                    properties:
+                      awsElasticBlockStore:
+                        properties:
+                          fsType:
+                            type: string
+                          partition:
+                            format: int32
+                            type: integer
+                          readOnly:
+                            type: boolean
+                          volumeID:
+                            type: string
+                        required:
+                        - volumeID
+                        type: object
+                      azureDisk:
+                        properties:
+                          cachingMode:
+                            type: string
+                          diskName:
+                            type: string
+                          diskURI:
+                            type: string
+                          fsType:
+                            type: string
+                          kind:
+                            type: string
+                          readOnly:
+                            type: boolean
+                        required:
+                        - diskName
+                        - diskURI
+                        type: object
+                      azureFile:
+                        properties:
+                          readOnly:
+                            type: boolean
+                          secretName:
+                            type: string
+                          shareName:
+                            type: string
+                        required:
+                        - secretName
+                        - shareName
+                        type: object
+                      cephfs:
+                        properties:
+                          monitors:
+                            items:
+                              type: string
+                            type: array
+                          path:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          secretFile:
+                            type: string
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          user:
+                            type: string
+                        required:
+                        - monitors
+                        type: object
+                      cinder:
+                        properties:
+                          fsType:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          volumeID:
+                            type: string
+                        required:
+                        - volumeID
+                        type: object
+                      configMap:
+                        properties:
+                          defaultMode:
+                            format: int32
+                            type: integer
+                          items:
+                            items:
+                              properties:
+                                key:
+                                  type: string
+                                mode:
+                                  format: int32
+                                  type: integer
+                                path:
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              type: object
+                            type: array
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        type: object
+                      csi:
+                        properties:
+                          driver:
+                            type: string
+                          fsType:
+                            type: string
+                          nodePublishSecretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          readOnly:
+                            type: boolean
+                          volumeAttributes:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        required:
+                        - driver
+                        type: object
+                      downwardAPI:
+                        properties:
+                          defaultMode:
+                            format: int32
+                            type: integer
+                          items:
+                            items:
+                              properties:
+                                fieldRef:
+                                  properties:
+                                    apiVersion:
+                                      type: string
+                                    fieldPath:
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                mode:
+                                  format: int32
+                                  type: integer
+                                path:
+                                  type: string
+                                resourceFieldRef:
+                                  properties:
+                                    containerName:
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                              required:
+                              - path
+                              type: object
+                            type: array
+                        type: object
+                      emptyDir:
+                        properties:
+                          medium:
+                            type: string
+                          sizeLimit:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      ephemeral:
+                        properties:
+                          readOnly:
+                            type: boolean
+                          volumeClaimTemplate:
+                            properties:
+                              metadata:
+                                type: object
+                              spec:
+                                properties:
+                                  accessModes:
+                                    items:
+                                      type: string
+                                    type: array
+                                  dataSource:
+                                    properties:
+                                      apiGroup:
+                                        type: string
+                                      kind:
+                                        type: string
+                                      name:
+                                        type: string
+                                    required:
+                                    - kind
+                                    - name
+                                    type: object
+                                  resources:
+                                    properties:
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                    type: object
+                                  selector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  storageClassName:
+                                    type: string
+                                  volumeMode:
+                                    type: string
+                                  volumeName:
+                                    type: string
+                                type: object
+                            required:
+                            - spec
+                            type: object
+                        type: object
+                      fc:
+                        properties:
+                          fsType:
+                            type: string
+                          lun:
+                            format: int32
+                            type: integer
+                          readOnly:
+                            type: boolean
+                          targetWWNs:
+                            items:
+                              type: string
+                            type: array
+                          wwids:
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      flexVolume:
+                        properties:
+                          driver:
+                            type: string
+                          fsType:
+                            type: string
+                          options:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          readOnly:
+                            type: boolean
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                        required:
+                        - driver
+                        type: object
+                      flocker:
+                        properties:
+                          datasetName:
+                            type: string
+                          datasetUUID:
+                            type: string
+                        type: object
+                      gcePersistentDisk:
+                        properties:
+                          fsType:
+                            type: string
+                          partition:
+                            format: int32
+                            type: integer
+                          pdName:
+                            type: string
+                          readOnly:
+                            type: boolean
+                        required:
+                        - pdName
+                        type: object
+                      gitRepo:
+                        properties:
+                          directory:
+                            type: string
+                          repository:
+                            type: string
+                          revision:
+                            type: string
+                        required:
+                        - repository
+                        type: object
+                      glusterfs:
+                        properties:
+                          endpoints:
+                            type: string
+                          path:
+                            type: string
+                          readOnly:
+                            type: boolean
+                        required:
+                        - endpoints
+                        - path
+                        type: object
+                      hostPath:
+                        properties:
+                          path:
+                            type: string
+                          type:
+                            type: string
+                        required:
+                        - path
+                        type: object
+                      iscsi:
+                        properties:
+                          chapAuthDiscovery:
+                            type: boolean
+                          chapAuthSession:
+                            type: boolean
+                          fsType:
+                            type: string
+                          initiatorName:
+                            type: string
+                          iqn:
+                            type: string
+                          iscsiInterface:
+                            type: string
+                          lun:
+                            format: int32
+                            type: integer
+                          portals:
+                            items:
+                              type: string
+                            type: array
+                          readOnly:
+                            type: boolean
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          targetPortal:
+                            type: string
+                        required:
+                        - iqn
+                        - lun
+                        - targetPortal
+                        type: object
+                      name:
+                        type: string
+                      nfs:
+                        properties:
+                          path:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          server:
+                            type: string
+                        required:
+                        - path
+                        - server
+                        type: object
+                      persistentVolumeClaim:
+                        properties:
+                          claimName:
+                            type: string
+                          readOnly:
+                            type: boolean
+                        required:
+                        - claimName
+                        type: object
+                      photonPersistentDisk:
+                        properties:
+                          fsType:
+                            type: string
+                          pdID:
+                            type: string
+                        required:
+                        - pdID
+                        type: object
+                      portworxVolume:
+                        properties:
+                          fsType:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          volumeID:
+                            type: string
+                        required:
+                        - volumeID
+                        type: object
+                      projected:
+                        properties:
+                          defaultMode:
+                            format: int32
+                            type: integer
+                          sources:
+                            items:
+                              properties:
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        type: object
+                                      type: array
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  type: object
+                                downwardAPI:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          fieldRef:
+                                            properties:
+                                              apiVersion:
+                                                type: string
+                                              fieldPath:
+                                                type: string
+                                            required:
+                                            - fieldPath
+                                            type: object
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                          resourceFieldRef:
+                                            properties:
+                                              containerName:
+                                                type: string
+                                              divisor:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              resource:
+                                                type: string
+                                            required:
+                                            - resource
+                                            type: object
+                                        required:
+                                        - path
+                                        type: object
+                                      type: array
+                                  type: object
+                                secret:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        type: object
+                                      type: array
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  type: object
+                                serviceAccountToken:
+                                  properties:
+                                    audience:
+                                      type: string
+                                    expirationSeconds:
+                                      format: int64
+                                      type: integer
+                                    path:
+                                      type: string
+                                  required:
+                                  - path
+                                  type: object
+                              type: object
+                            type: array
+                        type: object
+                      quobyte:
+                        properties:
+                          group:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          registry:
+                            type: string
+                          tenant:
+                            type: string
+                          user:
+                            type: string
+                          volume:
+                            type: string
+                        required:
+                        - registry
+                        - volume
+                        type: object
+                      rbd:
+                        properties:
+                          fsType:
+                            type: string
+                          image:
+                            type: string
+                          keyring:
+                            type: string
+                          monitors:
+                            items:
+                              type: string
+                            type: array
+                          pool:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          user:
+                            type: string
+                        required:
+                        - image
+                        - monitors
+                        type: object
+                      scaleIO:
+                        properties:
+                          fsType:
+                            type: string
+                          gateway:
+                            type: string
+                          protectionDomain:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          sslEnabled:
+                            type: boolean
+                          storageMode:
+                            type: string
+                          storagePool:
+                            type: string
+                          system:
+                            type: string
+                          volumeName:
+                            type: string
+                        required:
+                        - gateway
+                        - secretRef
+                        - system
+                        type: object
+                      secret:
+                        properties:
+                          defaultMode:
+                            format: int32
+                            type: integer
+                          items:
+                            items:
+                              properties:
+                                key:
+                                  type: string
+                                mode:
+                                  format: int32
+                                  type: integer
+                                path:
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              type: object
+                            type: array
+                          optional:
+                            type: boolean
+                          secretName:
+                            type: string
+                        type: object
+                      storageos:
+                        properties:
+                          fsType:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          volumeName:
+                            type: string
+                          volumeNamespace:
+                            type: string
+                        type: object
+                      vsphereVolume:
+                        properties:
+                          fsType:
+                            type: string
+                          storagePolicyID:
+                            type: string
+                          storagePolicyName:
+                            type: string
+                          volumePath:
+                            type: string
+                        required:
+                        - volumePath
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+              type: object
+            labels:
+              additionalProperties:
+                type: string
+              type: object
+            query:
+              properties:
+                affinity:
+                  properties:
+                    nodeAffinity:
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              preference:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchFields:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                type: object
+                              weight:
+                                format: int32
+                                type: integer
+                            required:
+                            - preference
+                            - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          properties:
+                            nodeSelectorTerms:
+                              items:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchFields:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                type: object
+                              type: array
+                          required:
+                          - nodeSelectorTerms
+                          type: object
+                      type: object
+                    podAffinity:
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              podAffinityTerm:
+                                properties:
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              weight:
+                                format: int32
+                                type: integer
+                            required:
+                            - podAffinityTerm
+                            - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              labelSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              namespaces:
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                type: string
+                            required:
+                            - topologyKey
+                            type: object
+                          type: array
+                      type: object
+                    podAntiAffinity:
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              podAffinityTerm:
+                                properties:
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              weight:
+                                format: int32
+                                type: integer
+                            required:
+                            - podAffinityTerm
+                            - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          items:
+                            properties:
+                              labelSelector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              namespaces:
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                type: string
+                            required:
+                            - topologyKey
+                            type: object
+                          type: array
+                      type: object
+                  type: object
+                annotations:
+                  additionalProperties:
+                    type: string
+                  nullable: true
+                  type: object
+                image:
+                  type: string
+                labels:
+                  additionalProperties:
+                    type: string
+                  type: object
+                nodePort:
+                  format: int32
+                  type: integer
+                options:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                priorityClassName:
+                  type: string
+                replicas:
+                  format: int32
+                  type: integer
+                resources:
+                  nullable: true
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      type: object
+                  type: object
+                securityContext:
+                  properties:
+                    fsGroup:
+                      format: int64
+                      type: integer
+                    fsGroupChangePolicy:
+                      type: string
+                    runAsGroup:
+                      format: int64
+                      type: integer
+                    runAsNonRoot:
+                      type: boolean
+                    runAsUser:
+                      format: int64
+                      type: integer
+                    seLinuxOptions:
+                      properties:
+                        level:
+                          type: string
+                        role:
+                          type: string
+                        type:
+                          type: string
+                        user:
+                          type: string
+                      type: object
+                    seccompProfile:
+                      properties:
+                        localhostProfile:
+                          type: string
+                        type:
+                          type: string
+                      required:
+                      - type
+                      type: object
+                    supplementalGroups:
+                      items:
+                        format: int64
+                        type: integer
+                      type: array
+                    sysctls:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                        required:
+                        - name
+                        - value
+                        type: object
+                      type: array
+                    windowsOptions:
+                      properties:
+                        gmsaCredentialSpec:
+                          type: string
+                        gmsaCredentialSpecName:
+                          type: string
+                        runAsUserName:
+                          type: string
+                      type: object
+                  type: object
+                serviceAccount:
+                  type: string
+                serviceType:
+                  type: string
+                tolerations:
+                  items:
+                    properties:
+                      effect:
+                        type: string
+                      key:
+                        type: string
+                      operator:
+                        type: string
+                      tolerationSeconds:
+                        format: int64
+                        type: integer
+                      value:
+                        type: string
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                tracingEnabled:
+                  type: boolean
+                volumeMounts:
+                  items:
+                    properties:
+                      mountPath:
+                        type: string
+                      mountPropagation:
+                        type: string
+                      name:
+                        type: string
+                      readOnly:
+                        type: boolean
+                      subPath:
+                        type: string
+                      subPathExpr:
+                        type: string
+                    required:
+                    - mountPath
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+                volumes:
+                  items:
+                    properties:
+                      awsElasticBlockStore:
+                        properties:
+                          fsType:
+                            type: string
+                          partition:
+                            format: int32
+                            type: integer
+                          readOnly:
+                            type: boolean
+                          volumeID:
+                            type: string
+                        required:
+                        - volumeID
+                        type: object
+                      azureDisk:
+                        properties:
+                          cachingMode:
+                            type: string
+                          diskName:
+                            type: string
+                          diskURI:
+                            type: string
+                          fsType:
+                            type: string
+                          kind:
+                            type: string
+                          readOnly:
+                            type: boolean
+                        required:
+                        - diskName
+                        - diskURI
+                        type: object
+                      azureFile:
+                        properties:
+                          readOnly:
+                            type: boolean
+                          secretName:
+                            type: string
+                          shareName:
+                            type: string
+                        required:
+                        - secretName
+                        - shareName
+                        type: object
+                      cephfs:
+                        properties:
+                          monitors:
+                            items:
+                              type: string
+                            type: array
+                          path:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          secretFile:
+                            type: string
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          user:
+                            type: string
+                        required:
+                        - monitors
+                        type: object
+                      cinder:
+                        properties:
+                          fsType:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          volumeID:
+                            type: string
+                        required:
+                        - volumeID
+                        type: object
+                      configMap:
+                        properties:
+                          defaultMode:
+                            format: int32
+                            type: integer
+                          items:
+                            items:
+                              properties:
+                                key:
+                                  type: string
+                                mode:
+                                  format: int32
+                                  type: integer
+                                path:
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              type: object
+                            type: array
+                          name:
+                            type: string
+                          optional:
+                            type: boolean
+                        type: object
+                      csi:
+                        properties:
+                          driver:
+                            type: string
+                          fsType:
+                            type: string
+                          nodePublishSecretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          readOnly:
+                            type: boolean
+                          volumeAttributes:
+                            additionalProperties:
+                              type: string
+                            type: object
+                        required:
+                        - driver
+                        type: object
+                      downwardAPI:
+                        properties:
+                          defaultMode:
+                            format: int32
+                            type: integer
+                          items:
+                            items:
+                              properties:
+                                fieldRef:
+                                  properties:
+                                    apiVersion:
+                                      type: string
+                                    fieldPath:
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                mode:
+                                  format: int32
+                                  type: integer
+                                path:
+                                  type: string
+                                resourceFieldRef:
+                                  properties:
+                                    containerName:
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                              required:
+                              - path
+                              type: object
+                            type: array
+                        type: object
+                      emptyDir:
+                        properties:
+                          medium:
+                            type: string
+                          sizeLimit:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        type: object
+                      ephemeral:
+                        properties:
+                          readOnly:
+                            type: boolean
+                          volumeClaimTemplate:
+                            properties:
+                              metadata:
+                                type: object
+                              spec:
+                                properties:
+                                  accessModes:
+                                    items:
+                                      type: string
+                                    type: array
+                                  dataSource:
+                                    properties:
+                                      apiGroup:
+                                        type: string
+                                      kind:
+                                        type: string
+                                      name:
+                                        type: string
+                                    required:
+                                    - kind
+                                    - name
+                                    type: object
+                                  resources:
+                                    properties:
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                    type: object
+                                  selector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  storageClassName:
+                                    type: string
+                                  volumeMode:
+                                    type: string
+                                  volumeName:
+                                    type: string
+                                type: object
+                            required:
+                            - spec
+                            type: object
+                        type: object
+                      fc:
+                        properties:
+                          fsType:
+                            type: string
+                          lun:
+                            format: int32
+                            type: integer
+                          readOnly:
+                            type: boolean
+                          targetWWNs:
+                            items:
+                              type: string
+                            type: array
+                          wwids:
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      flexVolume:
+                        properties:
+                          driver:
+                            type: string
+                          fsType:
+                            type: string
+                          options:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          readOnly:
+                            type: boolean
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                        required:
+                        - driver
+                        type: object
+                      flocker:
+                        properties:
+                          datasetName:
+                            type: string
+                          datasetUUID:
+                            type: string
+                        type: object
+                      gcePersistentDisk:
+                        properties:
+                          fsType:
+                            type: string
+                          partition:
+                            format: int32
+                            type: integer
+                          pdName:
+                            type: string
+                          readOnly:
+                            type: boolean
+                        required:
+                        - pdName
+                        type: object
+                      gitRepo:
+                        properties:
+                          directory:
+                            type: string
+                          repository:
+                            type: string
+                          revision:
+                            type: string
+                        required:
+                        - repository
+                        type: object
+                      glusterfs:
+                        properties:
+                          endpoints:
+                            type: string
+                          path:
+                            type: string
+                          readOnly:
+                            type: boolean
+                        required:
+                        - endpoints
+                        - path
+                        type: object
+                      hostPath:
+                        properties:
+                          path:
+                            type: string
+                          type:
+                            type: string
+                        required:
+                        - path
+                        type: object
+                      iscsi:
+                        properties:
+                          chapAuthDiscovery:
+                            type: boolean
+                          chapAuthSession:
+                            type: boolean
+                          fsType:
+                            type: string
+                          initiatorName:
+                            type: string
+                          iqn:
+                            type: string
+                          iscsiInterface:
+                            type: string
+                          lun:
+                            format: int32
+                            type: integer
+                          portals:
+                            items:
+                              type: string
+                            type: array
+                          readOnly:
+                            type: boolean
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          targetPortal:
+                            type: string
+                        required:
+                        - iqn
+                        - lun
+                        - targetPortal
+                        type: object
+                      name:
+                        type: string
+                      nfs:
+                        properties:
+                          path:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          server:
+                            type: string
+                        required:
+                        - path
+                        - server
+                        type: object
+                      persistentVolumeClaim:
+                        properties:
+                          claimName:
+                            type: string
+                          readOnly:
+                            type: boolean
+                        required:
+                        - claimName
+                        type: object
+                      photonPersistentDisk:
+                        properties:
+                          fsType:
+                            type: string
+                          pdID:
+                            type: string
+                        required:
+                        - pdID
+                        type: object
+                      portworxVolume:
+                        properties:
+                          fsType:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          volumeID:
+                            type: string
+                        required:
+                        - volumeID
+                        type: object
+                      projected:
+                        properties:
+                          defaultMode:
+                            format: int32
+                            type: integer
+                          sources:
+                            items:
+                              properties:
+                                configMap:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        type: object
+                                      type: array
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  type: object
+                                downwardAPI:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          fieldRef:
+                                            properties:
+                                              apiVersion:
+                                                type: string
+                                              fieldPath:
+                                                type: string
+                                            required:
+                                            - fieldPath
+                                            type: object
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                          resourceFieldRef:
+                                            properties:
+                                              containerName:
+                                                type: string
+                                              divisor:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              resource:
+                                                type: string
+                                            required:
+                                            - resource
+                                            type: object
+                                        required:
+                                        - path
+                                        type: object
+                                      type: array
+                                  type: object
+                                secret:
+                                  properties:
+                                    items:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          mode:
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            type: string
+                                        required:
+                                        - key
+                                        - path
+                                        type: object
+                                      type: array
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  type: object
+                                serviceAccountToken:
+                                  properties:
+                                    audience:
+                                      type: string
+                                    expirationSeconds:
+                                      format: int64
+                                      type: integer
+                                    path:
+                                      type: string
+                                  required:
+                                  - path
+                                  type: object
+                              type: object
+                            type: array
+                        type: object
+                      quobyte:
+                        properties:
+                          group:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          registry:
+                            type: string
+                          tenant:
+                            type: string
+                          user:
+                            type: string
+                          volume:
+                            type: string
+                        required:
+                        - registry
+                        - volume
+                        type: object
+                      rbd:
+                        properties:
+                          fsType:
+                            type: string
+                          image:
+                            type: string
+                          keyring:
+                            type: string
+                          monitors:
+                            items:
+                              type: string
+                            type: array
+                          pool:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          user:
+                            type: string
+                        required:
+                        - image
+                        - monitors
+                        type: object
+                      scaleIO:
+                        properties:
+                          fsType:
+                            type: string
+                          gateway:
+                            type: string
+                          protectionDomain:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          sslEnabled:
+                            type: boolean
+                          storageMode:
+                            type: string
+                          storagePool:
+                            type: string
+                          system:
+                            type: string
+                          volumeName:
+                            type: string
+                        required:
+                        - gateway
+                        - secretRef
+                        - system
+                        type: object
+                      secret:
+                        properties:
+                          defaultMode:
+                            format: int32
+                            type: integer
+                          items:
+                            items:
+                              properties:
+                                key:
+                                  type: string
+                                mode:
+                                  format: int32
+                                  type: integer
+                                path:
+                                  type: string
+                              required:
+                              - key
+                              - path
+                              type: object
+                            type: array
+                          optional:
+                            type: boolean
+                          secretName:
+                            type: string
+                        type: object
+                      storageos:
+                        properties:
+                          fsType:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          secretRef:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          volumeName:
+                            type: string
+                          volumeNamespace:
+                            type: string
+                        type: object
+                      vsphereVolume:
+                        properties:
+                          fsType:
+                            type: string
+                          storagePolicyID:
+                            type: string
+                          storagePolicyName:
+                            type: string
+                          volumePath:
+                            type: string
+                        required:
+                        - volumePath
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  type: array
+                  x-kubernetes-list-type: atomic
+              type: object
+            resources:
+              nullable: true
+              properties:
+                limits:
+                  additionalProperties:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  type: object
+                requests:
+                  additionalProperties:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  type: object
+              type: object
+            sampling:
+              properties:
+                options:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+              type: object
+            securityContext:
+              properties:
+                fsGroup:
+                  format: int64
+                  type: integer
+                fsGroupChangePolicy:
+                  type: string
+                runAsGroup:
+                  format: int64
+                  type: integer
+                runAsNonRoot:
+                  type: boolean
+                runAsUser:
+                  format: int64
+                  type: integer
+                seLinuxOptions:
+                  properties:
+                    level:
+                      type: string
+                    role:
+                      type: string
+                    type:
+                      type: string
+                    user:
+                      type: string
+                  type: object
+                seccompProfile:
+                  properties:
+                    localhostProfile:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - type
+                  type: object
+                supplementalGroups:
+                  items:
+                    format: int64
+                    type: integer
+                  type: array
+                sysctls:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                      value:
+                        type: string
+                    required:
+                    - name
+                    - value
+                    type: object
+                  type: array
+                windowsOptions:
+                  properties:
+                    gmsaCredentialSpec:
+                      type: string
+                    gmsaCredentialSpecName:
+                      type: string
+                    runAsUserName:
+                      type: string
+                  type: object
+              type: object
+            serviceAccount:
+              type: string
+            storage:
+              properties:
+                cassandraCreateSchema:
+                  properties:
+                    datacenter:
+                      type: string
+                    enabled:
+                      type: boolean
+                    image:
+                      type: string
+                    mode:
+                      type: string
+                    timeout:
+                      type: string
+                    traceTTL:
+                      type: string
+                    ttlSecondsAfterFinished:
+                      format: int32
+                      type: integer
+                  type: object
+                dependencies:
+                  properties:
+                    affinity:
+                      properties:
+                        nodeAffinity:
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              items:
+                                properties:
+                                  preference:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchFields:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                  weight:
+                                    format: int32
+                                    type: integer
+                                required:
+                                - preference
+                                - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              properties:
+                                nodeSelectorTerms:
+                                  items:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchFields:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                  type: array
+                              required:
+                              - nodeSelectorTerms
+                              type: object
+                          type: object
+                        podAffinity:
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              items:
+                                properties:
+                                  podAffinityTerm:
+                                    properties:
+                                      labelSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        type: string
+                                    required:
+                                    - topologyKey
+                                    type: object
+                                  weight:
+                                    format: int32
+                                    type: integer
+                                required:
+                                - podAffinityTerm
+                                - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              items:
+                                properties:
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              type: array
+                          type: object
+                        podAntiAffinity:
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              items:
+                                properties:
+                                  podAffinityTerm:
+                                    properties:
+                                      labelSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        type: string
+                                    required:
+                                    - topologyKey
+                                    type: object
+                                  weight:
+                                    format: int32
+                                    type: integer
+                                required:
+                                - podAffinityTerm
+                                - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              items:
+                                properties:
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              type: array
+                          type: object
+                      type: object
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      nullable: true
+                      type: object
+                    backoffLimit:
+                      format: int32
+                      type: integer
+                    cassandraClientAuthEnabled:
+                      type: boolean
+                    elasticsearchClientNodeOnly:
+                      type: boolean
+                    elasticsearchNodesWanOnly:
+                      type: boolean
+                    enabled:
+                      type: boolean
+                    image:
+                      type: string
+                    javaOpts:
+                      type: string
+                    labels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    resources:
+                      nullable: true
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type: object
+                      type: object
+                    schedule:
+                      type: string
+                    securityContext:
+                      properties:
+                        fsGroup:
+                          format: int64
+                          type: integer
+                        fsGroupChangePolicy:
+                          type: string
+                        runAsGroup:
+                          format: int64
+                          type: integer
+                        runAsNonRoot:
+                          type: boolean
+                        runAsUser:
+                          format: int64
+                          type: integer
+                        seLinuxOptions:
+                          properties:
+                            level:
+                              type: string
+                            role:
+                              type: string
+                            type:
+                              type: string
+                            user:
+                              type: string
+                          type: object
+                        seccompProfile:
+                          properties:
+                            localhostProfile:
+                              type: string
+                            type:
+                              type: string
+                          required:
+                          - type
+                          type: object
+                        supplementalGroups:
+                          items:
+                            format: int64
+                            type: integer
+                          type: array
+                        sysctls:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        windowsOptions:
+                          properties:
+                            gmsaCredentialSpec:
+                              type: string
+                            gmsaCredentialSpecName:
+                              type: string
+                            runAsUserName:
+                              type: string
+                          type: object
+                      type: object
+                    serviceAccount:
+                      type: string
+                    sparkMaster:
+                      type: string
+                    successfulJobsHistoryLimit:
+                      format: int32
+                      type: integer
+                    tolerations:
+                      items:
+                        properties:
+                          effect:
+                            type: string
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          tolerationSeconds:
+                            format: int64
+                            type: integer
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    ttlSecondsAfterFinished:
+                      format: int32
+                      type: integer
+                    volumeMounts:
+                      items:
+                        properties:
+                          mountPath:
+                            type: string
+                          mountPropagation:
+                            type: string
+                          name:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          subPath:
+                            type: string
+                          subPathExpr:
+                            type: string
+                        required:
+                        - mountPath
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    volumes:
+                      items:
+                        properties:
+                          awsElasticBlockStore:
+                            properties:
+                              fsType:
+                                type: string
+                              partition:
+                                format: int32
+                                type: integer
+                              readOnly:
+                                type: boolean
+                              volumeID:
+                                type: string
+                            required:
+                            - volumeID
+                            type: object
+                          azureDisk:
+                            properties:
+                              cachingMode:
+                                type: string
+                              diskName:
+                                type: string
+                              diskURI:
+                                type: string
+                              fsType:
+                                type: string
+                              kind:
+                                type: string
+                              readOnly:
+                                type: boolean
+                            required:
+                            - diskName
+                            - diskURI
+                            type: object
+                          azureFile:
+                            properties:
+                              readOnly:
+                                type: boolean
+                              secretName:
+                                type: string
+                              shareName:
+                                type: string
+                            required:
+                            - secretName
+                            - shareName
+                            type: object
+                          cephfs:
+                            properties:
+                              monitors:
+                                items:
+                                  type: string
+                                type: array
+                              path:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              secretFile:
+                                type: string
+                              secretRef:
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                              user:
+                                type: string
+                            required:
+                            - monitors
+                            type: object
+                          cinder:
+                            properties:
+                              fsType:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              secretRef:
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                              volumeID:
+                                type: string
+                            required:
+                            - volumeID
+                            type: object
+                          configMap:
+                            properties:
+                              defaultMode:
+                                format: int32
+                                type: integer
+                              items:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    mode:
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  type: object
+                                type: array
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                          csi:
+                            properties:
+                              driver:
+                                type: string
+                              fsType:
+                                type: string
+                              nodePublishSecretRef:
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                              readOnly:
+                                type: boolean
+                              volumeAttributes:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            required:
+                            - driver
+                            type: object
+                          downwardAPI:
+                            properties:
+                              defaultMode:
+                                format: int32
+                                type: integer
+                              items:
+                                items:
+                                  properties:
+                                    fieldRef:
+                                      properties:
+                                        apiVersion:
+                                          type: string
+                                        fieldPath:
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    mode:
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      type: string
+                                    resourceFieldRef:
+                                      properties:
+                                        containerName:
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                  required:
+                                  - path
+                                  type: object
+                                type: array
+                            type: object
+                          emptyDir:
+                            properties:
+                              medium:
+                                type: string
+                              sizeLimit:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          ephemeral:
+                            properties:
+                              readOnly:
+                                type: boolean
+                              volumeClaimTemplate:
+                                properties:
+                                  metadata:
+                                    type: object
+                                  spec:
+                                    properties:
+                                      accessModes:
+                                        items:
+                                          type: string
+                                        type: array
+                                      dataSource:
+                                        properties:
+                                          apiGroup:
+                                            type: string
+                                          kind:
+                                            type: string
+                                          name:
+                                            type: string
+                                        required:
+                                        - kind
+                                        - name
+                                        type: object
+                                      resources:
+                                        properties:
+                                          limits:
+                                            additionalProperties:
                                               anyOf:
                                               - type: integer
                                               - type: string
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
-                                            resource:
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
+                                      selector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
                                               type: string
-                                          required:
-                                          - resource
-                                          type: object
-                                      required:
-                                      - path
-                                      type: object
-                                    type: array
+                                            type: object
+                                        type: object
+                                      storageClassName:
+                                        type: string
+                                      volumeMode:
+                                        type: string
+                                      volumeName:
+                                        type: string
+                                    type: object
+                                required:
+                                - spec
                                 type: object
-                              secret:
+                            type: object
+                          fc:
+                            properties:
+                              fsType:
+                                type: string
+                              lun:
+                                format: int32
+                                type: integer
+                              readOnly:
+                                type: boolean
+                              targetWWNs:
+                                items:
+                                  type: string
+                                type: array
+                              wwids:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          flexVolume:
+                            properties:
+                              driver:
+                                type: string
+                              fsType:
+                                type: string
+                              options:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              readOnly:
+                                type: boolean
+                              secretRef:
                                 properties:
-                                  items:
-                                    items:
+                                  name:
+                                    type: string
+                                type: object
+                            required:
+                            - driver
+                            type: object
+                          flocker:
+                            properties:
+                              datasetName:
+                                type: string
+                              datasetUUID:
+                                type: string
+                            type: object
+                          gcePersistentDisk:
+                            properties:
+                              fsType:
+                                type: string
+                              partition:
+                                format: int32
+                                type: integer
+                              pdName:
+                                type: string
+                              readOnly:
+                                type: boolean
+                            required:
+                            - pdName
+                            type: object
+                          gitRepo:
+                            properties:
+                              directory:
+                                type: string
+                              repository:
+                                type: string
+                              revision:
+                                type: string
+                            required:
+                            - repository
+                            type: object
+                          glusterfs:
+                            properties:
+                              endpoints:
+                                type: string
+                              path:
+                                type: string
+                              readOnly:
+                                type: boolean
+                            required:
+                            - endpoints
+                            - path
+                            type: object
+                          hostPath:
+                            properties:
+                              path:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                            - path
+                            type: object
+                          iscsi:
+                            properties:
+                              chapAuthDiscovery:
+                                type: boolean
+                              chapAuthSession:
+                                type: boolean
+                              fsType:
+                                type: string
+                              initiatorName:
+                                type: string
+                              iqn:
+                                type: string
+                              iscsiInterface:
+                                type: string
+                              lun:
+                                format: int32
+                                type: integer
+                              portals:
+                                items:
+                                  type: string
+                                type: array
+                              readOnly:
+                                type: boolean
+                              secretRef:
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                              targetPortal:
+                                type: string
+                            required:
+                            - iqn
+                            - lun
+                            - targetPortal
+                            type: object
+                          name:
+                            type: string
+                          nfs:
+                            properties:
+                              path:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              server:
+                                type: string
+                            required:
+                            - path
+                            - server
+                            type: object
+                          persistentVolumeClaim:
+                            properties:
+                              claimName:
+                                type: string
+                              readOnly:
+                                type: boolean
+                            required:
+                            - claimName
+                            type: object
+                          photonPersistentDisk:
+                            properties:
+                              fsType:
+                                type: string
+                              pdID:
+                                type: string
+                            required:
+                            - pdID
+                            type: object
+                          portworxVolume:
+                            properties:
+                              fsType:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              volumeID:
+                                type: string
+                            required:
+                            - volumeID
+                            type: object
+                          projected:
+                            properties:
+                              defaultMode:
+                                format: int32
+                                type: integer
+                              sources:
+                                items:
+                                  properties:
+                                    configMap:
                                       properties:
-                                        key:
+                                        items:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              mode:
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                        name:
                                           type: string
-                                        mode:
-                                          format: int32
+                                        optional:
+                                          type: boolean
+                                      type: object
+                                    downwardAPI:
+                                      properties:
+                                        items:
+                                          items:
+                                            properties:
+                                              fieldRef:
+                                                properties:
+                                                  apiVersion:
+                                                    type: string
+                                                  fieldPath:
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                              mode:
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                type: string
+                                              resourceFieldRef:
+                                                properties:
+                                                  containerName:
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                            required:
+                                            - path
+                                            type: object
+                                          type: array
+                                      type: object
+                                    secret:
+                                      properties:
+                                        items:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              mode:
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      type: object
+                                    serviceAccountToken:
+                                      properties:
+                                        audience:
+                                          type: string
+                                        expirationSeconds:
+                                          format: int64
                                           type: integer
                                         path:
                                           type: string
                                       required:
-                                      - key
                                       - path
                                       type: object
-                                    type: array
-                                  name:
-                                    type: string
-                                  optional:
-                                    type: boolean
-                                type: object
-                              serviceAccountToken:
-                                properties:
-                                  audience:
-                                    type: string
-                                  expirationSeconds:
-                                    format: int64
-                                    type: integer
-                                  path:
-                                    type: string
-                                required:
-                                - path
-                                type: object
+                                  type: object
+                                type: array
                             type: object
-                          type: array
-                      type: object
-                    quobyte:
-                      properties:
-                        group:
-                          type: string
-                        readOnly:
-                          type: boolean
-                        registry:
-                          type: string
-                        tenant:
-                          type: string
-                        user:
-                          type: string
-                        volume:
-                          type: string
-                      required:
-                      - registry
-                      - volume
-                      type: object
-                    rbd:
-                      properties:
-                        fsType:
-                          type: string
-                        image:
-                          type: string
-                        keyring:
-                          type: string
-                        monitors:
-                          items:
-                            type: string
-                          type: array
-                        pool:
-                          type: string
-                        readOnly:
-                          type: boolean
-                        secretRef:
-                          properties:
-                            name:
-                              type: string
-                          type: object
-                        user:
-                          type: string
-                      required:
-                      - image
-                      - monitors
-                      type: object
-                    scaleIO:
-                      properties:
-                        fsType:
-                          type: string
-                        gateway:
-                          type: string
-                        protectionDomain:
-                          type: string
-                        readOnly:
-                          type: boolean
-                        secretRef:
-                          properties:
-                            name:
-                              type: string
-                          type: object
-                        sslEnabled:
-                          type: boolean
-                        storageMode:
-                          type: string
-                        storagePool:
-                          type: string
-                        system:
-                          type: string
-                        volumeName:
-                          type: string
-                      required:
-                      - gateway
-                      - secretRef
-                      - system
-                      type: object
-                    secret:
-                      properties:
-                        defaultMode:
-                          format: int32
-                          type: integer
-                        items:
-                          items:
+                          quobyte:
                             properties:
-                              key:
+                              group:
                                 type: string
-                              mode:
-                                format: int32
-                                type: integer
-                              path:
+                              readOnly:
+                                type: boolean
+                              registry:
+                                type: string
+                              tenant:
+                                type: string
+                              user:
+                                type: string
+                              volume:
                                 type: string
                             required:
-                            - key
-                            - path
+                            - registry
+                            - volume
                             type: object
-                          type: array
-                        optional:
-                          type: boolean
-                        secretName:
+                          rbd:
+                            properties:
+                              fsType:
+                                type: string
+                              image:
+                                type: string
+                              keyring:
+                                type: string
+                              monitors:
+                                items:
+                                  type: string
+                                type: array
+                              pool:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              secretRef:
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                              user:
+                                type: string
+                            required:
+                            - image
+                            - monitors
+                            type: object
+                          scaleIO:
+                            properties:
+                              fsType:
+                                type: string
+                              gateway:
+                                type: string
+                              protectionDomain:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              secretRef:
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                              sslEnabled:
+                                type: boolean
+                              storageMode:
+                                type: string
+                              storagePool:
+                                type: string
+                              system:
+                                type: string
+                              volumeName:
+                                type: string
+                            required:
+                            - gateway
+                            - secretRef
+                            - system
+                            type: object
+                          secret:
+                            properties:
+                              defaultMode:
+                                format: int32
+                                type: integer
+                              items:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    mode:
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  type: object
+                                type: array
+                              optional:
+                                type: boolean
+                              secretName:
+                                type: string
+                            type: object
+                          storageos:
+                            properties:
+                              fsType:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              secretRef:
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                              volumeName:
+                                type: string
+                              volumeNamespace:
+                                type: string
+                            type: object
+                          vsphereVolume:
+                            properties:
+                              fsType:
+                                type: string
+                              storagePolicyID:
+                                type: string
+                              storagePolicyName:
+                                type: string
+                              volumePath:
+                                type: string
+                            required:
+                            - volumePath
+                            type: object
+                        required:
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                  type: object
+                elasticsearch:
+                  properties:
+                    image:
+                      type: string
+                    nodeCount:
+                      format: int32
+                      type: integer
+                    nodeSelector:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    redundancyPolicy:
+                      type: string
+                    resources:
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type: object
+                      type: object
+                    storage:
+                      properties:
+                        size:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        storageClassName:
                           type: string
                       type: object
-                    storageos:
+                    tolerations:
+                      items:
+                        properties:
+                          effect:
+                            type: string
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          tolerationSeconds:
+                            format: int64
+                            type: integer
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                  type: object
+                esIndexCleaner:
+                  properties:
+                    affinity:
                       properties:
-                        fsType:
-                          type: string
-                        readOnly:
-                          type: boolean
-                        secretRef:
+                        nodeAffinity:
                           properties:
-                            name:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              items:
+                                properties:
+                                  preference:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchFields:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                  weight:
+                                    format: int32
+                                    type: integer
+                                required:
+                                - preference
+                                - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              properties:
+                                nodeSelectorTerms:
+                                  items:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchFields:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                  type: array
+                              required:
+                              - nodeSelectorTerms
+                              type: object
+                          type: object
+                        podAffinity:
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              items:
+                                properties:
+                                  podAffinityTerm:
+                                    properties:
+                                      labelSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        type: string
+                                    required:
+                                    - topologyKey
+                                    type: object
+                                  weight:
+                                    format: int32
+                                    type: integer
+                                required:
+                                - podAffinityTerm
+                                - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              items:
+                                properties:
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              type: array
+                          type: object
+                        podAntiAffinity:
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              items:
+                                properties:
+                                  podAffinityTerm:
+                                    properties:
+                                      labelSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        type: string
+                                    required:
+                                    - topologyKey
+                                    type: object
+                                  weight:
+                                    format: int32
+                                    type: integer
+                                required:
+                                - podAffinityTerm
+                                - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              items:
+                                properties:
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              type: array
+                          type: object
+                      type: object
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      nullable: true
+                      type: object
+                    backoffLimit:
+                      format: int32
+                      type: integer
+                    enabled:
+                      type: boolean
+                    image:
+                      type: string
+                    labels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    numberOfDays:
+                      type: integer
+                    resources:
+                      nullable: true
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type: object
+                      type: object
+                    schedule:
+                      type: string
+                    securityContext:
+                      properties:
+                        fsGroup:
+                          format: int64
+                          type: integer
+                        fsGroupChangePolicy:
+                          type: string
+                        runAsGroup:
+                          format: int64
+                          type: integer
+                        runAsNonRoot:
+                          type: boolean
+                        runAsUser:
+                          format: int64
+                          type: integer
+                        seLinuxOptions:
+                          properties:
+                            level:
+                              type: string
+                            role:
+                              type: string
+                            type:
+                              type: string
+                            user:
                               type: string
                           type: object
-                        volumeName:
-                          type: string
-                        volumeNamespace:
-                          type: string
+                        seccompProfile:
+                          properties:
+                            localhostProfile:
+                              type: string
+                            type:
+                              type: string
+                          required:
+                          - type
+                          type: object
+                        supplementalGroups:
+                          items:
+                            format: int64
+                            type: integer
+                          type: array
+                        sysctls:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        windowsOptions:
+                          properties:
+                            gmsaCredentialSpec:
+                              type: string
+                            gmsaCredentialSpecName:
+                              type: string
+                            runAsUserName:
+                              type: string
+                          type: object
                       type: object
-                    vsphereVolume:
-                      properties:
-                        fsType:
-                          type: string
-                        storagePolicyID:
-                          type: string
-                        storagePolicyName:
-                          type: string
-                        volumePath:
-                          type: string
-                      required:
-                      - volumePath
-                      type: object
-                  required:
-                  - name
+                    serviceAccount:
+                      type: string
+                    successfulJobsHistoryLimit:
+                      format: int32
+                      type: integer
+                    tolerations:
+                      items:
+                        properties:
+                          effect:
+                            type: string
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          tolerationSeconds:
+                            format: int64
+                            type: integer
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    ttlSecondsAfterFinished:
+                      format: int32
+                      type: integer
+                    volumeMounts:
+                      items:
+                        properties:
+                          mountPath:
+                            type: string
+                          mountPropagation:
+                            type: string
+                          name:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          subPath:
+                            type: string
+                          subPathExpr:
+                            type: string
+                        required:
+                        - mountPath
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    volumes:
+                      items:
+                        properties:
+                          awsElasticBlockStore:
+                            properties:
+                              fsType:
+                                type: string
+                              partition:
+                                format: int32
+                                type: integer
+                              readOnly:
+                                type: boolean
+                              volumeID:
+                                type: string
+                            required:
+                            - volumeID
+                            type: object
+                          azureDisk:
+                            properties:
+                              cachingMode:
+                                type: string
+                              diskName:
+                                type: string
+                              diskURI:
+                                type: string
+                              fsType:
+                                type: string
+                              kind:
+                                type: string
+                              readOnly:
+                                type: boolean
+                            required:
+                            - diskName
+                            - diskURI
+                            type: object
+                          azureFile:
+                            properties:
+                              readOnly:
+                                type: boolean
+                              secretName:
+                                type: string
+                              shareName:
+                                type: string
+                            required:
+                            - secretName
+                            - shareName
+                            type: object
+                          cephfs:
+                            properties:
+                              monitors:
+                                items:
+                                  type: string
+                                type: array
+                              path:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              secretFile:
+                                type: string
+                              secretRef:
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                              user:
+                                type: string
+                            required:
+                            - monitors
+                            type: object
+                          cinder:
+                            properties:
+                              fsType:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              secretRef:
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                              volumeID:
+                                type: string
+                            required:
+                            - volumeID
+                            type: object
+                          configMap:
+                            properties:
+                              defaultMode:
+                                format: int32
+                                type: integer
+                              items:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    mode:
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  type: object
+                                type: array
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                          csi:
+                            properties:
+                              driver:
+                                type: string
+                              fsType:
+                                type: string
+                              nodePublishSecretRef:
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                              readOnly:
+                                type: boolean
+                              volumeAttributes:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            required:
+                            - driver
+                            type: object
+                          downwardAPI:
+                            properties:
+                              defaultMode:
+                                format: int32
+                                type: integer
+                              items:
+                                items:
+                                  properties:
+                                    fieldRef:
+                                      properties:
+                                        apiVersion:
+                                          type: string
+                                        fieldPath:
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    mode:
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      type: string
+                                    resourceFieldRef:
+                                      properties:
+                                        containerName:
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                  required:
+                                  - path
+                                  type: object
+                                type: array
+                            type: object
+                          emptyDir:
+                            properties:
+                              medium:
+                                type: string
+                              sizeLimit:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          ephemeral:
+                            properties:
+                              readOnly:
+                                type: boolean
+                              volumeClaimTemplate:
+                                properties:
+                                  metadata:
+                                    type: object
+                                  spec:
+                                    properties:
+                                      accessModes:
+                                        items:
+                                          type: string
+                                        type: array
+                                      dataSource:
+                                        properties:
+                                          apiGroup:
+                                            type: string
+                                          kind:
+                                            type: string
+                                          name:
+                                            type: string
+                                        required:
+                                        - kind
+                                        - name
+                                        type: object
+                                      resources:
+                                        properties:
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
+                                      selector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      storageClassName:
+                                        type: string
+                                      volumeMode:
+                                        type: string
+                                      volumeName:
+                                        type: string
+                                    type: object
+                                required:
+                                - spec
+                                type: object
+                            type: object
+                          fc:
+                            properties:
+                              fsType:
+                                type: string
+                              lun:
+                                format: int32
+                                type: integer
+                              readOnly:
+                                type: boolean
+                              targetWWNs:
+                                items:
+                                  type: string
+                                type: array
+                              wwids:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          flexVolume:
+                            properties:
+                              driver:
+                                type: string
+                              fsType:
+                                type: string
+                              options:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              readOnly:
+                                type: boolean
+                              secretRef:
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                            required:
+                            - driver
+                            type: object
+                          flocker:
+                            properties:
+                              datasetName:
+                                type: string
+                              datasetUUID:
+                                type: string
+                            type: object
+                          gcePersistentDisk:
+                            properties:
+                              fsType:
+                                type: string
+                              partition:
+                                format: int32
+                                type: integer
+                              pdName:
+                                type: string
+                              readOnly:
+                                type: boolean
+                            required:
+                            - pdName
+                            type: object
+                          gitRepo:
+                            properties:
+                              directory:
+                                type: string
+                              repository:
+                                type: string
+                              revision:
+                                type: string
+                            required:
+                            - repository
+                            type: object
+                          glusterfs:
+                            properties:
+                              endpoints:
+                                type: string
+                              path:
+                                type: string
+                              readOnly:
+                                type: boolean
+                            required:
+                            - endpoints
+                            - path
+                            type: object
+                          hostPath:
+                            properties:
+                              path:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                            - path
+                            type: object
+                          iscsi:
+                            properties:
+                              chapAuthDiscovery:
+                                type: boolean
+                              chapAuthSession:
+                                type: boolean
+                              fsType:
+                                type: string
+                              initiatorName:
+                                type: string
+                              iqn:
+                                type: string
+                              iscsiInterface:
+                                type: string
+                              lun:
+                                format: int32
+                                type: integer
+                              portals:
+                                items:
+                                  type: string
+                                type: array
+                              readOnly:
+                                type: boolean
+                              secretRef:
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                              targetPortal:
+                                type: string
+                            required:
+                            - iqn
+                            - lun
+                            - targetPortal
+                            type: object
+                          name:
+                            type: string
+                          nfs:
+                            properties:
+                              path:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              server:
+                                type: string
+                            required:
+                            - path
+                            - server
+                            type: object
+                          persistentVolumeClaim:
+                            properties:
+                              claimName:
+                                type: string
+                              readOnly:
+                                type: boolean
+                            required:
+                            - claimName
+                            type: object
+                          photonPersistentDisk:
+                            properties:
+                              fsType:
+                                type: string
+                              pdID:
+                                type: string
+                            required:
+                            - pdID
+                            type: object
+                          portworxVolume:
+                            properties:
+                              fsType:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              volumeID:
+                                type: string
+                            required:
+                            - volumeID
+                            type: object
+                          projected:
+                            properties:
+                              defaultMode:
+                                format: int32
+                                type: integer
+                              sources:
+                                items:
+                                  properties:
+                                    configMap:
+                                      properties:
+                                        items:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              mode:
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      type: object
+                                    downwardAPI:
+                                      properties:
+                                        items:
+                                          items:
+                                            properties:
+                                              fieldRef:
+                                                properties:
+                                                  apiVersion:
+                                                    type: string
+                                                  fieldPath:
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                              mode:
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                type: string
+                                              resourceFieldRef:
+                                                properties:
+                                                  containerName:
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                            required:
+                                            - path
+                                            type: object
+                                          type: array
+                                      type: object
+                                    secret:
+                                      properties:
+                                        items:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              mode:
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      type: object
+                                    serviceAccountToken:
+                                      properties:
+                                        audience:
+                                          type: string
+                                        expirationSeconds:
+                                          format: int64
+                                          type: integer
+                                        path:
+                                          type: string
+                                      required:
+                                      - path
+                                      type: object
+                                  type: object
+                                type: array
+                            type: object
+                          quobyte:
+                            properties:
+                              group:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              registry:
+                                type: string
+                              tenant:
+                                type: string
+                              user:
+                                type: string
+                              volume:
+                                type: string
+                            required:
+                            - registry
+                            - volume
+                            type: object
+                          rbd:
+                            properties:
+                              fsType:
+                                type: string
+                              image:
+                                type: string
+                              keyring:
+                                type: string
+                              monitors:
+                                items:
+                                  type: string
+                                type: array
+                              pool:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              secretRef:
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                              user:
+                                type: string
+                            required:
+                            - image
+                            - monitors
+                            type: object
+                          scaleIO:
+                            properties:
+                              fsType:
+                                type: string
+                              gateway:
+                                type: string
+                              protectionDomain:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              secretRef:
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                              sslEnabled:
+                                type: boolean
+                              storageMode:
+                                type: string
+                              storagePool:
+                                type: string
+                              system:
+                                type: string
+                              volumeName:
+                                type: string
+                            required:
+                            - gateway
+                            - secretRef
+                            - system
+                            type: object
+                          secret:
+                            properties:
+                              defaultMode:
+                                format: int32
+                                type: integer
+                              items:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    mode:
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  type: object
+                                type: array
+                              optional:
+                                type: boolean
+                              secretName:
+                                type: string
+                            type: object
+                          storageos:
+                            properties:
+                              fsType:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              secretRef:
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                              volumeName:
+                                type: string
+                              volumeNamespace:
+                                type: string
+                            type: object
+                          vsphereVolume:
+                            properties:
+                              fsType:
+                                type: string
+                              storagePolicyID:
+                                type: string
+                              storagePolicyName:
+                                type: string
+                              volumePath:
+                                type: string
+                            required:
+                            - volumePath
+                            type: object
+                        required:
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
                   type: object
-                type: array
-                x-kubernetes-list-type: atomic
-            type: object
-          status:
-            properties:
-              phase:
-                type: string
-              version:
-                type: string
-            required:
-            - phase
-            - version
-            type: object
-        type: object
+                esRollover:
+                  properties:
+                    affinity:
+                      properties:
+                        nodeAffinity:
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              items:
+                                properties:
+                                  preference:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchFields:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                  weight:
+                                    format: int32
+                                    type: integer
+                                required:
+                                - preference
+                                - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              properties:
+                                nodeSelectorTerms:
+                                  items:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchFields:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                  type: array
+                              required:
+                              - nodeSelectorTerms
+                              type: object
+                          type: object
+                        podAffinity:
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              items:
+                                properties:
+                                  podAffinityTerm:
+                                    properties:
+                                      labelSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        type: string
+                                    required:
+                                    - topologyKey
+                                    type: object
+                                  weight:
+                                    format: int32
+                                    type: integer
+                                required:
+                                - podAffinityTerm
+                                - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              items:
+                                properties:
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              type: array
+                          type: object
+                        podAntiAffinity:
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              items:
+                                properties:
+                                  podAffinityTerm:
+                                    properties:
+                                      labelSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        type: string
+                                    required:
+                                    - topologyKey
+                                    type: object
+                                  weight:
+                                    format: int32
+                                    type: integer
+                                required:
+                                - podAffinityTerm
+                                - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              items:
+                                properties:
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              type: array
+                          type: object
+                      type: object
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      nullable: true
+                      type: object
+                    backoffLimit:
+                      format: int32
+                      type: integer
+                    conditions:
+                      type: string
+                    image:
+                      type: string
+                    labels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    readTTL:
+                      type: string
+                    resources:
+                      nullable: true
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type: object
+                      type: object
+                    schedule:
+                      type: string
+                    securityContext:
+                      properties:
+                        fsGroup:
+                          format: int64
+                          type: integer
+                        fsGroupChangePolicy:
+                          type: string
+                        runAsGroup:
+                          format: int64
+                          type: integer
+                        runAsNonRoot:
+                          type: boolean
+                        runAsUser:
+                          format: int64
+                          type: integer
+                        seLinuxOptions:
+                          properties:
+                            level:
+                              type: string
+                            role:
+                              type: string
+                            type:
+                              type: string
+                            user:
+                              type: string
+                          type: object
+                        seccompProfile:
+                          properties:
+                            localhostProfile:
+                              type: string
+                            type:
+                              type: string
+                          required:
+                          - type
+                          type: object
+                        supplementalGroups:
+                          items:
+                            format: int64
+                            type: integer
+                          type: array
+                        sysctls:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        windowsOptions:
+                          properties:
+                            gmsaCredentialSpec:
+                              type: string
+                            gmsaCredentialSpecName:
+                              type: string
+                            runAsUserName:
+                              type: string
+                          type: object
+                      type: object
+                    serviceAccount:
+                      type: string
+                    successfulJobsHistoryLimit:
+                      format: int32
+                      type: integer
+                    tolerations:
+                      items:
+                        properties:
+                          effect:
+                            type: string
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          tolerationSeconds:
+                            format: int64
+                            type: integer
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    ttlSecondsAfterFinished:
+                      format: int32
+                      type: integer
+                    volumeMounts:
+                      items:
+                        properties:
+                          mountPath:
+                            type: string
+                          mountPropagation:
+                            type: string
+                          name:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          subPath:
+                            type: string
+                          subPathExpr:
+                            type: string
+                        required:
+                        - mountPath
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    volumes:
+                      items:
+                        properties:
+                          awsElasticBlockStore:
+                            properties:
+                              fsType:
+                                type: string
+                              partition:
+                                format: int32
+                                type: integer
+                              readOnly:
+                                type: boolean
+                              volumeID:
+                                type: string
+                            required:
+                            - volumeID
+                            type: object
+                          azureDisk:
+                            properties:
+                              cachingMode:
+                                type: string
+                              diskName:
+                                type: string
+                              diskURI:
+                                type: string
+                              fsType:
+                                type: string
+                              kind:
+                                type: string
+                              readOnly:
+                                type: boolean
+                            required:
+                            - diskName
+                            - diskURI
+                            type: object
+                          azureFile:
+                            properties:
+                              readOnly:
+                                type: boolean
+                              secretName:
+                                type: string
+                              shareName:
+                                type: string
+                            required:
+                            - secretName
+                            - shareName
+                            type: object
+                          cephfs:
+                            properties:
+                              monitors:
+                                items:
+                                  type: string
+                                type: array
+                              path:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              secretFile:
+                                type: string
+                              secretRef:
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                              user:
+                                type: string
+                            required:
+                            - monitors
+                            type: object
+                          cinder:
+                            properties:
+                              fsType:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              secretRef:
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                              volumeID:
+                                type: string
+                            required:
+                            - volumeID
+                            type: object
+                          configMap:
+                            properties:
+                              defaultMode:
+                                format: int32
+                                type: integer
+                              items:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    mode:
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  type: object
+                                type: array
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                          csi:
+                            properties:
+                              driver:
+                                type: string
+                              fsType:
+                                type: string
+                              nodePublishSecretRef:
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                              readOnly:
+                                type: boolean
+                              volumeAttributes:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                            required:
+                            - driver
+                            type: object
+                          downwardAPI:
+                            properties:
+                              defaultMode:
+                                format: int32
+                                type: integer
+                              items:
+                                items:
+                                  properties:
+                                    fieldRef:
+                                      properties:
+                                        apiVersion:
+                                          type: string
+                                        fieldPath:
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                    mode:
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      type: string
+                                    resourceFieldRef:
+                                      properties:
+                                        containerName:
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                  required:
+                                  - path
+                                  type: object
+                                type: array
+                            type: object
+                          emptyDir:
+                            properties:
+                              medium:
+                                type: string
+                              sizeLimit:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          ephemeral:
+                            properties:
+                              readOnly:
+                                type: boolean
+                              volumeClaimTemplate:
+                                properties:
+                                  metadata:
+                                    type: object
+                                  spec:
+                                    properties:
+                                      accessModes:
+                                        items:
+                                          type: string
+                                        type: array
+                                      dataSource:
+                                        properties:
+                                          apiGroup:
+                                            type: string
+                                          kind:
+                                            type: string
+                                          name:
+                                            type: string
+                                        required:
+                                        - kind
+                                        - name
+                                        type: object
+                                      resources:
+                                        properties:
+                                          limits:
+                                            additionalProperties:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              anyOf:
+                                              - type: integer
+                                              - type: string
+                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                              x-kubernetes-int-or-string: true
+                                            type: object
+                                        type: object
+                                      selector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      storageClassName:
+                                        type: string
+                                      volumeMode:
+                                        type: string
+                                      volumeName:
+                                        type: string
+                                    type: object
+                                required:
+                                - spec
+                                type: object
+                            type: object
+                          fc:
+                            properties:
+                              fsType:
+                                type: string
+                              lun:
+                                format: int32
+                                type: integer
+                              readOnly:
+                                type: boolean
+                              targetWWNs:
+                                items:
+                                  type: string
+                                type: array
+                              wwids:
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          flexVolume:
+                            properties:
+                              driver:
+                                type: string
+                              fsType:
+                                type: string
+                              options:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              readOnly:
+                                type: boolean
+                              secretRef:
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                            required:
+                            - driver
+                            type: object
+                          flocker:
+                            properties:
+                              datasetName:
+                                type: string
+                              datasetUUID:
+                                type: string
+                            type: object
+                          gcePersistentDisk:
+                            properties:
+                              fsType:
+                                type: string
+                              partition:
+                                format: int32
+                                type: integer
+                              pdName:
+                                type: string
+                              readOnly:
+                                type: boolean
+                            required:
+                            - pdName
+                            type: object
+                          gitRepo:
+                            properties:
+                              directory:
+                                type: string
+                              repository:
+                                type: string
+                              revision:
+                                type: string
+                            required:
+                            - repository
+                            type: object
+                          glusterfs:
+                            properties:
+                              endpoints:
+                                type: string
+                              path:
+                                type: string
+                              readOnly:
+                                type: boolean
+                            required:
+                            - endpoints
+                            - path
+                            type: object
+                          hostPath:
+                            properties:
+                              path:
+                                type: string
+                              type:
+                                type: string
+                            required:
+                            - path
+                            type: object
+                          iscsi:
+                            properties:
+                              chapAuthDiscovery:
+                                type: boolean
+                              chapAuthSession:
+                                type: boolean
+                              fsType:
+                                type: string
+                              initiatorName:
+                                type: string
+                              iqn:
+                                type: string
+                              iscsiInterface:
+                                type: string
+                              lun:
+                                format: int32
+                                type: integer
+                              portals:
+                                items:
+                                  type: string
+                                type: array
+                              readOnly:
+                                type: boolean
+                              secretRef:
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                              targetPortal:
+                                type: string
+                            required:
+                            - iqn
+                            - lun
+                            - targetPortal
+                            type: object
+                          name:
+                            type: string
+                          nfs:
+                            properties:
+                              path:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              server:
+                                type: string
+                            required:
+                            - path
+                            - server
+                            type: object
+                          persistentVolumeClaim:
+                            properties:
+                              claimName:
+                                type: string
+                              readOnly:
+                                type: boolean
+                            required:
+                            - claimName
+                            type: object
+                          photonPersistentDisk:
+                            properties:
+                              fsType:
+                                type: string
+                              pdID:
+                                type: string
+                            required:
+                            - pdID
+                            type: object
+                          portworxVolume:
+                            properties:
+                              fsType:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              volumeID:
+                                type: string
+                            required:
+                            - volumeID
+                            type: object
+                          projected:
+                            properties:
+                              defaultMode:
+                                format: int32
+                                type: integer
+                              sources:
+                                items:
+                                  properties:
+                                    configMap:
+                                      properties:
+                                        items:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              mode:
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      type: object
+                                    downwardAPI:
+                                      properties:
+                                        items:
+                                          items:
+                                            properties:
+                                              fieldRef:
+                                                properties:
+                                                  apiVersion:
+                                                    type: string
+                                                  fieldPath:
+                                                    type: string
+                                                required:
+                                                - fieldPath
+                                                type: object
+                                              mode:
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                type: string
+                                              resourceFieldRef:
+                                                properties:
+                                                  containerName:
+                                                    type: string
+                                                  divisor:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                    x-kubernetes-int-or-string: true
+                                                  resource:
+                                                    type: string
+                                                required:
+                                                - resource
+                                                type: object
+                                            required:
+                                            - path
+                                            type: object
+                                          type: array
+                                      type: object
+                                    secret:
+                                      properties:
+                                        items:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              mode:
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                type: string
+                                            required:
+                                            - key
+                                            - path
+                                            type: object
+                                          type: array
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      type: object
+                                    serviceAccountToken:
+                                      properties:
+                                        audience:
+                                          type: string
+                                        expirationSeconds:
+                                          format: int64
+                                          type: integer
+                                        path:
+                                          type: string
+                                      required:
+                                      - path
+                                      type: object
+                                  type: object
+                                type: array
+                            type: object
+                          quobyte:
+                            properties:
+                              group:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              registry:
+                                type: string
+                              tenant:
+                                type: string
+                              user:
+                                type: string
+                              volume:
+                                type: string
+                            required:
+                            - registry
+                            - volume
+                            type: object
+                          rbd:
+                            properties:
+                              fsType:
+                                type: string
+                              image:
+                                type: string
+                              keyring:
+                                type: string
+                              monitors:
+                                items:
+                                  type: string
+                                type: array
+                              pool:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              secretRef:
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                              user:
+                                type: string
+                            required:
+                            - image
+                            - monitors
+                            type: object
+                          scaleIO:
+                            properties:
+                              fsType:
+                                type: string
+                              gateway:
+                                type: string
+                              protectionDomain:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              secretRef:
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                              sslEnabled:
+                                type: boolean
+                              storageMode:
+                                type: string
+                              storagePool:
+                                type: string
+                              system:
+                                type: string
+                              volumeName:
+                                type: string
+                            required:
+                            - gateway
+                            - secretRef
+                            - system
+                            type: object
+                          secret:
+                            properties:
+                              defaultMode:
+                                format: int32
+                                type: integer
+                              items:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    mode:
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      type: string
+                                  required:
+                                  - key
+                                  - path
+                                  type: object
+                                type: array
+                              optional:
+                                type: boolean
+                              secretName:
+                                type: string
+                            type: object
+                          storageos:
+                            properties:
+                              fsType:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              secretRef:
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                              volumeName:
+                                type: string
+                              volumeNamespace:
+                                type: string
+                            type: object
+                          vsphereVolume:
+                            properties:
+                              fsType:
+                                type: string
+                              storagePolicyID:
+                                type: string
+                              storagePolicyName:
+                                type: string
+                              volumePath:
+                                type: string
+                            required:
+                            - volumePath
+                            type: object
+                        required:
+                        - name
+                        type: object
+                      type: array
+                      x-kubernetes-list-type: atomic
+                  type: object
+                options:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                secretName:
+                  type: string
+                type:
+                  type: string
+              type: object
+            strategy:
+              type: string
+            tolerations:
+              items:
+                properties:
+                  effect:
+                    type: string
+                  key:
+                    type: string
+                  operator:
+                    type: string
+                  tolerationSeconds:
+                    format: int64
+                    type: integer
+                  value:
+                    type: string
+                type: object
+              type: array
+              x-kubernetes-list-type: atomic
+            ui:
+              properties:
+                options:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+              type: object
+            volumeMounts:
+              items:
+                properties:
+                  mountPath:
+                    type: string
+                  mountPropagation:
+                    type: string
+                  name:
+                    type: string
+                  readOnly:
+                    type: boolean
+                  subPath:
+                    type: string
+                  subPathExpr:
+                    type: string
+                required:
+                - mountPath
+                - name
+                type: object
+              type: array
+              x-kubernetes-list-type: atomic
+            volumes:
+              items:
+                properties:
+                  awsElasticBlockStore:
+                    properties:
+                      fsType:
+                        type: string
+                      partition:
+                        format: int32
+                        type: integer
+                      readOnly:
+                        type: boolean
+                      volumeID:
+                        type: string
+                    required:
+                    - volumeID
+                    type: object
+                  azureDisk:
+                    properties:
+                      cachingMode:
+                        type: string
+                      diskName:
+                        type: string
+                      diskURI:
+                        type: string
+                      fsType:
+                        type: string
+                      kind:
+                        type: string
+                      readOnly:
+                        type: boolean
+                    required:
+                    - diskName
+                    - diskURI
+                    type: object
+                  azureFile:
+                    properties:
+                      readOnly:
+                        type: boolean
+                      secretName:
+                        type: string
+                      shareName:
+                        type: string
+                    required:
+                    - secretName
+                    - shareName
+                    type: object
+                  cephfs:
+                    properties:
+                      monitors:
+                        items:
+                          type: string
+                        type: array
+                      path:
+                        type: string
+                      readOnly:
+                        type: boolean
+                      secretFile:
+                        type: string
+                      secretRef:
+                        properties:
+                          name:
+                            type: string
+                        type: object
+                      user:
+                        type: string
+                    required:
+                    - monitors
+                    type: object
+                  cinder:
+                    properties:
+                      fsType:
+                        type: string
+                      readOnly:
+                        type: boolean
+                      secretRef:
+                        properties:
+                          name:
+                            type: string
+                        type: object
+                      volumeID:
+                        type: string
+                    required:
+                    - volumeID
+                    type: object
+                  configMap:
+                    properties:
+                      defaultMode:
+                        format: int32
+                        type: integer
+                      items:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            mode:
+                              format: int32
+                              type: integer
+                            path:
+                              type: string
+                          required:
+                          - key
+                          - path
+                          type: object
+                        type: array
+                      name:
+                        type: string
+                      optional:
+                        type: boolean
+                    type: object
+                  csi:
+                    properties:
+                      driver:
+                        type: string
+                      fsType:
+                        type: string
+                      nodePublishSecretRef:
+                        properties:
+                          name:
+                            type: string
+                        type: object
+                      readOnly:
+                        type: boolean
+                      volumeAttributes:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    required:
+                    - driver
+                    type: object
+                  downwardAPI:
+                    properties:
+                      defaultMode:
+                        format: int32
+                        type: integer
+                      items:
+                        items:
+                          properties:
+                            fieldRef:
+                              properties:
+                                apiVersion:
+                                  type: string
+                                fieldPath:
+                                  type: string
+                              required:
+                              - fieldPath
+                              type: object
+                            mode:
+                              format: int32
+                              type: integer
+                            path:
+                              type: string
+                            resourceFieldRef:
+                              properties:
+                                containerName:
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  type: string
+                              required:
+                              - resource
+                              type: object
+                          required:
+                          - path
+                          type: object
+                        type: array
+                    type: object
+                  emptyDir:
+                    properties:
+                      medium:
+                        type: string
+                      sizeLimit:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                    type: object
+                  ephemeral:
+                    properties:
+                      readOnly:
+                        type: boolean
+                      volumeClaimTemplate:
+                        properties:
+                          metadata:
+                            type: object
+                          spec:
+                            properties:
+                              accessModes:
+                                items:
+                                  type: string
+                                type: array
+                              dataSource:
+                                properties:
+                                  apiGroup:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  name:
+                                    type: string
+                                required:
+                                - kind
+                                - name
+                                type: object
+                              resources:
+                                properties:
+                                  limits:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    type: object
+                                type: object
+                              selector:
+                                properties:
+                                  matchExpressions:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        operator:
+                                          type: string
+                                        values:
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              storageClassName:
+                                type: string
+                              volumeMode:
+                                type: string
+                              volumeName:
+                                type: string
+                            type: object
+                        required:
+                        - spec
+                        type: object
+                    type: object
+                  fc:
+                    properties:
+                      fsType:
+                        type: string
+                      lun:
+                        format: int32
+                        type: integer
+                      readOnly:
+                        type: boolean
+                      targetWWNs:
+                        items:
+                          type: string
+                        type: array
+                      wwids:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  flexVolume:
+                    properties:
+                      driver:
+                        type: string
+                      fsType:
+                        type: string
+                      options:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      readOnly:
+                        type: boolean
+                      secretRef:
+                        properties:
+                          name:
+                            type: string
+                        type: object
+                    required:
+                    - driver
+                    type: object
+                  flocker:
+                    properties:
+                      datasetName:
+                        type: string
+                      datasetUUID:
+                        type: string
+                    type: object
+                  gcePersistentDisk:
+                    properties:
+                      fsType:
+                        type: string
+                      partition:
+                        format: int32
+                        type: integer
+                      pdName:
+                        type: string
+                      readOnly:
+                        type: boolean
+                    required:
+                    - pdName
+                    type: object
+                  gitRepo:
+                    properties:
+                      directory:
+                        type: string
+                      repository:
+                        type: string
+                      revision:
+                        type: string
+                    required:
+                    - repository
+                    type: object
+                  glusterfs:
+                    properties:
+                      endpoints:
+                        type: string
+                      path:
+                        type: string
+                      readOnly:
+                        type: boolean
+                    required:
+                    - endpoints
+                    - path
+                    type: object
+                  hostPath:
+                    properties:
+                      path:
+                        type: string
+                      type:
+                        type: string
+                    required:
+                    - path
+                    type: object
+                  iscsi:
+                    properties:
+                      chapAuthDiscovery:
+                        type: boolean
+                      chapAuthSession:
+                        type: boolean
+                      fsType:
+                        type: string
+                      initiatorName:
+                        type: string
+                      iqn:
+                        type: string
+                      iscsiInterface:
+                        type: string
+                      lun:
+                        format: int32
+                        type: integer
+                      portals:
+                        items:
+                          type: string
+                        type: array
+                      readOnly:
+                        type: boolean
+                      secretRef:
+                        properties:
+                          name:
+                            type: string
+                        type: object
+                      targetPortal:
+                        type: string
+                    required:
+                    - iqn
+                    - lun
+                    - targetPortal
+                    type: object
+                  name:
+                    type: string
+                  nfs:
+                    properties:
+                      path:
+                        type: string
+                      readOnly:
+                        type: boolean
+                      server:
+                        type: string
+                    required:
+                    - path
+                    - server
+                    type: object
+                  persistentVolumeClaim:
+                    properties:
+                      claimName:
+                        type: string
+                      readOnly:
+                        type: boolean
+                    required:
+                    - claimName
+                    type: object
+                  photonPersistentDisk:
+                    properties:
+                      fsType:
+                        type: string
+                      pdID:
+                        type: string
+                    required:
+                    - pdID
+                    type: object
+                  portworxVolume:
+                    properties:
+                      fsType:
+                        type: string
+                      readOnly:
+                        type: boolean
+                      volumeID:
+                        type: string
+                    required:
+                    - volumeID
+                    type: object
+                  projected:
+                    properties:
+                      defaultMode:
+                        format: int32
+                        type: integer
+                      sources:
+                        items:
+                          properties:
+                            configMap:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                            downwardAPI:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      fieldRef:
+                                        properties:
+                                          apiVersion:
+                                            type: string
+                                          fieldPath:
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                      resourceFieldRef:
+                                        properties:
+                                          containerName:
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                    required:
+                                    - path
+                                    type: object
+                                  type: array
+                              type: object
+                            secret:
+                              properties:
+                                items:
+                                  items:
+                                    properties:
+                                      key:
+                                        type: string
+                                      mode:
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                name:
+                                  type: string
+                                optional:
+                                  type: boolean
+                              type: object
+                            serviceAccountToken:
+                              properties:
+                                audience:
+                                  type: string
+                                expirationSeconds:
+                                  format: int64
+                                  type: integer
+                                path:
+                                  type: string
+                              required:
+                              - path
+                              type: object
+                          type: object
+                        type: array
+                    type: object
+                  quobyte:
+                    properties:
+                      group:
+                        type: string
+                      readOnly:
+                        type: boolean
+                      registry:
+                        type: string
+                      tenant:
+                        type: string
+                      user:
+                        type: string
+                      volume:
+                        type: string
+                    required:
+                    - registry
+                    - volume
+                    type: object
+                  rbd:
+                    properties:
+                      fsType:
+                        type: string
+                      image:
+                        type: string
+                      keyring:
+                        type: string
+                      monitors:
+                        items:
+                          type: string
+                        type: array
+                      pool:
+                        type: string
+                      readOnly:
+                        type: boolean
+                      secretRef:
+                        properties:
+                          name:
+                            type: string
+                        type: object
+                      user:
+                        type: string
+                    required:
+                    - image
+                    - monitors
+                    type: object
+                  scaleIO:
+                    properties:
+                      fsType:
+                        type: string
+                      gateway:
+                        type: string
+                      protectionDomain:
+                        type: string
+                      readOnly:
+                        type: boolean
+                      secretRef:
+                        properties:
+                          name:
+                            type: string
+                        type: object
+                      sslEnabled:
+                        type: boolean
+                      storageMode:
+                        type: string
+                      storagePool:
+                        type: string
+                      system:
+                        type: string
+                      volumeName:
+                        type: string
+                    required:
+                    - gateway
+                    - secretRef
+                    - system
+                    type: object
+                  secret:
+                    properties:
+                      defaultMode:
+                        format: int32
+                        type: integer
+                      items:
+                        items:
+                          properties:
+                            key:
+                              type: string
+                            mode:
+                              format: int32
+                              type: integer
+                            path:
+                              type: string
+                          required:
+                          - key
+                          - path
+                          type: object
+                        type: array
+                      optional:
+                        type: boolean
+                      secretName:
+                        type: string
+                    type: object
+                  storageos:
+                    properties:
+                      fsType:
+                        type: string
+                      readOnly:
+                        type: boolean
+                      secretRef:
+                        properties:
+                          name:
+                            type: string
+                        type: object
+                      volumeName:
+                        type: string
+                      volumeNamespace:
+                        type: string
+                    type: object
+                  vsphereVolume:
+                    properties:
+                      fsType:
+                        type: string
+                      storagePolicyID:
+                        type: string
+                      storagePolicyName:
+                        type: string
+                      volumePath:
+                        type: string
+                    required:
+                    - volumePath
+                    type: object
+                required:
+                - name
+                type: object
+              type: array
+              x-kubernetes-list-type: atomic
+          type: object
+        status:
+          properties:
+            phase:
+              type: string
+            version:
+              type: string
+          required:
+          - phase
+          - version
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
     served: true
     storage: true
-    subresources:
-      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/pkg/apis/jaegertracing/v1/jaeger_types.go
+++ b/pkg/apis/jaegertracing/v1/jaeger_types.go
@@ -667,7 +667,7 @@ type JaegerEsRolloverSpec struct {
 	// BackoffLimit sets the Kubernetes back-off limit
 	// +optional
 	BackoffLimit *int32 `json:"backoffLimit,omitempty"`
-	
+
 	// we parse it with time.ParseDuration
 	// +optional
 	ReadTTL string `json:"readTTL,omitempty"`

--- a/pkg/apis/jaegertracing/v1/jaeger_types.go
+++ b/pkg/apis/jaegertracing/v1/jaeger_types.go
@@ -610,6 +610,10 @@ type JaegerDependenciesSpec struct {
 	// +optional
 	TTLSecondsAfterFinished *int32 `json:"ttlSecondsAfterFinished,omitempty"`
 
+	// BackoffLimit sets the Kubernetes back-off limit
+	// +optional
+	BackoffLimit *int32 `json:"backoffLimit,omitempty"`
+
 	// +optional
 	JaegerCommonSpec `json:",inline,omitempty"`
 }
@@ -635,6 +639,10 @@ type JaegerEsIndexCleanerSpec struct {
 	// +optional
 	TTLSecondsAfterFinished *int32 `json:"ttlSecondsAfterFinished,omitempty"`
 
+	// BackoffLimit sets the Kubernetes back-off limit
+	// +optional
+	BackoffLimit *int32 `json:"backoffLimit,omitempty"`
+
 	// +optional
 	JaegerCommonSpec `json:",inline,omitempty"`
 }
@@ -656,6 +664,10 @@ type JaegerEsRolloverSpec struct {
 	// +optional
 	TTLSecondsAfterFinished *int32 `json:"ttlSecondsAfterFinished,omitempty"`
 
+	// BackoffLimit sets the Kubernetes back-off limit
+	// +optional
+	BackoffLimit *int32 `json:"backoffLimit,omitempty"`
+	
 	// we parse it with time.ParseDuration
 	// +optional
 	ReadTTL string `json:"readTTL,omitempty"`

--- a/pkg/apis/jaegertracing/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/jaegertracing/v1/zz_generated.deepcopy.go
@@ -328,6 +328,11 @@ func (in *JaegerDependenciesSpec) DeepCopyInto(out *JaegerDependenciesSpec) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.BackoffLimit != nil {
+		in, out := &in.BackoffLimit, &out.BackoffLimit
+		*out = new(int32)
+		**out = **in
+	}
 	in.JaegerCommonSpec.DeepCopyInto(&out.JaegerCommonSpec)
 	return
 }
@@ -365,6 +370,11 @@ func (in *JaegerEsIndexCleanerSpec) DeepCopyInto(out *JaegerEsIndexCleanerSpec) 
 		*out = new(int32)
 		**out = **in
 	}
+	if in.BackoffLimit != nil {
+		in, out := &in.BackoffLimit, &out.BackoffLimit
+		*out = new(int32)
+		**out = **in
+	}
 	in.JaegerCommonSpec.DeepCopyInto(&out.JaegerCommonSpec)
 	return
 }
@@ -389,6 +399,11 @@ func (in *JaegerEsRolloverSpec) DeepCopyInto(out *JaegerEsRolloverSpec) {
 	}
 	if in.TTLSecondsAfterFinished != nil {
 		in, out := &in.TTLSecondsAfterFinished, &out.TTLSecondsAfterFinished
+		*out = new(int32)
+		**out = **in
+	}
+	if in.BackoffLimit != nil {
+		in, out := &in.BackoffLimit, &out.BackoffLimit
 		*out = new(int32)
 		**out = **in
 	}

--- a/pkg/apis/jaegertracing/v1/zz_generated.openapi.go
+++ b/pkg/apis/jaegertracing/v1/zz_generated.openapi.go
@@ -918,6 +918,13 @@ func schema_pkg_apis_jaegertracing_v1_JaegerDependenciesSpec(ref common.Referenc
 							Format: "int32",
 						},
 					},
+					"backoffLimit": {
+						SchemaProps: spec.SchemaProps{
+							Description: "BackoffLimit sets the Kubernetes back-off limit",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 					"volumes": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{
@@ -1067,6 +1074,13 @@ func schema_pkg_apis_jaegertracing_v1_JaegerEsIndexCleanerSpec(ref common.Refere
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"integer"},
 							Format: "int32",
+						},
+					},
+					"backoffLimit": {
+						SchemaProps: spec.SchemaProps{
+							Description: "BackoffLimit sets the Kubernetes back-off limit",
+							Type:        []string{"integer"},
+							Format:      "int32",
 						},
 					},
 					"volumes": {

--- a/pkg/cronjob/es_index_cleaner.go
+++ b/pkg/cronjob/es_index_cleaner.go
@@ -68,6 +68,7 @@ func CreateEsIndexCleaner(jaeger *v1.Jaeger) *batchv1beta1.CronJob {
 				Spec: batchv1.JobSpec{
 					Parallelism:             &one,
 					TTLSecondsAfterFinished: jaeger.Spec.Storage.EsIndexCleaner.TTLSecondsAfterFinished,
+					BackoffLimit:            jaeger.Spec.Storage.EsIndexCleaner.BackoffLimit,
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
 							Containers: []corev1.Container{

--- a/pkg/cronjob/es_index_cleaner_test.go
+++ b/pkg/cronjob/es_index_cleaner_test.go
@@ -100,6 +100,19 @@ func TestEsIndexCleanerAnnotations(t *testing.T) {
 	assert.Equal(t, "disabled", cjob.Spec.JobTemplate.Spec.Template.Annotations["linkerd.io/inject"])
 }
 
+func TestEsIndexCleanerBackoffLimit(t *testing.T) {
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestEsIndexCleanerAnnotations"})
+
+	BackoffLimit := int32(3)
+	jaeger.Spec.Storage.EsIndexCleaner.BackoffLimit = &BackoffLimit
+
+	days := 0
+	jaeger.Spec.Storage.EsIndexCleaner.NumberOfDays = &days
+
+	cjob := CreateEsIndexCleaner(jaeger)
+	assert.Equal(t, &BackoffLimit, cjob.Spec.JobTemplate.Spec.BackoffLimit)
+}
+
 func TestEsIndexCleanerLabels(t *testing.T) {
 	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestEsIndexCleanerLabels"})
 	jaeger.Spec.Labels = map[string]string{

--- a/pkg/cronjob/es_rollover.go
+++ b/pkg/cronjob/es_rollover.go
@@ -51,9 +51,9 @@ func rollover(jaeger *v1.Jaeger) batchv1beta1.CronJob {
 			SuccessfulJobsHistoryLimit: jaeger.Spec.Storage.EsRollover.SuccessfulJobsHistoryLimit,
 			JobTemplate: batchv1beta1.JobTemplateSpec{
 				Spec: batchv1.JobSpec{
-					Parallelism: &one,
+					Parallelism:  &one,
 					BackoffLimit: jaeger.Spec.Storage.EsRollover.BackoffLimit,
-					Template:    *createTemplate(name, "rollover", jaeger, envs),
+					Template:     *createTemplate(name, "rollover", jaeger, envs),
 				},
 			},
 		},

--- a/pkg/cronjob/es_rollover.go
+++ b/pkg/cronjob/es_rollover.go
@@ -52,6 +52,7 @@ func rollover(jaeger *v1.Jaeger) batchv1beta1.CronJob {
 			JobTemplate: batchv1beta1.JobTemplateSpec{
 				Spec: batchv1.JobSpec{
 					Parallelism: &one,
+					BackoffLimit: jaeger.Spec.Storage.EsRollover.BackoffLimit,
 					Template:    *createTemplate(name, "rollover", jaeger, envs),
 				},
 			},

--- a/pkg/cronjob/es_rollover_test.go
+++ b/pkg/cronjob/es_rollover_test.go
@@ -142,6 +142,16 @@ func TestEsRolloverAnnotations(t *testing.T) {
 	assert.Equal(t, "disabled", cjob.Spec.JobTemplate.Spec.Template.Annotations["linkerd.io/inject"])
 }
 
+func TestEsRolloverBackoffLimit(t *testing.T) {
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestEsIndexCleanerAnnotations"})
+
+	BackoffLimit := int32(3)
+	jaeger.Spec.Storage.EsRollover.BackoffLimit = &BackoffLimit
+
+	cjob := rollover(jaeger)
+	assert.Equal(t, &BackoffLimit, cjob.Spec.JobTemplate.Spec.BackoffLimit)
+}
+
 func TestEsRolloverLabels(t *testing.T) {
 	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestEsRolloverLabels"})
 	jaeger.Spec.Labels = map[string]string{

--- a/pkg/cronjob/spark_dependencies.go
+++ b/pkg/cronjob/spark_dependencies.go
@@ -86,6 +86,7 @@ func CreateSparkDependencies(jaeger *v1.Jaeger) *batchv1beta1.CronJob {
 			JobTemplate: batchv1beta1.JobTemplateSpec{
 				Spec: batchv1.JobSpec{
 					Parallelism: &one,
+					BackoffLimit: jaeger.Spec.Storage.Dependencies.BackoffLimit,
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{
 							Containers: []corev1.Container{

--- a/pkg/cronjob/spark_dependencies.go
+++ b/pkg/cronjob/spark_dependencies.go
@@ -85,7 +85,7 @@ func CreateSparkDependencies(jaeger *v1.Jaeger) *batchv1beta1.CronJob {
 			SuccessfulJobsHistoryLimit: jaeger.Spec.Storage.Dependencies.SuccessfulJobsHistoryLimit,
 			JobTemplate: batchv1beta1.JobTemplateSpec{
 				Spec: batchv1.JobSpec{
-					Parallelism: &one,
+					Parallelism:  &one,
 					BackoffLimit: jaeger.Spec.Storage.Dependencies.BackoffLimit,
 					Template: corev1.PodTemplateSpec{
 						Spec: corev1.PodSpec{

--- a/pkg/cronjob/spark_dependencies_test.go
+++ b/pkg/cronjob/spark_dependencies_test.go
@@ -118,6 +118,16 @@ func TestDependenciesAnnotations(t *testing.T) {
 	assert.Equal(t, "disabled", cjob.Spec.JobTemplate.Spec.Template.Annotations["linkerd.io/inject"])
 }
 
+func TestSparkDependenciesBackoffLimit(t *testing.T) {
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestSparkDependenciesSecrets"})
+
+	BackoffLimit := int32(3)
+	jaeger.Spec.Storage.Dependencies.BackoffLimit = &BackoffLimit
+
+	cronJob := CreateSparkDependencies(jaeger)
+	assert.Equal(t, &BackoffLimit, cronJob.Spec.JobTemplate.Spec.BackoffLimit)
+}
+
 func TestDependenciesLabels(t *testing.T) {
 	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestDependenciesLabels"})
 	jaeger.Spec.Labels = map[string]string{


### PR DESCRIPTION
Resolves #1424 

## Short description of the changes
- Add optional BackoffLimit to JaegerEsIndexCleanerSpec
- Add optional BackoffLimit to JaegerEsIndexCleanerSpec
- Add optional BackoffLimit to JaegerEsRolloverSpec
- Update es_index_cleaner.go CreateEsIndexCleaner function with BackoffLimit
- Update es_rollover rollover function with BackoffLimit
- Update spark_dependencies.go CreateSparkDependencies function with BackoffLimit
- TestEsIndexCleanerBackoffLimit
- TestEsRolloverBackoffLimit
- Add TestSparkDependenciesBackoffLimit