### PR TITLE
Fix overwritten default labels in label selectors of `Service`

### DIFF
--- a/pkg/deployment/all_in_one.go
+++ b/pkg/deployment/all_in_one.go
@@ -231,7 +231,10 @@ func (a *AllInOne) Get() *appsv1.Deployment {
 
 // Services returns a list of services to be deployed along with the all-in-one deployment
 func (a *AllInOne) Services() []*corev1.Service {
-	labels := a.labels()
+	// merge defined labels with default labels
+	spec := util.Merge([]v1.JaegerCommonSpec{a.jaeger.Spec.AllInOne.JaegerCommonSpec, a.jaeger.Spec.JaegerCommonSpec, v1.JaegerCommonSpec{Labels: a.labels()}})
+	labels := spec.Labels
+
 	return append(service.NewCollectorServices(a.jaeger, labels),
 		service.NewQueryService(a.jaeger, labels),
 		service.NewAgentService(a.jaeger, labels),

--- a/pkg/strategy/controller.go
+++ b/pkg/strategy/controller.go
@@ -78,6 +78,16 @@ func normalize(ctx context.Context, jaeger *v1.Jaeger) {
 		jaeger.Spec.Storage.Type = v1.JaegerMemoryStorage
 	}
 
+	// remove reserved labels
+	delete(jaeger.Spec.JaegerCommonSpec.Labels, "app.kubernetes.io/instance")
+	delete(jaeger.Spec.JaegerCommonSpec.Labels, "app.kubernetes.io/managed-by")
+
+	delete(jaeger.Spec.AllInOne.JaegerCommonSpec.Labels, "app.kubernetes.io/instance")
+	delete(jaeger.Spec.AllInOne.JaegerCommonSpec.Labels, "app.kubernetes.io/managed-by")
+
+	delete(jaeger.Spec.Query.JaegerCommonSpec.Labels, "app.kubernetes.io/instance")
+	delete(jaeger.Spec.Query.JaegerCommonSpec.Labels, "app.kubernetes.io/managed-by")
+
 	// normalize the deployment strategy
 	if jaeger.Spec.Strategy != v1.DeploymentStrategyProduction && jaeger.Spec.Strategy != v1.DeploymentStrategyStreaming {
 		jaeger.Spec.Strategy = v1.DeploymentStrategyAllInOne

--- a/pkg/strategy/controller_test.go
+++ b/pkg/strategy/controller_test.go
@@ -178,6 +178,19 @@ func TestAcceptExplicitValueFromSecurityWhenOnOpenShift(t *testing.T) {
 	assert.Equal(t, v1.IngressSecurityNoneExplicit, jaeger.Spec.Ingress.Security)
 }
 
+func TestRemoveReservedLabels(t *testing.T) {
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestRemoveReservedLabels"})
+	jaeger.Spec.Labels = map[string]string{
+		"app.kubernetes.io/instance":   "custom-instance",
+		"app.kubernetes.io/managed-by": "custom-managed-by",
+	}
+
+	normalize(context.Background(), jaeger)
+
+	assert.NotContains(t, jaeger.Spec.Labels, "app.kubernetes.io/instance")
+	assert.NotContains(t, jaeger.Spec.Labels, "app.kubernetes.io/managed-by")
+}
+
 func TestNormalizeIndexCleaner(t *testing.T) {
 	trueVar := true
 	falseVar := false


### PR DESCRIPTION
Signed-off-by: Yuchen Cheng <rudeigerc@gmail.com>

## Which problem is this PR solving?
- Resolves #1479 

## Short description of the changes
- Fix overwritten default labels in label selectors of `Service`.
- Remove reserved labels in the normalize operation.