### PR TITLE
Include OIDC plugin in binary

### DIFF
--- a/pkg/cmd/start/bootstrap.go
+++ b/pkg/cmd/start/bootstrap.go
@@ -21,6 +21,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/rest"
+
+	//  import OIDC cluster authentication plugin, e.g. for IBM Cloud
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"


### PR DESCRIPTION
Signed-off-by: Ed Snible <snible@us.ibm.com>

## Which problem is this PR solving?

On OIDC-secured clusters, such as IBM Cloud, the `make run` target fails with `FATA[0000] no Auth Provider found for name "oidc"`

This happens when _.kube/config_ contains `users[*].user.auth-provider.config.name` == `oidc`.  When running within the cluster the OIDC provider isn't needed (on my cloud, with my configuration), but when running outside the cluster it is needed -- otherwise the go-client can't talk to the API server.

## Short description of the changes

Include "k8s.io/client-go/plugin/pkg/client/auth/oidc" in binary.  Even though we don't use the include, because it is there [this line](https://github.com/kubernetes/client-go/blob/master/plugin/pkg/client/auth/oidc/oidc.go#L50) allows the code to use OIDC if needed.

I did not create a test case because I don't know how to mock auth providers.