### PR TITLE
Ignore kubeconfig files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,5 @@ tags
 # End of https://www.gitignore.io/api/go,vim,emacs,visualstudiocode
 fmt.log
 import.log
+### Kubernetes ###
+kubeconfig


### PR DESCRIPTION
## Which problem is this PR solving?
- A `kubeconfig` file is created when running the KUTTL E2E tests. Changing the branch is not possible until that file is committed (not desired) or stashed (not desired because we probably want to reuse that `kubeconfig` to test another branch)
