### PR TITLE
Register oschema for openshift resources 

### DIFF
--- a/pkg/cmd/start/bootstrap.go
+++ b/pkg/cmd/start/bootstrap.go
@@ -42,6 +42,9 @@ import (
 	"github.com/jaegertracing/jaeger-operator/pkg/upgrade"
 	"github.com/jaegertracing/jaeger-operator/pkg/util"
 	"github.com/jaegertracing/jaeger-operator/pkg/version"
+
+	consolev1 "github.com/openshift/api/console/v1"
+	routev1 "github.com/openshift/api/route/v1"
 )
 
 var (
@@ -53,6 +56,9 @@ func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(jaegertracingv1.AddToScheme(scheme))
 	utilruntime.Must(kafkav1beta2.AddToScheme(scheme))
+	utilruntime.Must(routev1.Install(scheme))
+	utilruntime.Must(osimagev1.Install(scheme))
+	utilruntime.Must(consolev1.Install(scheme))
 	//+kubebuilder:scaffold:scheme
 }
 


### PR DESCRIPTION

## Which problem is this PR solving?
- During the migration to operator-sdk 1.13 we miss to add some resource schemas. this PR fixes that

## Short description of the changes
- Register openshift , images and console link resources


@rkukura  Could you please review? Thanks!