### PR TITLE
Add service annotations

### DIFF
--- a/pkg/service/collector.go
+++ b/pkg/service/collector.go
@@ -47,7 +47,8 @@ func collectorService(jaeger *v1.Jaeger, selector map[string]string) *corev1.Ser
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      GetNameForCollectorService(jaeger),
 			Namespace: jaeger.Namespace,
-			Labels:    util.Labels(GetNameForCollectorService(jaeger), "service-collector", *jaeger),
+			Annotations: jaeger.Spec.Collector.Annotations,
+			Labels: util.Labels(GetNameForCollectorService(jaeger), "service-collector", *jaeger),
 			OwnerReferences: []metav1.OwnerReference{{
 				APIVersion: jaeger.APIVersion,
 				Kind:       jaeger.Kind,

--- a/pkg/service/collector_test.go
+++ b/pkg/service/collector_test.go
@@ -143,3 +143,13 @@ func TestCollectorServiceLoadBalancer(t *testing.T) {
 	// Only the non-headless service will receive the type
 	assert.Equal(t, svc[1].Spec.Type, corev1.ServiceTypeLoadBalancer)
 }
+func TestCollectorServiceAnnotations(t *testing.T) {
+	name := "TestCollectorServiceLoadBalancer"
+	selector := map[string]string{"app": "myapp", "jaeger": name, "jaeger-component": "collector"}
+
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: name})
+	jaeger.Spec.Collector.Annotations = map[string]string{"component": "collector"}
+	svc := NewCollectorServices(jaeger, selector)
+
+	assert.Equal(t, map[string]string{"component": "collector"}, svc[1].Annotations)
+}

--- a/pkg/service/query.go
+++ b/pkg/service/query.go
@@ -14,6 +14,9 @@ func NewQueryService(jaeger *v1.Jaeger, selector map[string]string) *corev1.Serv
 	trueVar := true
 
 	annotations := map[string]string{}
+	if jaeger.Spec.Query.Annotations !=nil{
+		annotations = jaeger.Spec.Query.Annotations
+	}
 	if jaeger.Spec.Ingress.Security == v1.IngressSecurityOAuthProxy {
 		annotations["service.alpha.openshift.io/serving-cert-secret-name"] = GetTLSSecretNameForQueryService(jaeger)
 	}

--- a/pkg/service/query_test.go
+++ b/pkg/service/query_test.go
@@ -109,3 +109,20 @@ func TestQueryServiceSpecifiedNodePortWithIngress(t *testing.T) {
 	assert.Equal(t, intstr.FromInt(16686), svc.Spec.Ports[0].TargetPort)
 	assert.Equal(t, svc.Spec.Type, corev1.ServiceTypeNodePort)
 }
+
+func TestQueryServiceSpecAnnotations(t *testing.T) {
+	name := "TestQueryServiceSpecAnnotations"
+	selector := map[string]string{"app": "myapp", "jaeger": name, "jaeger-component": "query"}
+
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: name})
+	jaeger.Spec.Query.Annotations = map[string]string{"component": "jaeger"}
+	svc := NewQueryService(jaeger, selector)
+
+	assert.Equal(t, "testqueryservicespecannotations-query", svc.ObjectMeta.Name)
+	assert.Len(t, svc.Spec.Ports, 2)
+	assert.Equal(t, int32(16686), svc.Spec.Ports[0].Port)
+	assert.Equal(t, int32(16685), svc.Spec.Ports[1].Port)
+	assert.Equal(t, "http-query", svc.Spec.Ports[0].Name)
+	assert.Equal(t, intstr.FromInt(16686), svc.Spec.Ports[0].TargetPort)
+	assert.Equal(t, map[string]string{"component": "jaeger"}, svc.Annotations)
+}


### PR DESCRIPTION
## Which problem is this PR solving?
When I use the jaeger operator,  I need to add the annotations of the jaeger-query or jaeger-collector service. But the jaeger-operator do not supply the function.  So I alter the code to supply this.

## Short description of the changes
- I didn't alter the jaeger's type , just use the Annotation field. Before, it's just use to the component deployment, now I add the code to use it to the component  service .
