### PR TITLE
Only expose the query-http[s] port in the OpenShift route

### DIFF
--- a/pkg/route/query.go
+++ b/pkg/route/query.go
@@ -3,6 +3,7 @@ package route
 import (
 	corev1 "github.com/openshift/api/route/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	v1 "github.com/jaegertracing/jaeger-operator/apis/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/service"
@@ -67,6 +68,9 @@ func (r *QueryRoute) Get() *corev1.Route {
 			To: corev1.RouteTargetReference{
 				Kind: "Service",
 				Name: service.GetNameForQueryService(r.jaeger),
+			},
+			Port: &corev1.RoutePort{
+				TargetPort: intstr.FromString(service.GetPortNameForQueryService(r.jaeger)),
 			},
 			TLS: &corev1.TLSConfig{
 				Termination: termination,

--- a/pkg/route/query_test.go
+++ b/pkg/route/query_test.go
@@ -6,6 +6,7 @@ import (
 	corev1 "github.com/openshift/api/route/v1"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	v1 "github.com/jaegertracing/jaeger-operator/apis/v1"
 )
@@ -44,20 +45,22 @@ func TestQueryRouteEnabled(t *testing.T) {
 	assert.NotNil(t, dep)
 }
 
-func TestQueryRouteTerminationTypeWithOAuthProxy(t *testing.T) {
-	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestQueryRouteTerminationTypeWithOAuthProxy"})
+func TestQueryRouteWithOAuthProxy(t *testing.T) {
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestQueryRouteWithOAuthProxy"})
 	jaeger.Spec.Ingress.Security = v1.IngressSecurityOAuthProxy
 	route := NewQueryRoute(jaeger)
 
 	r := route.Get()
 	assert.Equal(t, corev1.TLSTerminationReencrypt, r.Spec.TLS.Termination)
+	assert.Equal(t, intstr.FromString("https-query"), r.Spec.Port.TargetPort)
 }
 
-func TestQueryRouteTerminationTypeWithoutOAuthProxy(t *testing.T) {
-	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestQueryRouteTerminationTypeWithOAuthProxy"})
+func TestQueryRouteWithoutOAuthProxy(t *testing.T) {
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestQueryRouteWithOAuthProxy"})
 	jaeger.Spec.Ingress.Security = v1.IngressSecurityNone
 	route := NewQueryRoute(jaeger)
 
 	r := route.Get()
 	assert.Equal(t, corev1.TLSTerminationEdge, r.Spec.TLS.Termination)
+	assert.Equal(t, intstr.FromString("http-query"), r.Spec.Port.TargetPort)
 }

--- a/pkg/service/query.go
+++ b/pkg/service/query.go
@@ -20,7 +20,7 @@ func NewQueryService(jaeger *v1.Jaeger, selector map[string]string) *corev1.Serv
 
 	ports := []corev1.ServicePort{
 		{
-			Name:       getPortNameForQueryService(jaeger),
+			Name:       GetPortNameForQueryService(jaeger),
 			Port:       int32(GetPortForQueryService(jaeger)),
 			TargetPort: intstr.FromInt(getTargetPortForQueryService(jaeger)),
 		},
@@ -74,7 +74,7 @@ func GetTLSSecretNameForQueryService(jaeger *v1.Jaeger) string {
 	return util.DNSName(util.Truncate("%s-ui-oauth-proxy-tls", 63, jaeger.Name))
 }
 
-// GetPortForQueryService returns the query service name for this Jaeger instance
+// GetPortForQueryService returns the query service port number for this Jaeger instance
 func GetPortForQueryService(jaeger *v1.Jaeger) int {
 	if jaeger.Spec.Ingress.Security == v1.IngressSecurityOAuthProxy {
 		return 443
@@ -82,7 +82,8 @@ func GetPortForQueryService(jaeger *v1.Jaeger) int {
 	return 16686
 }
 
-func getPortNameForQueryService(jaeger *v1.Jaeger) string {
+// GetPortNameForQueryService returns the query service port name for this Jaeger instance
+func GetPortNameForQueryService(jaeger *v1.Jaeger) string {
 	if jaeger.Spec.Ingress.Security == v1.IngressSecurityOAuthProxy {
 		return "https-query"
 	}


### PR DESCRIPTION
Signed-off-by: Robert Kukura <rkukura@redhat.com>

## Which problem is this PR solving?
- Eliminates warnings logged every 5 seconds due to OpenShift's router attempting to perform health checks on the query-grpc port.

## Short description of the changes
- Include spec.port.targetPort selecting the query-http[s] port in the OpenShift route.
