### PR TITLE
Restore default metrics port to avoid breaking helm

### DIFF
--- a/bundle/manifests/jaeger-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/jaeger-operator.clusterserviceversion.yaml
@@ -357,7 +357,7 @@ spec:
               containers:
               - args:
                 - --secure-listen-address=0.0.0.0:8443
-                - --upstream=http://127.0.0.1:8080/
+                - --upstream=http://127.0.0.1:8383/
                 - --logtostderr=true
                 - --v=10
                 image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -12,7 +12,7 @@ spec:
         image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
-        - "--upstream=http://127.0.0.1:8080/"
+        - "--upstream=http://127.0.0.1:8383/"
         - "--logtostderr=true"
         - "--v=10"
         ports:

--- a/pkg/cmd/start/main.go
+++ b/pkg/cmd/start/main.go
@@ -57,7 +57,7 @@ func NewStartCommand() *cobra.Command {
 
 	AddFlags(cmd)
 	cmd.Flags().String("metrics-host", "0.0.0.0", "The host to bind the metrics port")
-	cmd.Flags().Int32("metrics-port", 8080, "The metrics port")
+	cmd.Flags().Int32("metrics-port", 8383, "The metrics port")
 	cmd.Flags().Int32("cr-metrics-port", 8686, "The metrics port for Operator and/or Custom Resource based metrics")
 	cmd.Flags().String("jaeger-agent-hostport", "localhost:6831", "The location for the Jaeger Agent")
 	cmd.Flags().Bool("tracing-enabled", false, "Whether the Operator should report its own spans to a Jaeger instance")


### PR DESCRIPTION
Signed-off-by: Ruben Vargas <ruben.vp8510@gmail.com>

## Which problem is this PR solving?
Fixes https://github.com/jaegertracing/jaeger-operator/issues/1697 


