### PR TITLE
Only reconcile namespaces matching WATCH_NAMESPACE

### DIFF
--- a/pkg/controller/namespace/namespace_controller.go
+++ b/pkg/controller/namespace/namespace_controller.go
@@ -87,11 +87,11 @@ func (r *ReconcileNamespace) Reconcile(request reconcile.Request) (reconcile.Res
 	defer span.End()
 
 	// Don't reconcile namespace unless unless namespace matches $WATCH_NAMESPACE
-	watched_namespaces := os.Getenv("WATCH_NAMESPACE")
-	if watched_namespaces != "" {
+	watchedNamespaces := os.Getenv("WATCH_NAMESPACE")
+	if watchedNamespaces != "" {
 		watched := false
-		for _, watched_namespace := range strings.Split(watched_namespaces, ",") {
-			if request.Name == watched_namespace {
+		for _, watchedNamespace := range strings.Split(watchedNamespaces, ",") {
+			if request.Name == watchedNamespace {
 				watched = true
 				break
 			}


### PR DESCRIPTION
Signed-off-by: Ed Snible <snible@us.ibm.com>

This fixes the problem I brought up in https://github.com/jaegertracing/jaeger-operator/issues/1431#issuecomment-915574074

It doesn't fix the problem of #1431 .  It fixes the problem where the operator reconciles more namespaces than it should, if it has the RBAC permission to do so.

I don't know how to test operators and therefor didn't write any tests.  Please suggest how to test this.