### PR TITLE
util.Truncate add the values to the truncated after the excess is 0

### DIFF
--- a/pkg/util/truncate.go
+++ b/pkg/util/truncate.go
@@ -22,6 +22,8 @@ func Truncate(format string, max int, values ...interface{}) string {
 		// we try to reduce the first string we find
 		for _, value := range values {
 			if excess == 0 {
+				// add the values to the truncated so no formatting issues are encountered
+				truncated = append(truncated, value)
 				continue
 			}
 

--- a/pkg/util/truncate_test.go
+++ b/pkg/util/truncate_test.go
@@ -43,6 +43,13 @@ func TestTruncate(t *testing.T) {
 			cap:      "first value gets dropped, second truncated",
 		},
 		{
+			format:   "%s-%s-collector",
+			max:      63,
+			values:   []interface{}{"4d96-11ea-b174-c85b7644b6b5-5d0c1e62-4d96-11ea-b174-c85b7644b6b5", "d0c1e62"},
+			expected: "4d96-11ea-b174-c85b7644b6b5-5d0c1e62-4d96-11e-d0c1e62-collector",
+			cap:      "first value gets truncated, second added",
+		},
+		{
 			format:   "%d-%s-collector",
 			max:      63,
 			values:   []interface{}{42, "d0c1e62-4d96-11ea-b174-c85b7644b6b5-5d0c1e62-4d96-11ea-b174-c85b7644b6b5"},


### PR DESCRIPTION
## Which problem is this PR solving?
Resolves: #1677

## Short description of the changes
-  If the excess goes to 0, we continue to add the values to the truncated list to avoid formatting errors
