### PR TITLE
#1729: improve robustness of wait-cronjob

### DIFF
--- a/tests/cmd-utils/wait-cronjob/main.go
+++ b/tests/cmd-utils/wait-cronjob/main.go
@@ -42,7 +42,7 @@ func checkCronJobExists(clientset *kubernetes.Clientset) error {
 	retryInterval := viper.GetDuration(flagRetryInterval)
 	timeout := viper.GetDuration(flagTimeout)
 
-	log.Debugln("Checking if the", cronjobName, "CronJob exists")
+	logrus.Debugln("Checking if the", cronjobName, "CronJob exists")
 
 	err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
 		ctxWithTimeout, cancel := context.WithTimeout(context.Background(), timeout)
@@ -51,10 +51,10 @@ func checkCronJobExists(clientset *kubernetes.Clientset) error {
 		cronjobs, err := clientset.BatchV1beta1().CronJobs(namespace).List(ctxWithTimeout, metav1.ListOptions{})
 		if err != nil {
 			if apierrors.IsNotFound(err) {
-				log.Debug("No cronjobs were found")
+				logrus.Debug("No cronjobs were found")
 				return false, nil
 			}
-			return false, err
+			return false, nil
 		}
 
 		for _, cronjob := range cronjobs.Items {
@@ -63,10 +63,15 @@ func checkCronJobExists(clientset *kubernetes.Clientset) error {
 			}
 		}
 
-		return false, fmt.Errorf(fmt.Sprintf("The %s CronJob was not found", cronjobName))
+		logrus.Warningln("The Cronjob", cronjobName, "was not found")
+		logrus.Debugln("Found cronjobs:")
+		for _, cronjob := range cronjobs.Items {
+			logrus.Debugln("\t", cronjob.Name)
+		}
+		return false, nil
 	})
 
-	log.Debugln("Cronjob", cronjobName, "found successfully")
+	logrus.Infoln("Cronjob", cronjobName, "found successfully")
 	return err
 }
 
@@ -79,7 +84,7 @@ func waitForNextJob(clientset *kubernetes.Clientset) error {
 	timeout := viper.GetDuration(flagTimeout)
 	start := time.Now()
 
-	log.Debugln("Waiting for the next scheduled job from", cronjobName, "cronjob")
+	logrus.Debugln("Waiting for the next scheduled job from", cronjobName, "cronjob")
 	err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
 		ctxWithTimeout, cancel := context.WithTimeout(context.Background(), timeout)
 		defer cancel()
@@ -87,7 +92,7 @@ func waitForNextJob(clientset *kubernetes.Clientset) error {
 		jobList, err := clientset.BatchV1().Jobs(namespace).List(ctxWithTimeout, metav1.ListOptions{})
 		if err != nil {
 			if apierrors.IsNotFound(err) {
-				log.Debugf("No jobs provided by the Kubernetes API")
+				logrus.Debug("No jobs provided by the Kubernetes API")
 				return false, nil
 			}
 			return false, err
@@ -117,10 +122,10 @@ func waitForNextJob(clientset *kubernetes.Clientset) error {
 			}
 		}
 
-		log.Debugln("Waiting for next job from", cronjobName, "to succeed")
+		logrus.Debugln("Waiting for next job from", cronjobName, "to succeed")
 		return false, nil
 	})
-	log.Debugln("Job of owner", cronjobName, "succeeded after", cronjobName, time.Since(start))
+	logrus.Infoln("Job of owner", cronjobName, "succeeded after", cronjobName, time.Since(start))
 	return err
 }
 
@@ -147,11 +152,11 @@ func initCmd() error {
 	viper.SetDefault(flagcronJobName, "")
 	flag.String(flagcronJobName, "", "Cronjob name")
 
-	viper.SetDefault(flagRetryInterval, time.Second*5)
-	flag.Duration(flagRetryInterval, time.Second*5, "Retry interval")
+	viper.SetDefault(flagRetryInterval, time.Second*10)
+	flag.Duration(flagRetryInterval, time.Second*10, "Retry interval")
 
-	viper.SetDefault(flagTimeout, time.Minute)
-	flag.Duration(flagTimeout, time.Minute, "Timeout")
+	viper.SetDefault(flagTimeout, time.Hour)
+	flag.Duration(flagTimeout, time.Hour, "Timeout")
 
 	viper.SetDefault(flagNamespace, "default")
 	flag.String(flagNamespace, "", "Kubernetes namespace")

--- a/tests/cmd-utils/wait-cronjob/main.go
+++ b/tests/cmd-utils/wait-cronjob/main.go
@@ -52,7 +52,6 @@ func checkCronJobExists(clientset *kubernetes.Clientset) error {
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				logrus.Debug("No cronjobs were found")
-				return false, nil
 			}
 			return false, nil
 		}


### PR DESCRIPTION
Signed-off-by: Israel Blancas <iblancas@redhat.com>

## Which problem is this PR solving?
-#1729

## Short description of the changes
- Fix some issues in the logging
- Avoid stopping the program when the cronjob is not found
- Increase the default timeout of the program to ensure it is bigger than the timeout set by KUTTL
