### PR TITLE
Use image without prefix v

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ OPERATOR_NAME ?= jaeger-operator
 IMG_PREFIX ?= quay.io/${USER}
 OPERATOR_VERSION ?= "$(shell grep -v '\#' versions.txt | grep operator | awk -F= '{print $$2}')"
 VERSION ?= "$(shell git describe --tags | sed 's/^v//')"
-IMG ?= ${IMG_PREFIX}/${OPERATOR_NAME}:$(addprefix v,${VERSION})
+IMG ?= ${IMG_PREFIX}/${OPERATOR_NAME}:${VERSION}
 BUNDLE_IMG ?= ${IMG_PREFIX}/${OPERATOR_NAME}-bundle:$(addprefix v,${VERSION})
 OUTPUT_BINARY ?= "$(BIN_DIR)/jaeger-operator"
 VERSION_PKG ?= "github.com/jaegertracing/jaeger-operator/pkg/version"

--- a/bundle/manifests/jaeger-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/jaeger-operator.clusterserviceversion.yaml
@@ -384,7 +384,7 @@ spec:
                       fieldPath: metadata.namespace
                 - name: OPERATOR_NAME
                   value: jaeger-operator
-                image: quay.io/jaegertracing/jaeger-operator:v1.29.0
+                image: quay.io/jaegertracing/jaeger-operator:1.29.0
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/jaegertracing/jaeger-operator
-  newTag: v1.29.0
+  newTag: 1.29.0


### PR DESCRIPTION
Signed-off-by: Megrez Lu <lujiajing1126@gmail.com>

The image pushed to the quay registry is not the same as we generate in the yaml.

https://quay.io/repository/jaegertracing/jaeger-operator?tag=latest&tab=tags

## Which problem is this PR solving?
- #1666 

## Short description of the changes

Remove `v` in the kustomization yaml file.

I suppose a new tag should be created to fix this flawed resource file.
