### PR TITLE
Add gRPC port for jaeger-query into its service resource

### DIFF
--- a/deploy/crds/jaegertracing.io_jaegers_crd.yaml
+++ b/deploy/crds/jaegertracing.io_jaegers_crd.yaml
@@ -6149,6 +6149,9 @@ spec:
                       type: string
                     nullable: true
                     type: object
+                  grpcNodePort:
+                    format: int32
+                    type: integer
                   image:
                     type: string
                   labels:

--- a/pkg/apis/jaegertracing/v1/jaeger_types.go
+++ b/pkg/apis/jaegertracing/v1/jaeger_types.go
@@ -267,6 +267,10 @@ type JaegerQuerySpec struct {
 	NodePort int32 `json:"nodePort,omitempty"`
 
 	// +optional
+	// NodePort represents the port at which the NodePort service to allocate
+	GRPCNodePort int32 `json:"grpcNodePort,omitempty"`
+
+	// +optional
 	// TracingEnabled if set to false adds the JAEGER_DISABLED environment flag and removes the injected
 	// agent container from the query component to disable tracing requests to the query service.
 	// The default, if ommited, is true

--- a/pkg/apis/jaegertracing/v1/zz_generated.openapi.go
+++ b/pkg/apis/jaegertracing/v1/zz_generated.openapi.go
@@ -1792,6 +1792,13 @@ func schema_pkg_apis_jaegertracing_v1_JaegerQuerySpec(ref common.ReferenceCallba
 							Format:      "int32",
 						},
 					},
