### PR TITLE
Avoid an error if the jaeger-operator-system was created

### DIFF
--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -7,7 +7,7 @@ kindContainers:
   - local/asserts:e2e
   - jaegertracing/vertx-create-span:operator-e2e-tests
 commands:
-  - command: kubectl create namespace jaeger-operator-system
+  - script: kubectl create namespace jaeger-operator-system 2>&1 | grep -v "already exists" || true
   - command: kubectl apply -f ./tests/_build/manifests/01-jaeger-operator.yaml -n jaeger-operator-system
   - command: kubectl wait --timeout=5m --for=condition=available deployment jaeger-operator -n jaeger-operator-system
   - command: kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.0.1/deploy/static/provider/kind/deploy.yaml


### PR DESCRIPTION
Signed-off-by: Israel Blancas <iblancas@redhat.com>

## Which problem is this PR solving?
- Solves #1573

## Short description of the changes
-  Not fail if the namespace was created previously
