### PR TITLE
Fix finding the correct instance when there are multiple jaeger instances during injecting the sidecar

### DIFF
--- a/pkg/inject/sidecar.go
+++ b/pkg/inject/sidecar.go
@@ -162,7 +162,8 @@ func getJaegerFromNamespace(namespace string, jaegers *v1.JaegerList) []*v1.Jaeg
 	for _, p := range jaegers.Items {
 		if p.Namespace == namespace {
 			// matched the namespace!
-			instances = append(instances, &p)
+			j := p
+			instances = append(instances, &j)
 		}
 	}
 	return instances


### PR DESCRIPTION

## Which problem is this PR solving?
- Resolves #1414
- Resolves #1317 

## Short description of the changes
- When `sidecar.jaegertracing.io/inject` annotation is set to `true` and there are multiple jaeger instances in the cluster, it always chooses the last jaeger instance (from the ordered list of `<namespace>/<jaeger-instance-name>` items). See https://github.com/jaegertracing/jaeger-operator/issues/1414#issuecomment-974802158 for more information.