+					"grpcNodePort": {
+						SchemaProps: spec.SchemaProps{
+							Description: "NodePort represents the port at which the NodePort service to allocate",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 					"tracingEnabled": {
 						SchemaProps: spec.SchemaProps{
 							Description: "TracingEnabled if set to false adds the JAEGER_DISABLED environment flag and removes the injected agent container from the query component to disable tracing requests to the query service. The default, if ommited, is true",

--- a/pkg/service/query.go
+++ b/pkg/service/query.go
@@ -24,9 +24,16 @@ func NewQueryService(jaeger *v1.Jaeger, selector map[string]string) *corev1.Serv
 			Port:       int32(GetPortForQueryService(jaeger)),
 			TargetPort: intstr.FromInt(getTargetPortForQueryService(jaeger)),
 		},
+		{
+			Name:       "grpc-query",
+			Port:       int32(16685),
+			TargetPort: intstr.FromInt(16685),
+		},
 	}
 	if jaeger.Spec.Query.ServiceType == corev1.ServiceTypeNodePort {
 		ports[0].NodePort = GetNodePortForQueryService(jaeger)
+		ports[1].NodePort = GetGRPCNodePortForQueryService(jaeger)
+
 	}
 
 	return &corev1.Service{
@@ -99,4 +106,9 @@ func getTypeForQueryService(jaeger *v1.Jaeger) corev1.ServiceType {
 // GetNodePortForQueryService returns the query service NodePort for this Jaeger instance
 func GetNodePortForQueryService(jaeger *v1.Jaeger) int32 {
 	return jaeger.Spec.Query.NodePort
+}
+
+// GetGRPCNodePortForQueryService returns the query service grpc NodePort for this Jaeger instance
+func GetGRPCNodePortForQueryService(jaeger *v1.Jaeger) int32 {
+	return jaeger.Spec.Query.GRPCNodePort
 }

--- a/pkg/service/query_test.go
+++ b/pkg/service/query_test.go
@@ -20,8 +20,9 @@ func TestQueryServiceNameAndPorts(t *testing.T) {
 	svc := NewQueryService(jaeger, selector)
 
 	assert.Equal(t, "testqueryservicenameandports-query", svc.ObjectMeta.Name)
-	assert.Len(t, svc.Spec.Ports, 1)
+	assert.Len(t, svc.Spec.Ports, 2)
 	assert.Equal(t, int32(16686), svc.Spec.Ports[0].Port)
+	assert.Equal(t, int32(16685), svc.Spec.Ports[1].Port)
 	assert.Equal(t, "http-query", svc.Spec.Ports[0].Name)
 	assert.Equal(t, intstr.FromInt(16686), svc.Spec.Ports[0].TargetPort)
 	assert.Len(t, svc.Spec.ClusterIP, 0)                        // make sure we get a cluster IP
@@ -47,8 +48,9 @@ func TestQueryServiceNameAndPortsWithOAuthProxy(t *testing.T) {
 	svc := NewQueryService(jaeger, selector)
 
 	assert.Equal(t, "testqueryservicenameandportswithoauthproxy-query", svc.ObjectMeta.Name)
-	assert.Len(t, svc.Spec.Ports, 1)
+	assert.Len(t, svc.Spec.Ports, 2)
 	assert.Equal(t, int32(443), svc.Spec.Ports[0].Port)
+	assert.Equal(t, int32(16685), svc.Spec.Ports[1].Port)
 	assert.Equal(t, "https-query", svc.Spec.Ports[0].Name)
 	assert.Equal(t, intstr.FromInt(8443), svc.Spec.Ports[0].TargetPort)
 }
@@ -62,10 +64,12 @@ func TestQueryServiceNodePortWithIngress(t *testing.T) {
 	svc := NewQueryService(jaeger, selector)
 
 	assert.Equal(t, "testqueryservicenodeportwithingress-query", svc.ObjectMeta.Name)
-	assert.Len(t, svc.Spec.Ports, 1)
+	assert.Len(t, svc.Spec.Ports, 2)
 	assert.Equal(t, int32(16686), svc.Spec.Ports[0].Port)
+	assert.Equal(t, int32(16685), svc.Spec.Ports[1].Port)
 	assert.Equal(t, "http-query", svc.Spec.Ports[0].Name)
 	assert.Equal(t, int32(0), svc.Spec.Ports[0].NodePort)
+	assert.Equal(t, int32(0), svc.Spec.Ports[1].NodePort)
 	assert.Equal(t, intstr.FromInt(16686), svc.Spec.Ports[0].TargetPort)
 	assert.Equal(t, svc.Spec.Type, corev1.ServiceTypeNodePort) // make sure we get a NodePort service
 }
@@ -79,8 +83,9 @@ func TestQueryServiceLoadBalancerWithIngress(t *testing.T) {
 	svc := NewQueryService(jaeger, selector)
 
 	assert.Equal(t, "testqueryservicenodeportwithingress-query", svc.ObjectMeta.Name)
-	assert.Len(t, svc.Spec.Ports, 1)
+	assert.Len(t, svc.Spec.Ports, 2)
 	assert.Equal(t, int32(16686), svc.Spec.Ports[0].Port)
+	assert.Equal(t, int32(16685), svc.Spec.Ports[1].Port)
 	assert.Equal(t, "http-query", svc.Spec.Ports[0].Name)
 	assert.Equal(t, intstr.FromInt(16686), svc.Spec.Ports[0].TargetPort)
 	assert.Equal(t, svc.Spec.Type, corev1.ServiceTypeLoadBalancer) // make sure we get a LoadBalancer service
@@ -96,8 +101,9 @@ func TestQueryServiceSpecifiedNodePortWithIngress(t *testing.T) {
 	svc := NewQueryService(jaeger, selector)
 
 	assert.Equal(t, "testqueryservicespecifiednodeportwithingress-query", svc.ObjectMeta.Name)
-	assert.Len(t, svc.Spec.Ports, 1)
+	assert.Len(t, svc.Spec.Ports, 2)
 	assert.Equal(t, int32(16686), svc.Spec.Ports[0].Port)
+	assert.Equal(t, int32(16685), svc.Spec.Ports[1].Port)
 	assert.Equal(t, "http-query", svc.Spec.Ports[0].Name)
 	assert.Equal(t, int32(32767), svc.Spec.Ports[0].NodePort) // make sure we get the same NodePort as set above
 	assert.Equal(t, intstr.FromInt(16686), svc.Spec.Ports[0].TargetPort)


### PR DESCRIPTION
Signed-off-by: Ruben Vargas <ruben.vp8510@gmail.com>



<!--
Please delete this comment before posting.

We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Fixes #1520 

## Short description of the changes
-  Added GRPC port to query service
