### PR TITLE
 Fix ingress tests for kuttl 

### DIFF
--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -10,7 +10,7 @@ commands:
   - command: kubectl create namespace jaeger-operator-system
   - command: kubectl apply -f ./tests/_build/manifests/01-jaeger-operator.yaml -n jaeger-operator-system
   - command: kubectl wait --timeout=5m --for=condition=available deployment jaeger-operator -n jaeger-operator-system
-  - command: kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/kind/deploy.yaml
+  - command: kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/helm-chart-3.33.0/deploy/static/provider/kind/deploy.yaml
   - command: kubectl wait --namespace ingress-nginx --for=condition=ready pod --selector=app.kubernetes.io/component=controller --timeout=150s
   - command: sleep 5s
 

--- a/pkg/controller/jaeger/configmap.go
+++ b/pkg/controller/jaeger/configmap.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/selection"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/inventory"
 	"github.com/jaegertracing/jaeger-operator/pkg/tracing"
 	"github.com/jaegertracing/jaeger-operator/pkg/util"

--- a/pkg/ingress/query.go
+++ b/pkg/ingress/query.go
@@ -123,13 +123,15 @@ func getRules(path string, hosts []string, backend *networkingv1.IngressBackend)
 }
 
 func getRule(host string, path string, backend *networkingv1.IngressBackend) networkingv1.IngressRule {
+	pathType := networkingv1.PathTypePrefix
 	rule := networkingv1.IngressRule{}
 	rule.Host = host
 	rule.HTTP = &networkingv1.HTTPIngressRuleValue{
 		Paths: []networkingv1.HTTPIngressPath{
 			networkingv1.HTTPIngressPath{
-				Path:    path,
-				Backend: *backend,
+				PathType: &pathType,
+				Path:     path,
+				Backend:  *backend,
 			},
 		},
 	}

--- a/pkg/ingress/query.go
+++ b/pkg/ingress/query.go
@@ -123,7 +123,7 @@ func getRules(path string, hosts []string, backend *networkingv1.IngressBackend)
 }
 
 func getRule(host string, path string, backend *networkingv1.IngressBackend) networkingv1.IngressRule {
-	pathType := networkingv1.PathTypePrefix
+	pathType := networkingv1.PathTypeImplementationSpecific
 	rule := networkingv1.IngressRule{}
 	rule.Host = host
 	rule.HTTP = &networkingv1.HTTPIngressRuleValue{


### PR DESCRIPTION
<!--
Please delete this comment before posting.

We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
-  Fixes ingress tests for kuttl

## Short description of the changes
-  The `ingress-nginx`  controller in the `master` branch  has a `ValidatingAdmissionWebhook` for `networking.k8s.io/v1` but the validation aren't migrated yet on ingress controller _0.47.0_ which is the image used by the` deploy.yaml `on `master`  (the validation is already migrated on 1.0.0. See [commit](https://github.com/kubernetes/ingress-nginx/commit/78afe7e389a3b54f5b3b733635c9dc098909ee41#diff-994d32c26c5c0bfa793222a8a5171ed8e4ea78fc850353bb98602b76751f4c2dR47)  ). This produces an error when `jaeger-operator` tried to create an Ingress CR using `networking.k8s.io/v1` API.  It fails with the following message in the log:

`Error: server.go:84] "failed to process webhook request" err="rejecting admission review because the request does not contain an Ingress resource but networking.k8s.io/v1, Kind=Ingress with name`

The solution for now is to use branch `helm-chart-3.33.0` which still haven't has the validation for `networking.k8s.io/v1`. We can move to 1.0 when it is released.


There was also another detail regarding to Ingress:

We forgot one thing when the migration of API work was done, we need to specify the pathType, because is mandatory for 1.22 (https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122)

> pathType is now required for each specified path. Options are Prefix, Exact, and ImplementationSpecific. To match the undefined v1beta1 behavior, use ImplementationSpecific