### PR TITLE
Increase the timeout for the test

### DIFF
--- a/tests/e2e/allinone-ingress/00-assert.yaml
+++ b/tests/e2e/allinone-ingress/00-assert.yaml
@@ -1,3 +1,4 @@
+# Assert there is an ingress entry for the Jaeger query
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/tests/e2e/allinone-ingress/00-install.yaml
+++ b/tests/e2e/allinone-ingress/00-install.yaml
@@ -1,3 +1,4 @@
+# Install the Jaeger intance
 apiVersion: jaegertracing.io/v1
 kind: Jaeger
 metadata:

--- a/tests/e2e/allinone-ingress/01-assert.yaml
+++ b/tests/e2e/allinone-ingress/01-assert.yaml
@@ -1,0 +1,7 @@
+# Assert the spans are reported
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: report-span
+status:
+  succeeded: 1

--- a/tests/e2e/allinone-ingress/01-report-span.yaml
+++ b/tests/e2e/allinone-ingress/01-report-span.yaml
@@ -1,3 +1,4 @@
+# Report some spans
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/tests/e2e/allinone-ingress/02-check-ingress.yaml
+++ b/tests/e2e/allinone-ingress/02-check-ingress.yaml
@@ -1,6 +1,6 @@
+# Check the spans werer reported successfully and Jaeger query is reachable from
+# localhost
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: "kubectl wait --for=condition=complete --timeout=30s job/report-span"
-    namespaced: true
   - script: "go run ../../assert-jobs/query/main.go --service-name=my-test-service"


### PR DESCRIPTION
Signed-off-by: Israel Blancas <iblancas@redhat.com>

## Which problem is this PR solving?
- Resolves #1590

## Short description of the changes
- Use a `xx-assert.yaml` file instead of a `kubectl wait` command to assert a job was run properly.
