### PR TITLE
Add E2E testing for Rollover ES feature

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ make run
 At this point, a Jaeger instance can be installed:
 
 ```
-kubectl apply -f deploy/examples/simplest.yaml
+kubectl apply -f examples/simplest.yaml
 kubectl get jaegers
 kubectl get pods
 ```
@@ -45,7 +45,7 @@ kubectl get pods
 To remove the instance:
 
 ```
-kubectl delete -f deploy/examples/simplest.yaml
+kubectl delete -f examples/simplest.yaml
 ```
 
 Tests should be simple unit tests and/or end-to-end tests. For small changes, unit tests should be sufficient, but every new feature should be accompanied with end-to-end tests as well. Tests can be executed with:
@@ -77,7 +77,7 @@ kubectl get pods -n ingress-nginx
 To verify that it's working, deploy the `simplest.yaml` and check the ingress routes:
 
 ```
-$ kubectl apply -f deploy/examples/simplest.yaml 
+$ kubectl apply -f examples/simplest.yaml
 jaeger.jaegertracing.io/simplest created
 $ kubectl get ingress
 NAME             HOSTS     ADDRESS          PORTS     AGE
@@ -124,7 +124,7 @@ The generated CSV yaml should then be compared and used to update the deploy/olm
 The jaeger.clusterserviceversion.yaml file can then be tested with this command:
 
 ```
-$ operator-sdk scorecard --cr-manifest deploy/examples/simplest.yaml --csv-path deploy/olm-catalog/jaeger.clusterserviceversion.yaml --init-timeout 30
+$ operator-sdk scorecard --cr-manifest examples/simplest.yaml --csv-path deploy/olm-catalog/jaeger.clusterserviceversion.yaml --init-timeout 30
 Checking for existence of spec and status blocks in CR
 Checking that operator actions are reflected in status
 Checking that writing into CRs has an effect

--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,11 @@ e2e-tests-es: prepare-e2e-tests es
 	@echo Running Elasticsearch end-to-end tests...
 	@STORAGE_NAMESPACE=$(STORAGE_NAMESPACE) go test -tags=elasticsearch ./test/e2e/... $(TEST_OPTIONS)
 
+.PHONY: e2e-tests-es-rollover
+e2e-tests-es-rollover: prepare-e2e-tests es
+	@echo Running Elasticsearch end-to-end tests...
+	@STORAGE_NAMESPACE=$(STORAGE_NAMESPACE) go test -tags=elasticsearch_rollover ./test/e2e/... $(TEST_OPTIONS)
+
 .PHONY: e2e-tests-self-provisioned-es
 e2e-tests-self-provisioned-es: prepare-e2e-tests deploy-es-operator
 	@echo Running Self provisioned Elasticsearch end-to-end tests...

