### PR TITLE
kafka 2.5.0 is not supported by RH AMQ operator 1.7.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,8 @@ JAEGER_VERSION ?= "$(shell grep jaeger= versions.txt | awk -F= '{print $$2}')"
 OPERATOR_VERSION ?= "$(shell git describe --tags)"
 STORAGE_NAMESPACE ?= "${shell kubectl get sa default -o jsonpath='{.metadata.namespace}' || oc project -q}"
 KAFKA_NAMESPACE ?= "kafka"
-KAFKA_EXAMPLE ?= "https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/0.19.0/examples/kafka/kafka-persistent-single.yaml"
-KAFKA_YAML ?= "https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.19.0/strimzi-cluster-operator-0.19.0.yaml"
+KAFKA_EXAMPLE ?= "https://raw.githubusercontent.com/strimzi/strimzi-kafka-operator/0.20.1/examples/kafka/kafka-persistent-single.yaml"
+KAFKA_YAML ?= "https://github.com/strimzi/strimzi-kafka-operator/releases/download/0.20.1/strimzi-cluster-operator-0.20.1.yaml"
 ES_OPERATOR_NAMESPACE ?= openshift-logging
 ES_OPERATOR_BRANCH ?= release-4.4
 ES_OPERATOR_IMAGE ?= quay.io/openshift/origin-elasticsearch-operator:4.4


### PR DESCRIPTION
Signed-off-by: Jeeva Kandasamy <jkandasa@gmail.com>

* RH AMQ operator `1.7.x` is available now and kafka version `2.5.0` is not supported
* Supported Kafka versions are `2.6.0` and `2.7.0`
* strimzi-kafka-operator `0.20.1` has `2.6.0` template.

```
io.strimzi.operator.cluster.model.InvalidResourceException: Version 2.5.0 is not supported. Supported versions are: 2.6.0, 2.7.0.
```