### PR TITLE
Allow sidecar injection for query pod from other Jaeger instances

### DIFF
--- a/pkg/controller/deployment/deployment_controller.go
+++ b/pkg/controller/deployment/deployment_controller.go
@@ -106,7 +106,7 @@ func (r *ReconcileDeployment) Reconcile(request reconcile.Request) (reconcile.Re
 		return reconcile.Result{}, tracing.HandleError(err, span)
 	}
 
-	if dep.Labels["app"] == "jaeger" {
+	if dep.Labels["app"] == "jaeger" && dep.Labels["app.kubernetes.io/component"] != "query" {
 		// Don't touch jaeger deployments
 		return reconcile.Result{}, nil
 	}

--- a/pkg/inject/sidecar.go
+++ b/pkg/inject/sidecar.go
@@ -104,7 +104,7 @@ func Needed(dep *appsv1.Deployment, ns *corev1.Namespace) bool {
 
 	// do not inject jaeger due to port collision
 	// do not inject if deployment's Annotation value is false
-	if dep.Labels["app"] == "jaeger" {
+	if dep.Labels["app"] == "jaeger" && dep.Labels["app.kubernetes.io/component"] != "query" {
 		return false
 	}
 

--- a/pkg/strategy/production.go
+++ b/pkg/strategy/production.go
@@ -120,9 +120,6 @@ func newProductionStrategy(ctx context.Context, jaeger *v1.Jaeger) S {
 	// prepare the deployments, which may get changed by the elasticsearch routine
 	cDep := collector.Get()
 	queryDep := inject.OAuthProxy(jaeger, query.Get())
-	if jaeger.Spec.Query.TracingEnabled == nil || *jaeger.Spec.Query.TracingEnabled == true {
-		queryDep = inject.Sidecar(jaeger, queryDep)
-	}
 	c.dependencies = storage.Dependencies(jaeger)
 
 	// assembles the pieces for an elasticsearch self-provisioned deployment via the elasticsearch operator

--- a/pkg/strategy/production_test.go
+++ b/pkg/strategy/production_test.go
@@ -192,8 +192,9 @@ func TestAgentSidecarIsInjectedIntoQueryForStreamingForProduction(t *testing.T) 
 	c := newProductionStrategy(context.Background(), j)
 	for _, dep := range c.Deployments() {
 		if strings.HasSuffix(dep.Name, "-query") {
-			assert.Equal(t, 2, len(dep.Spec.Template.Spec.Containers))
-			assert.Equal(t, "jaeger-agent", dep.Spec.Template.Spec.Containers[1].Name)
+			assert.Equal(t, "TestAgentSidecarIsInjectedIntoQueryForStreamingForProduction", dep.Annotations["sidecar.jaegertracing.io/inject"])
+			assert.Equal(t, 1, len(dep.Spec.Template.Spec.Containers))
+			assert.Equal(t, "jaeger-query", dep.Spec.Template.Spec.Containers[0].Name)
 		}
 	}
 }


### PR DESCRIPTION
This PR allows injecting jaeger-agent sidecar from another Jaeger instance to jaeger-query. 


If the tracing is enabled in jaeger-query deployment the operator adds an annotation `sidecar.jaegertracing.io/inject=<current-jaeger-instance>` to a created common spec object. The annotation is merged with annotations from the CR which allows overriding the instance name e.g.:

```yaml
apiVersion: jaegertracing.io/v1
kind: Jaeger
metadata:
  name: jaeger-tenant1
  namespace: rhosdt-tenant1
spec:
  strategy: production
  query:
    tracingEnabled: true
    annotations:
      sidecar.jaegertracing.io/inject: telemeter-jaeger
  storage:
    type: elasticsearch
    options:
      es:
        max-span-age: 168h # should match numberOfDays*24
    esIndexCleaner:
      enabled: true
      numberOfDays: 7
      schedule: "55 23 * * *"
    elasticsearch:
      nodeCount: 1
````