### PR TITLE
Disable metrics on generated manifest

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -21,7 +21,7 @@ bases:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 #- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
-- ../prometheus
+#- ../prometheus
 
 patchesStrategicMerge:
 # Protect the /metrics endpoint by putting it behind auth.

--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -4,7 +4,6 @@ crdDir: ./tests/_build/crds/
 artifactsDir: ./tests/_build/artifacts/
 commands:
   - script: kubectl create namespace jaeger-operator-system 2>&1 | grep -v "already exists" || true
-  - command: make deploy-prometheus-operator
   - command: kubectl apply -f ./tests/_build/manifests/01-jaeger-operator.yaml -n jaeger-operator-system
   - command: kubectl wait --timeout=5m --for=condition=available deployment jaeger-operator -n jaeger-operator-system
   - command: kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.0.1/deploy/static/provider/kind/deploy.yaml


### PR DESCRIPTION
Signed-off-by: Ruben Vargas <ruben.vp8510@gmail.com>

I had to disable metrics by default because if not the users trying to install the operator will be forced to install prometheus operator.