### PR TITLE
Avoid calling k8s api for each resource kind on the cluster

### DIFF
--- a/pkg/autodetect/main.go
+++ b/pkg/autodetect/main.go
@@ -22,7 +22,7 @@ import (
 	"github.com/jaegertracing/jaeger-operator/pkg/inject"
 )
 
-var listenedGroupsMap = map[string]struct{}{"logging.openshift.io": struct{}{}, "kafka.strimzi.io": struct{}{}, "route.openshift.io": struct{}{}}
+var listenedGroupsMap = map[string]bool{"logging.openshift.io": true, "kafka.strimzi.io": true, "route.openshift.io": true}
 
 // Background represents a procedure that runs in the background, periodically auto-detecting features
 type Background struct {
@@ -113,8 +113,7 @@ func (b *Background) autoDetectCapabilities() {
 }
 
 func (b *Background) isInListenedGroups(group metav1.APIGroup) bool {
-	_, exists := listenedGroupsMap[group.Name]
-	return exists
+	return listenedGroupsMap[group.Name]
 }
 
 func (b *Background) availableAPIs(_ context.Context) ([]*metav1.APIResourceList, error) {


### PR DESCRIPTION
Signed-off-by: Ruben Vargas <ruben.vp8510@gmail.com>

## Which problem is this PR solving?
- This PR should fixes [Issue-1684](https://github.com/jaegertracing/jaeger-operator/issues/1684) or at least alleviate the problem, The message of _"Waited for Xs due to client-side throttling, not priority and fairness"_ is caused because a lot of API calls to K8s. It seems like calling  `PreferedServerResources` does a lot of calls to the API when the cluster has a lot of different resource Kinds.



## Short description of the changes
- To avoid this, in this PR we ask for `ServerGroups`  and then only get the resources for our interested Groups.


Note: I still see one line in the log with the error "Waited Xs.." but one single time, I don't see the same error repeating in logs each N seconds. so I think this can be considered a fix.