### PR TITLE
Add ingressClassName field to query ingress

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ check:
 
 .PHONY: ensure-generate-is-noop
 ensure-generate-is-noop: generate format
+	@git diff  pkg/apis/jaegertracing/v1/zz_generated.*.go 
 	@git diff -s --exit-code pkg/apis/jaegertracing/v1/zz_generated.*.go || (echo "Build failed: a model has been changed but the generated resources aren't up to date. Run 'make generate' and update your PR." && exit 1)
 	@git diff -s --exit-code pkg/client/versioned || (echo "Build failed: the versioned clients aren't up to date. Run 'make generate'." && exit 1)
 

--- a/deploy/crds/jaegertracing.io_jaegers_crd.yaml
+++ b/deploy/crds/jaegertracing.io_jaegers_crd.yaml
@@ -5047,6 +5047,8 @@ spec:
                       type: string
                     type: array
                     x-kubernetes-list-type: atomic
+                  ingressClassName:
+                    type: string
                   labels:
                     additionalProperties:
                       type: string

--- a/pkg/apis/jaegertracing/v1/jaeger_types.go
+++ b/pkg/apis/jaegertracing/v1/jaeger_types.go
@@ -329,6 +329,9 @@ type JaegerIngressSpec struct {
 	// +optional
 	// +kubebuilder:pruning:PreserveUnknownFields
 	Options Options `json:"options,omitempty"`
+
+	// +optional
+	IngressClassName *string `json:"ingressClassName,omitempty"`
 }
 
 // JaegerIngressTLSSpec defines the TLS configuration to be used when deploying the query ingress

--- a/pkg/apis/jaegertracing/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/jaegertracing/v1/zz_generated.deepcopy.go
@@ -527,6 +527,11 @@ func (in *JaegerIngressSpec) DeepCopyInto(out *JaegerIngressSpec) {
 	}
 	in.JaegerCommonSpec.DeepCopyInto(&out.JaegerCommonSpec)
 	in.Options.DeepCopyInto(&out.Options)
+	if in.IngressClassName != nil {
+		in, out := &in.IngressClassName, &out.IngressClassName
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/jaegertracing/v1/zz_generated.openapi.go
+++ b/pkg/apis/jaegertracing/v1/zz_generated.openapi.go
@@ -1608,6 +1608,12 @@ func schema_pkg_apis_jaegertracing_v1_JaegerIngressSpec(ref common.ReferenceCall
 							Ref: ref("./pkg/apis/jaegertracing/v1.Options"),
 						},
 					},
+					"ingressClassName": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/deployment/all_in_one.go
+++ b/pkg/deployment/all_in_one.go
@@ -66,7 +66,6 @@ func (a *AllInOne) Get() *appsv1.Deployment {
 	configmap.Update(a.jaeger, commonSpec, &options)
 	sampling.Update(a.jaeger, commonSpec, &options)
 
-
 	// If tls is not explicitly set, update jaeger CR with the tls flags according to the platform
 	if len(util.FindItem("--collector.grpc.tls.enabled=", options)) == 0 {
 		tls.Update(a.jaeger, commonSpec, &options)

--- a/pkg/ingress/query.go
+++ b/pkg/ingress/query.go
@@ -50,6 +50,10 @@ func (i *QueryIngress) Get() *networkingv1.Ingress {
 
 	i.addTLSSpec(&spec)
 
+	if i.jaeger.Spec.Ingress.IngressClassName != nil {
+		spec.IngressClassName = i.jaeger.Spec.Ingress.IngressClassName
+	}
+
 	return &networkingv1.Ingress{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Ingress",

--- a/pkg/ingress/query_test.go
+++ b/pkg/ingress/query_test.go
@@ -251,6 +251,24 @@ func TestQueryIngressTLSSecret(t *testing.T) {
 	assert.Equal(t, "test-secret", dep.Spec.TLS[0].SecretName)
 }
 
+func TestQueryIngressClass(t *testing.T) {
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestQueryIngressClass"})
+	jaegerNoIngressNoClass := v1.NewJaeger(types.NamespacedName{Name: "TestQueryIngressNoClass"})
+
+	inressClassName := "nginx"
+	jaeger.Spec.Ingress.IngressClassName = &inressClassName
+
+	ingress := NewQueryIngress(jaeger)
+	ingressNoClass := NewQueryIngress(jaegerNoIngressNoClass)
+
+	dep := ingress.Get()
+
+	assert.NotNil(t, dep.Spec.IngressClassName)
+	assert.Equal(t, "nginx", *dep.Spec.IngressClassName)
+	assert.Nil(t, ingressNoClass.Get().Spec.IngressClassName)
+
+}
+
 func TestQueryIngressTLSHosts(t *testing.T) {
 	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestQueryIngressTLSHosts"})
 


### PR DESCRIPTION
Signed-off-by: Ruben Vargas <ruben.vp8510@gmail.com>


## Which problem is this PR solving?
-  Fixes https://github.com/jaegertracing/jaeger-operator/issues/1550 

## Short description of the changes
-  Added `ingressClassName` field to the jaeger query ingress spec.

In old version of ingress API this was usually done with annotations (e.g. kubernetes.io/ingress.class). However, with the stable version of ingress API (networking.k8s.io/v1) the annotation way is deprecated and a new field `ingressClassName` is used for this.
