### PR TITLE
get rid of deprication warning when installing dependencies

### DIFF
--- a/.ci/vgot.sh
+++ b/.ci/vgot.sh
@@ -8,7 +8,7 @@ cd "$d"
 go mod init temp >/dev/null 2>&1
 for i; do
     pkg=`echo $i | sed 's/@.*//'`
-    go get "$i" &&
+    go get -d "$i" &&
     go install "$pkg" &&
     echo installed `go list -f '{{.ImportPath}}@{{.Module.Version}}' "$pkg"`
 done


### PR DESCRIPTION
Closes #1641

Signed-off-by: Benedikt Bongartz <bongartz@klimlive.de>

