### PR TITLE
First call of autodetect should be synchronous

### DIFF
--- a/pkg/autodetect/main.go
+++ b/pkg/autodetect/main.go
@@ -63,18 +63,12 @@ func WithClients(cl client.Client, dcl discovery.DiscoveryInterface, clr client.
 func (b *Background) Start() {
 	// periodically attempts to auto detect all the capabilities for this operator
 	b.ticker = time.NewTicker(5 * time.Second)
-
-	done := make(chan bool)
-	go func() {
-		b.autoDetectCapabilities()
-		done <- true
-	}()
+	b.autoDetectCapabilities()
+	log.Trace("finished the first auto-detection")
 
 	go func() {
 		for {
 			select {
-			case <-done:
-				log.Trace("finished the first auto-detection")
 			case <-b.ticker.C:
 				b.autoDetectCapabilities()
 			}

--- a/pkg/cmd/start/bootstrap.go
+++ b/pkg/cmd/start/bootstrap.go
@@ -105,6 +105,12 @@ func bootstrap(ctx context.Context) manager.Manager {
 
 	mgr := createManager(ctx, cfg)
 
+	if d, err := autodetect.New(mgr); err != nil {
+		log.WithError(err).Warn("failed to start the background process to auto-detect the operator capabilities")
+	} else {
+		d.Start()
+	}
+
 	detectNamespacePermissions(ctx, mgr)
 	performUpgrades(ctx, mgr)
 	setupControllers(ctx, mgr)
@@ -112,11 +118,6 @@ func bootstrap(ctx context.Context) manager.Manager {
 	err = opmetrics.Bootstrap(ctx, namespace, mgr.GetClient())
 	if err != nil {
 		log.WithError(err).Error("failed to initialize metrics")
-	}
-	if d, err := autodetect.New(mgr); err != nil {
-		log.WithError(err).Warn("failed to start the background process to auto-detect the operator capabilities")
-	} else {
-		d.Start()
 	}
 	return mgr
 }


### PR DESCRIPTION
Signed-off-by: Ruben Vargas <ruben.vp8510@gmail.com>


## Which problem is this PR solving?
- Other initialization routines relies on platform value to do certain detection, in this particular case the oauth image was not detected correctly.


## Short description of the changes
- We need to make sure to detect the platform before doing any other initialization. In order to do that I made the first call of auto-detect synchronous (other calls will happens as usual, each 5 sec) . I think we should not have problems with this, but if this is a problem we can at least change the platform detection to be sync on the first call.