--- a/test/e2e/elasticsearch_rollover_test.go
+++ b/test/e2e/elasticsearch_rollover_test.go
@@ -140,7 +140,6 @@ func (suite *ElasticSearchRolloverTestSuite) TestRolloverESEnable() {
 	GenerateSpansHistory(namespace, jaegerInstanceName, "span-rollover-test", ElasticSearchIndexDateLayout, generatedSpans)
 
 	// The generation of the indices is not instantaneus. So, we wait some time until they are generated
-	time.Sleep(time.Minute * 30)
 	serviceIndicesBefore, spansIndicesBefore := GetJaegerIndices(suite.esNamespace)
 
 	// Enable Rollover

--- a/test/e2e/elasticsearch_rollover_test.go
+++ b/test/e2e/elasticsearch_rollover_test.go
@@ -1,0 +1,239 @@
+// +build elasticsearchrollover
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	"testing"
+	"time"
+
+	framework "github.com/operator-framework/operator-sdk/pkg/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"k8s.io/apimachinery/pkg/types"
+
+	v1 "github.com/jaegertracing/jaeger-operator/pkg/apis/jaegertracing/v1"
+)
+
+type ElasticSearchRolloverTestSuite struct {
+	suite.Suite
+	esNamespace string // default storage namespace location
+}
+
+func TestElasticSearchRolloverSuite(t *testing.T) {
+	indexSuite := new(ElasticSearchRolloverTestSuite)
+	suite.Run(t, indexSuite)
+}
+
+func (suite *ElasticSearchRolloverTestSuite) SetupSuite() {
+	t = suite.T()
+	var err error
+	ctx, err = prepare(t)
+	if err != nil {
+		if ctx != nil {
+			ctx.Cleanup()
+		}
+		require.FailNow(t, "Failed in prepare")
+	}
+	fw = framework.Global
+	namespace = ctx.GetID()
+	require.NotNil(t, namespace, "GetID failed")
+
+	addToFrameworkSchemeForSmokeTests(t)
+}
+
+func (suite *ElasticSearchRolloverTestSuite) TearDownSuite() {
+	// if !skipESExternal {
+	// 	DeleteEsIndices(suite.esNamespace)
+	// }
+
+	handleSuiteTearDown()
+}
+
+func (suite *ElasticSearchRolloverTestSuite) SetupTest() {
+	t = suite.T()
+	// update storage namespace
+	if skipESExternal {
+		suite.esNamespace = namespace
+	} else {
+		suite.esNamespace = storageNamespace
+	}
+	// delete indices from external elasticsearch node
+	if !skipESExternal {
+		DeleteEsIndices(suite.esNamespace)
+	}
+}
+
+func (suite *ElasticSearchRolloverTestSuite) AfterTest(suiteName, testName string) {
+	handleTestFailure()
+}
+
+func (suite *ElasticSearchRolloverTestSuite) TestRolloverESSmoke() {
+	jaegerInstanceName := "test-es-rollover"
+
+	// Get the Jaeger CR to create the service
+	jaegerInstance := GetJaegerSelfProvSimpleProdCR(jaegerInstanceName, namespace, 1)
+	defer undeployJaegerInstance(jaegerInstance)
+
+	// If there is an external ES deployment use it instead of creating a self provisioned one
+	if !skipESExternal {
+		if isOpenShift(t) {
+			esServerUrls = "http://elasticsearch." + storageNamespace + ".svc.cluster.local:9200"
+		}
+	}
+
+	// Configure the ES Rollover feature
+	jaegerInstance.Spec.Storage = v1.JaegerStorageSpec{
+		Type: v1.JaegerESStorage,
+		Options: v1.NewOptions(map[string]interface{}{
+			"es.server-urls": esServerUrls,
+			"es.use-aliases": true,
+		}),
+		EsRollover: v1.JaegerEsRolloverSpec{
+			Schedule:   "* * * * *",
+			Conditions: "{\"max_age\": \"1d\"}",
+			ReadTTL:    "10h",
+		},
+	}
+
+	createESSelfProvDeployment(jaegerInstance, jaegerInstanceName, namespace)
+
+	suite.waitRolloverDeployment(jaegerInstanceName)
+}
+
+func (suite *ElasticSearchRolloverTestSuite) TestRolloverESIndex() {
+	jaegerInstanceName := "test-es-rollover"
+	jaegerInstance := suite.createJaegerDeployment(jaegerInstanceName)
+	defer undeployJaegerInstance(jaegerInstance)
+
+	// Enable Rollover
+	suite.updateJaegerCR(jaegerInstance, "* * * * *", "{\"max_docs\": \"100\", \"max_age\": \"1d\"}", "1m")
+	suite.waitRolloverDeployment(jaegerInstanceName)
+
+	generatedSpans := 2
+	GenerateSpansHistory(namespace, jaegerInstanceName, "span-rollover-test", ElasticSearchIndexDateLayout, generatedSpans)
+
+	// The generation of the indices is not instantaneus. So, we wait some time until they are generated
+	time.Sleep(time.Second * 5)
+	serviceIndices, spansIndices := GetJaegerIndices(suite.esNamespace)
+
+	// Find the the new created indices with the expected names
+	reRolloutPrefix := regexp.MustCompile(`jaeger-(span|service)-\d{6}`)
+
+	for _, esIndex := range spansIndices {
+		require.Regexp(t, reRolloutPrefix, esIndex.IndexName)
+	}
+
+	for _, esIndex := range serviceIndices {
+		require.Regexp(t, reRolloutPrefix, esIndex.IndexName)
+	}
+}
+
+func (suite *ElasticSearchRolloverTestSuite) TestRolloverESEnable() {
+	jaegerInstanceName := "test-es-rollover"
+	jaegerInstance := suite.createJaegerDeployment(jaegerInstanceName)
+	defer undeployJaegerInstance(jaegerInstance)
+
+	// We generate some spans before enabling the Rollover feature
+	generatedSpans := 2
+	GenerateSpansHistory(namespace, jaegerInstanceName, "span-rollover-test", ElasticSearchIndexDateLayout, generatedSpans)
+
+	// The generation of the indices is not instantaneus. So, we wait some time until they are generated
+	time.Sleep(time.Second * 5)
+	serviceIndicesBefore, spansIndicesBefore := GetJaegerIndices(suite.esNamespace)
+
+	// Enable Rollover
+	suite.updateJaegerCR(jaegerInstance, "* * * * *", "{\"max_docs\": \"100\", \"max_age\": \"1d\"}", "1m")
+	suite.waitRolloverDeployment(jaegerInstanceName)
+
+	// We add new spans after enabling the rollout feature
+	GenerateSpansHistory(namespace, jaegerInstanceName, "span-rollover-test", ElasticSearchIndexDateLayout, generatedSpans)
+	time.Sleep(time.Second * 5)
+	serviceIndicesAfter, spansIndicesAfter := GetJaegerIndices(suite.esNamespace)
+
+	// The old indices were not removed
+	assert.Greater(t, len(serviceIndicesAfter), len(serviceIndicesBefore))
+	assert.Greater(t, len(spansIndicesAfter), len(spansIndicesBefore))
+
+	// Check the old indices were not modified
+	for _, index := range serviceIndicesBefore {
+		foundIndex, err := FindIndex(serviceIndicesAfter, index.IndexName)
+		require.NoError(t, err)
+		require.Equal(t, foundIndex, index)
+	}
+
+	for _, index := range spansIndicesBefore {
+		foundIndex, err := FindIndex(spansIndicesAfter, index.IndexName)
+		require.NoError(t, err)
+		require.Equal(t, foundIndex, index)
+	}
+
+	// We remove all the indexes
+	DeleteEsIndices(suite.esNamespace)
+	GenerateSpansHistory(namespace, jaegerInstanceName, "span-rollover-test", ElasticSearchIndexDateLayout, generatedSpans)
+
+	// After starting from scratch, we just have 1 index for spans
+	time.Sleep(time.Second * 5)
+	serviceIndices, spansIndices := GetJaegerIndices(suite.esNamespace)
+	assert.Len(t, serviceIndices, 0)
+	assert.Len(t, spansIndices, 1)
+}
+
+func (suite *ElasticSearchRolloverTestSuite) waitRolloverDeployment(jaegerInstanceName string) {
+	// Wait until the cronjob is created
+	err := WaitForCronJob(t, fw.KubeClient, namespace, fmt.Sprintf("%s-es-rollover", jaegerInstanceName), retryInterval, timeout+1*time.Minute)
+	require.NoError(t, err, "Error waiting for Cron Job")
+
+	// Wait until the cronjob is executed properly at least one time
+	err = WaitForJobOfAnOwner(t, fw.KubeClient, namespace, fmt.Sprintf("%s-es-rollover", jaegerInstanceName), retryInterval, timeout)
+	require.NoError(t, err, "Error waiting for Cron Job")
+}
+
+// Create and deploy a Jaeger deployment without the Rollver ES feature enabled
+func (suite *ElasticSearchRolloverTestSuite) createJaegerDeployment(name string) *v1.Jaeger {
+	// Get the Jaeger CR to create the service
+	jaegerInstance := GetJaegerSelfProvSimpleProdCR(name, namespace, 1)
+
+	// If there is an external ES deployment use it instead of creating a self provisioned one
+	if !skipESExternal {
+		if isOpenShift(t) {
+			esServerUrls = "http://elasticsearch." + storageNamespace + ".svc.cluster.local:9200"
+		}
+	}
+
+	// Configure the ES Rollover feature
+	jaegerInstance.Spec.Storage = v1.JaegerStorageSpec{
+		Type: v1.JaegerESStorage,
+		Options: v1.NewOptions(map[string]interface{}{
+			"es.server-urls": esServerUrls,
+		}),
+	}
+
+	createESSelfProvDeployment(jaegerInstance, name, namespace)
+	return jaegerInstance
+}
+
+// function to update jaeger CR
+func (suite *ElasticSearchRolloverTestSuite) updateJaegerCR(jaegerInstance *v1.Jaeger, schedule string, conditions string, readTTL string) {
+	// get existing values
+	key := types.NamespacedName{Name: jaegerInstance.Name, Namespace: jaegerInstance.GetNamespace()}
+	err := fw.Client.Get(context.Background(), key, jaegerInstance)
+	require.NoError(t, err)
+
+	// update values
+	options := jaegerInstance.Spec.Storage.Options.GenericMap()
+	options["es.use-aliases"] = true // Enable Rollover feature
+
+	jaegerInstance.Spec.Storage.Options = v1.NewOptions(options)
+
+	jaegerInstance.Spec.Storage.EsRollover.Schedule = schedule
+	jaegerInstance.Spec.Storage.EsRollover.Conditions = conditions
+	jaegerInstance.Spec.Storage.EsRollover.ReadTTL = readTTL
+
+	err = fw.Client.Update(context.Background(), jaegerInstance)
+	require.NoError(t, err)
+}

