### PR TITLE
Allow to pass ES_TIME_RANGE var to Spark dependencies job

### DIFF
--- a/deploy/crds/jaegertracing.io_jaegers_crd.yaml
+++ b/deploy/crds/jaegertracing.io_jaegers_crd.yaml
@@ -7298,6 +7298,8 @@ spec:
                       type: boolean
                     elasticsearchNodesWanOnly:
                       type: boolean
+                    elasticsearchTimeRange:
+                      type: string
                     enabled:
                       type: boolean
                     image:

--- a/pkg/apis/jaegertracing/v1/jaeger_types.go
+++ b/pkg/apis/jaegertracing/v1/jaeger_types.go
@@ -608,6 +608,9 @@ type JaegerDependenciesSpec struct {
 	ElasticsearchNodesWanOnly *bool `json:"elasticsearchNodesWanOnly,omitempty"`
 
 	// +optional
+	ElasticsearchTimeRange string `json:"elasticsearchTimeRange,omitempty"`
+
+	// +optional
 	TTLSecondsAfterFinished *int32 `json:"ttlSecondsAfterFinished,omitempty"`
 
 	// BackoffLimit sets the Kubernetes back-off limit

--- a/pkg/apis/jaegertracing/v1/zz_generated.openapi.go
+++ b/pkg/apis/jaegertracing/v1/zz_generated.openapi.go
@@ -912,6 +912,12 @@ func schema_pkg_apis_jaegertracing_v1_JaegerDependenciesSpec(ref common.Referenc
 							Format: "",
 						},
 					},
+					"elasticsearchTimeRange": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 					"ttlSecondsAfterFinished": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"integer"},

--- a/pkg/controller/jaeger/configmap.go
+++ b/pkg/controller/jaeger/configmap.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/selection"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/inventory"
 	"github.com/jaegertracing/jaeger-operator/pkg/tracing"
 	"github.com/jaegertracing/jaeger-operator/pkg/util"

--- a/pkg/cronjob/spark_dependencies.go
+++ b/pkg/cronjob/spark_dependencies.go
@@ -141,6 +141,7 @@ func getStorageEnvs(s v1.JaegerStorageSpec) []corev1.EnvVar {
 			{Name: "ES_INDEX_PREFIX", Value: sFlagsMap["es.index-prefix"]},
 			{Name: "ES_USERNAME", Value: sFlagsMap["es.username"]},
 			{Name: "ES_PASSWORD", Value: sFlagsMap["es.password"]},
+			{Name: "ES_TIME_RANGE", Value: s.Dependencies.ElasticsearchTimeRange},
 		}
 		if s.Dependencies.ElasticsearchNodesWanOnly != nil {
 			vars = append(vars, corev1.EnvVar{Name: "ES_NODES_WAN_ONLY", Value: strconv.FormatBool(*s.Dependencies.ElasticsearchNodesWanOnly)})

--- a/pkg/cronjob/spark_dependencies_test.go
+++ b/pkg/cronjob/spark_dependencies_test.go
@@ -52,6 +52,7 @@ func TestStorageEnvs(t *testing.T) {
 				{Name: "ES_INDEX_PREFIX", Value: "haha"},
 				{Name: "ES_USERNAME", Value: "jdoe"},
 				{Name: "ES_PASSWORD", Value: "none"},
+				{Name: "ES_TIME_RANGE", Value: ""},
 			}},
 		{storage: v1.JaegerStorageSpec{Type: v1.JaegerESStorage,
 			Options: v1.NewOptions(map[string]interface{}{"es.server-urls": "lol:hol", "es.index-prefix": "haha",
@@ -62,8 +63,20 @@ func TestStorageEnvs(t *testing.T) {
 				{Name: "ES_INDEX_PREFIX", Value: "haha"},
 				{Name: "ES_USERNAME", Value: "jdoe"},
 				{Name: "ES_PASSWORD", Value: "none"},
+				{Name: "ES_TIME_RANGE", Value: ""},
 				{Name: "ES_NODES_WAN_ONLY", Value: "false"},
 				{Name: "ES_CLIENT_NODE_ONLY", Value: "true"},
+			}},
+		{storage: v1.JaegerStorageSpec{Type: v1.JaegerESStorage,
+			Options: v1.NewOptions(map[string]interface{}{"es.server-urls": "lol:hol", "es.index-prefix": "haha",
+				"es.username": "jdoe", "es.password": "none"}),
+			Dependencies: v1.JaegerDependenciesSpec{ElasticsearchTimeRange: "30m"}},
+			expected: []corev1.EnvVar{
+				{Name: "ES_NODES", Value: "lol:hol"},
+				{Name: "ES_INDEX_PREFIX", Value: "haha"},
+				{Name: "ES_USERNAME", Value: "jdoe"},
+				{Name: "ES_PASSWORD", Value: "none"},
+				{Name: "ES_TIME_RANGE", Value: "30m"},
 			}},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
<!--
Please delete this comment before posting.

We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- https://github.com/jaegertracing/spark-dependencies allows using variable `ES_TIME_RANGE` to specify how far in the past the job should look to for spans. But that variable is missing in the operator. PR simply adds the possibility to pass the required variable.

## Short description of the changes
- added `elasticsearchTimeRange` configuration option for Jaeger dependencies section