--- a/test/e2e/elasticsearch_test.go
+++ b/test/e2e/elasticsearch_test.go
@@ -1,4 +1,4 @@
-// +build elasticsearch
+// +build elasticsearch2
 
 package e2e
 

--- a/test/e2e/utils_elasticsearch.go
+++ b/test/e2e/utils_elasticsearch.go
@@ -30,6 +30,22 @@ type EsIndex struct {
 	StoreSize   string `json:"store.size"`
 }
 
+// CountDocsInIndex count the number of docs in an index
+func CountDocsInIndex(esNamespace, indexName string) int {
+	apiEndpoint := "/" + indexName + "/_count"
+	bodyBytes, err := ExecuteEsRequest(esNamespace, http.MethodGet, apiEndpoint)
+	require.NoError(t, err)
+
+	countAnswer := struct {
+		Count int `json:"count"`
+	}{}
+
+	err = json.Unmarshal(bodyBytes, &countAnswer)
+	require.NoError(t, err)
+
+	return countAnswer.Count
+}
+
 // GetEsIndices return indices from es node
 func GetEsIndices(esNamespace string) ([]EsIndex, error) {
 	bodyBytes, err := ExecuteEsRequest(esNamespace, http.MethodGet, "/_cat/indices?format=json")

--- a/test/e2e/utils_elasticsearch_indices.go
+++ b/test/e2e/utils_elasticsearch_indices.go
@@ -1,0 +1,85 @@
+package e2e
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const ElasticSearchIndexDateLayout = "2006-01-02" // date layout in elasticsearch indices, example:
+
+type esIndexData struct {
+	IndexName  string    // original index name
+	Type       string    // index type. span or service?
+	Prefix     string    // prefix of the index
+	Date       time.Time // index day/date
+	RolloverID string    // rollover string
+}
+
+// Get Jaeger ES indices
+// returns in order: serviceIndices, spansIndices
+func GetJaegerIndices(namespace string) ([]esIndexData, []esIndexData) {
+	esIndices, err := GetEsIndices(namespace)
+	require.NoError(t, err)
+
+	servicesIndices := make([]esIndexData, 0)
+	spansIndices := make([]esIndexData, 0)
+
+	// parse date, prefix, type from index
+	jaegerRe := regexp.MustCompile(`jaeger-(span|service)-`)
+	dateRe := regexp.MustCompile(`\d{4}-\d{2}-\d{2}`)
+	rolloverRe := regexp.MustCompile(`\d{6}`)
+
+	for _, esIndex := range esIndices {
+		if !jaegerRe.MatchString(esIndex.Index) { // assume this index not belongs to Jaeger
+			continue
+		}
+
+		esData := esIndexData{
+			IndexName: esIndex.Index,
+		}
+
+		dateString := dateRe.FindString(esIndex.Index)
+		indexName := strings.Replace(esIndex.Index, dateString, "", 1)
+
+		indexDate, err := time.Parse(ElasticSearchIndexDateLayout, dateString)
+		if err != nil {
+			esData.RolloverID = rolloverRe.FindString(dateString)
+			require.NotSame(t, esData.RolloverID, "", "Not date or rollover ID in index")
+		}
+		esData.Date = indexDate
+
+		// reference
+		// https://github.com/jaegertracing/jaeger/blob/6c2be456ca41cdb98ac4b81cb8d9a9a9044463cd/plugin/storage/es/spanstore/reader.go#L40
+		if strings.Contains(indexName, "jaeger-span-") {
+			esData.Type = "span"
+			prefix := strings.Replace(indexName, "jaeger-span-", "", 1)
+			if len(prefix) > 0 {
+				esData.Prefix = prefix[:len(prefix)-1] // removes "-" at end
+			}
+			spansIndices = append(spansIndices, esData)
+		} else if strings.Contains(indexName, "jaeger-service-") {
+
+			esData.Type = "service"
+			prefix := strings.Replace(indexName, "jaeger-service-", "", 1)
+			if len(prefix) > 0 {
+				esData.Prefix = prefix[:len(prefix)-1] // removes "-" at end
+			}
+			servicesIndices = append(servicesIndices, esData)
+		}
+	}
+
+	return servicesIndices, spansIndices
+}
+
+func FindIndex(indices []esIndexData, name string) (esIndexData, error) {
+	for _, esIndex := range indices {
+		if esIndex.IndexName == name {
+			return esIndex, nil
+		}
+	}
+	return esIndexData{}, errors.New("Index not found")
+}

--- a/test/e2e/utils_elasticsearch_indices.go
+++ b/test/e2e/utils_elasticsearch_indices.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"errors"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -17,6 +18,7 @@ type esIndexData struct {
 	Prefix     string    // prefix of the index
 	Date       time.Time // index day/date
 	RolloverID string    // rollover string
+	DocCount   int       // Document count
 }
 
 // Get Jaeger ES indices
@@ -42,10 +44,14 @@ func GetJaegerIndices(namespace string) ([]esIndexData, []esIndexData) {
 			IndexName: esIndex.Index,
 		}
 
+		esData.DocCount, err = strconv.Atoi(esIndex.DocsCount)
+		require.NoError(t, err)
+
 		dateString := dateRe.FindString(esIndex.Index)
 		indexName := strings.Replace(esIndex.Index, dateString, "", 1)
 
-		indexDate, err := time.Parse(ElasticSearchIndexDateLayout, dateString)
+		var indexDate time.Time
+		indexDate, err = time.Parse(ElasticSearchIndexDateLayout, dateString)
 		if err != nil {
 			esData.RolloverID = rolloverRe.FindString(dateString)
 			require.NotSame(t, esData.RolloverID, "", "Not date or rollover ID in index")

--- a/test/operator.yaml
+++ b/test/operator.yaml
@@ -20,7 +20,7 @@ spec:
           - containerPort: 60000
             name: metrics
           args: ["start", "--log-level=debug", "--tracing-enabled=false", "--kafka-provisioning-minimal=true"]
-          imagePullPolicy: Never
+          imagePullPolicy: Always
           env:
             - name: WATCH_NAMESPACE
               valueFrom:


### PR DESCRIPTION
## Which problem is this PR solving?
Add E2E testing to the Rollover ES feature implemented in #267

## Short description of the changes
* Added smoke E2E Test for the Rollover ES feature
* Added E2E Test to check everything works properly when the feature is enabled after the deployment
*  Added E2E Test to check the correct indices are created when the feature is enabled before the deployment
* Extract some common logic from the ES index test suite to reuse some logic in the Rollover ES test