### PR TITLE
Automatically set num shards and replicas from referenced OCP ES

### DIFF
--- a/apis/v1/jaeger_types.go
+++ b/apis/v1/jaeger_types.go
@@ -1,11 +1,10 @@
 package v1
 
 import (
+	esv1 "github.com/openshift/elasticsearch-operator/apis/logging/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	esv1 "github.com/openshift/elasticsearch-operator/apis/logging/v1"
 )
 
 // IngressSecurityType represents the possible values for the security type

--- a/apis/v1/jaeger_webhook.go
+++ b/apis/v1/jaeger_webhook.go
@@ -1,8 +1,15 @@
 package v1
 
 import (
+	"context"
+	"fmt"
+
+	esv1 "github.com/openshift/elasticsearch-operator/apis/logging/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
@@ -12,10 +19,14 @@ const (
 )
 
 // log is for logging in this package.
-var jaegerlog = logf.Log.WithName("jaeger-resource")
+var (
+	jaegerlog = logf.Log.WithName("jaeger-resource")
+	cl        client.Client
+)
 
 // SetupWebhookWithManager adds Jaeger webook to the manager.
 func (j *Jaeger) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	cl = mgr.GetClient()
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(j).
 		Complete()
@@ -31,6 +42,19 @@ func (j *Jaeger) Default() {
 
 	if j.Spec.Storage.Elasticsearch.Name == "" {
 		j.Spec.Storage.Elasticsearch.Name = defaultElasticsearchName
+	}
+
+	if ShouldInjectOpenShiftElasticsearchConfiguration(j.Spec.Storage) && j.Spec.Storage.Elasticsearch.DoNotProvision {
+		// check if ES instance exists
+		es := &esv1.Elasticsearch{}
+		err := cl.Get(context.Background(), types.NamespacedName{
+			Namespace: j.Namespace,
+			Name:      j.Spec.Storage.Elasticsearch.Name,
+		}, es)
+		if errors.IsNotFound(err) {
+			return
+		}
+		j.Spec.Storage.Elasticsearch.NodeCount = OpenShiftElasticsearchNodeCount(es.Spec)
 	}
 }
 
@@ -48,6 +72,18 @@ func (j *Jaeger) ValidateCreate() error {
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (j *Jaeger) ValidateUpdate(_ runtime.Object) error {
 	jaegerlog.Info("validate update", "name", j.Name)
+
+	if ShouldInjectOpenShiftElasticsearchConfiguration(j.Spec.Storage) && j.Spec.Storage.Elasticsearch.DoNotProvision {
+		// check if ES instance exists
+		es := &esv1.Elasticsearch{}
+		err := cl.Get(context.Background(), types.NamespacedName{
+			Namespace: j.Namespace,
+			Name:      j.Spec.Storage.Elasticsearch.Name,
+		}, es)
+		if errors.IsNotFound(err) {
+			return fmt.Errorf("elasticsearch instance not found: %v", err)
+		}
+	}
 	return nil
 }
 
@@ -55,4 +91,20 @@ func (j *Jaeger) ValidateUpdate(_ runtime.Object) error {
 func (j *Jaeger) ValidateDelete() error {
 	jaegerlog.Info("validate delete", "name", j.Name)
 	return nil
+}
+
+func OpenShiftElasticsearchNodeCount(spec esv1.ElasticsearchSpec) int32 {
+	nodes := int32(0)
+	for i := 0; i < len(spec.Nodes); i++ {
+		nodes += spec.Nodes[i].NodeCount
+	}
+	return nodes
+}
+
+func ShouldInjectOpenShiftElasticsearchConfiguration(s JaegerStorageSpec) bool {
+	if s.Type != JaegerESStorage {
+		return false
+	}
+	_, ok := s.Options.Map()["es.server-urls"]
+	return !ok
 }

--- a/apis/v1/jaeger_webhook.go
+++ b/apis/v1/jaeger_webhook.go
@@ -93,6 +93,7 @@ func (j *Jaeger) ValidateDelete() error {
 	return nil
 }
 
+// OpenShiftElasticsearchNodeCount returns total node count of Elasticsearch nodes.
 func OpenShiftElasticsearchNodeCount(spec esv1.ElasticsearchSpec) int32 {
 	nodes := int32(0)
 	for i := 0; i < len(spec.Nodes); i++ {
@@ -101,6 +102,7 @@ func OpenShiftElasticsearchNodeCount(spec esv1.ElasticsearchSpec) int32 {
 	return nodes
 }
 
+// ShouldInjectOpenShiftElasticsearchConfiguration returns true if OpenShift Elasticsearch is used and its configuration should be used.
 func ShouldInjectOpenShiftElasticsearchConfiguration(s JaegerStorageSpec) bool {
 	if s.Type != JaegerESStorage {
 		return false

--- a/apis/v1/jaeger_webhook_test.go
+++ b/apis/v1/jaeger_webhook_test.go
@@ -147,7 +147,6 @@ func TestValidate(t *testing.T) {
 		name         string
 		objsToCreate []runtime.Object
 		current      *Jaeger
-		old          *Jaeger
 		err          string
 	}{
 		{
@@ -221,7 +220,7 @@ func TestValidate(t *testing.T) {
 			fakeCl := fake.NewClientBuilder().WithRuntimeObjects(test.objsToCreate...).Build()
 			cl = fakeCl
 
-			err := test.current.ValidateUpdate(test.old)
+			err := test.current.ValidateCreate()
 			if test.err != "" {
 				assert.Equal(t, test.err, err.Error())
 			} else {

--- a/apis/v1/jaeger_webhook_test.go
+++ b/apis/v1/jaeger_webhook_test.go
@@ -1,0 +1,249 @@
+package v1
+
+import (
+	"fmt"
+	"testing"
+
+	esv1 "github.com/openshift/elasticsearch-operator/apis/logging/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefault(t *testing.T) {
+	tests := []struct {
+		name     string
+		objs     []runtime.Object
+		j        *Jaeger
+		expected *Jaeger
+	}{
+		{
+			name: "set missing ES name",
+			j: &Jaeger{
+				Spec: JaegerSpec{
+					Storage: JaegerStorageSpec{
+						Elasticsearch: ElasticsearchSpec{
+							Name: "",
+						},
+					},
+				},
+			},
+			expected: &Jaeger{
+				Spec: JaegerSpec{
+					Storage: JaegerStorageSpec{
+						Elasticsearch: ElasticsearchSpec{
+							Name: "elasticsearch",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "set ES node count",
+			objs: []runtime.Object{
+				&corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "project1",
+					},
+				},
+				&esv1.Elasticsearch{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-es",
+						Namespace: "project1",
+					},
+					Spec: esv1.ElasticsearchSpec{
+						Nodes: []esv1.ElasticsearchNode{
+							{
+								NodeCount: 3,
+							},
+						},
+					},
+				},
+			},
+			j: &Jaeger{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "project1",
+				},
+				Spec: JaegerSpec{
+					Storage: JaegerStorageSpec{
+						Type: "elasticsearch",
+						Elasticsearch: ElasticsearchSpec{
+							Name:           "my-es",
+							DoNotProvision: true,
+						},
+					},
+				},
+			},
+			expected: &Jaeger{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "project1",
+				},
+				Spec: JaegerSpec{
+					Storage: JaegerStorageSpec{
+						Type: "elasticsearch",
+						Elasticsearch: ElasticsearchSpec{
+							Name:           "my-es",
+							NodeCount:      3,
+							DoNotProvision: true,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "do not set ES node count",
+			j: &Jaeger{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "project1",
+				},
+				Spec: JaegerSpec{
+					Storage: JaegerStorageSpec{
+						Type: "elasticsearch",
+						Elasticsearch: ElasticsearchSpec{
+							Name:           "my-es",
+							DoNotProvision: false,
+							NodeCount:      1,
+						},
+					},
+				},
+			},
+			expected: &Jaeger{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "project1",
+				},
+				Spec: JaegerSpec{
+					Storage: JaegerStorageSpec{
+						Type: "elasticsearch",
+						Elasticsearch: ElasticsearchSpec{
+							Name:           "my-es",
+							NodeCount:      1,
+							DoNotProvision: false,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			esv1.AddToScheme(scheme.Scheme)
+			AddToScheme(scheme.Scheme)
+			fakeCl := fake.NewClientBuilder().WithRuntimeObjects(test.objs...).Build()
+			cl = fakeCl
+
+			test.j.Default()
+			assert.Equal(t, test.expected, test.j)
+		})
+	}
+}
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name         string
+		objsToCreate []runtime.Object
+		current      *Jaeger
+		old          *Jaeger
+		err          string
+	}{
+		{
+			name: "ES instance exists",
+			objsToCreate: []runtime.Object{
+				&corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "project1",
+					},
+				},
+				&esv1.Elasticsearch{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-es",
+						Namespace: "project1",
+					},
+					Spec: esv1.ElasticsearchSpec{
+						Nodes: []esv1.ElasticsearchNode{
+							{
+								NodeCount: 3,
+							},
+						},
+					},
+				},
+			},
+			current: &Jaeger{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "project1",
+				},
+				Spec: JaegerSpec{
+					Storage: JaegerStorageSpec{
+						Type: "elasticsearch",
+						Elasticsearch: ElasticsearchSpec{
+							Name:           "my-es",
+							DoNotProvision: true,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "ES instance does not exist",
+			objsToCreate: []runtime.Object{
+				&corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "project1",
+					},
+				},
+			},
+			current: &Jaeger{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "project1",
+				},
+				Spec: JaegerSpec{
+					Storage: JaegerStorageSpec{
+						Type: "elasticsearch",
+						Elasticsearch: ElasticsearchSpec{
+							Name:           "my-es",
+							DoNotProvision: true,
+						},
+					},
+				},
+			},
+			err: `elasticsearch instance not found: elasticsearchs.logging.openshift.io "my-es" not found`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			esv1.AddToScheme(scheme.Scheme)
+			AddToScheme(scheme.Scheme)
+			fakeCl := fake.NewClientBuilder().WithRuntimeObjects(test.objsToCreate...).Build()
+			cl = fakeCl
+
+			err := test.current.ValidateUpdate(test.old)
+			if test.err != "" {
+				assert.Equal(t, test.err, err.Error())
+			} else {
+				assert.Nil(t, err)
+			}
+		})
+	}
+}
+
+func TestShouldDeployElasticsearch(t *testing.T) {
+	tests := []struct {
+		j        JaegerStorageSpec
+		expected bool
+	}{
+		{j: JaegerStorageSpec{}},
+		{j: JaegerStorageSpec{Type: JaegerCassandraStorage}},
+		{j: JaegerStorageSpec{Type: JaegerESStorage, Options: NewOptions(map[string]interface{}{"es.server-urls": "foo"})}},
+		{j: JaegerStorageSpec{Type: JaegerESStorage}, expected: true},
+	}
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			assert.Equal(t, test.expected, ShouldInjectOpenShiftElasticsearchConfiguration(test.j))
+		})
+	}
+}

--- a/bundle/manifests/jaeger-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/jaeger-operator.clusterserviceversion.yaml
@@ -300,6 +300,18 @@ spec:
         - apiGroups:
           - logging.openshift.io
           resources:
+          - elasticsearch
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - logging.openshift.io
+          resources:
           - elasticsearches
           verbs:
           - create

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -187,6 +187,18 @@ rules:
 - apiGroups:
   - logging.openshift.io
   resources:
+  - elasticsearch
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - logging.openshift.io
+  resources:
   - elasticsearches
   verbs:
   - create

--- a/controllers/elasticsearch/elasticsearch_controller.go
+++ b/controllers/elasticsearch/elasticsearch_controller.go
@@ -33,11 +33,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
-	esKindInstalled, err := isOpenShiftElasticsearchController(mgr)
+	esCRDInstalled, err := isOpenShiftESCRDAvailable(mgr)
 	if err != nil {
 		return err
 	}
-	if esKindInstalled {
+	if esCRDInstalled {
 		return ctrl.NewControllerManagedBy(mgr).
 			For(&esv1.Elasticsearch{}).
 			Complete(r)
@@ -47,7 +47,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 const elasticsearchGroup = "logging.openshift.io"
 
-func isOpenShiftElasticsearchController(mgr ctrl.Manager) (bool, error) {
+func isOpenShiftESCRDAvailable(mgr ctrl.Manager) (bool, error) {
 	dcl, err := discovery.NewDiscoveryClientForConfig(mgr.GetConfig())
 	if err != nil {
 		return false, err

--- a/controllers/elasticsearch/elasticsearch_controller.go
+++ b/controllers/elasticsearch/elasticsearch_controller.go
@@ -2,14 +2,13 @@ package elasticsearch
 
 import (
 	"context"
-	"strings"
 
 	esv1 "github.com/openshift/elasticsearch-operator/apis/logging/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/discovery"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/jaegertracing/jaeger-operator/pkg/autodetect"
 	"github.com/jaegertracing/jaeger-operator/pkg/controller/elasticsearch"
 )
 
@@ -47,37 +46,15 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 const elasticsearchGroup = "logging.openshift.io"
-const elasticsearchKind = "Elasticsearch"
 
 func isOpenShiftElasticsearchController(mgr ctrl.Manager) (bool, error) {
 	dcl, err := discovery.NewDiscoveryClientForConfig(mgr.GetConfig())
 	if err != nil {
 		return false, err
 	}
-	var apiLists []*metav1.APIResourceList
-	groupList, err := dcl.ServerGroups()
+	apiLists, err := autodetect.AvailableAPIs(dcl, map[string]bool{elasticsearchGroup: true})
 	if err != nil {
 		return false, err
 	}
-
-	for _, sg := range groupList.Groups {
-		if sg.Name == elasticsearchGroup {
-			groupAPIList, err := dcl.ServerResourcesForGroupVersion(sg.PreferredVersion.GroupVersion)
-			if err != nil {
-				return false, err
-			}
-			apiLists = append(apiLists, groupAPIList)
-		}
-	}
-
-	for _, r := range apiLists {
-		if strings.HasPrefix(r.GroupVersion, elasticsearchGroup) {
-			for _, api := range r.APIResources {
-				if api.Kind == elasticsearchKind {
-					return true, nil
-				}
-			}
-		}
-	}
-	return false, nil
+	return autodetect.IsElasticsearchOperatorAvailable(apiLists), nil
 }

--- a/controllers/elasticsearch/elasticsearch_controller.go
+++ b/controllers/elasticsearch/elasticsearch_controller.go
@@ -2,8 +2,11 @@ package elasticsearch
 
 import (
 	"context"
+	"strings"
 
 	esv1 "github.com/openshift/elasticsearch-operator/apis/logging/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/discovery"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -31,7 +34,50 @@ func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
-		For(&esv1.Elasticsearch{}).
-		Complete(r)
+	esKindInstalled, err := isOpenShiftElasticsearchController(mgr)
+	if err != nil {
+		return err
+	}
+	if esKindInstalled {
+		return ctrl.NewControllerManagedBy(mgr).
+			For(&esv1.Elasticsearch{}).
+			Complete(r)
+	}
+	return nil
+}
+
+const elasticsearchGroup = "logging.openshift.io"
+const elasticsearchKind = "Elasticsearch"
+
+func isOpenShiftElasticsearchController(mgr ctrl.Manager) (bool, error) {
+	dcl, err := discovery.NewDiscoveryClientForConfig(mgr.GetConfig())
+	if err != nil {
+		return false, err
+	}
+	var apiLists []*metav1.APIResourceList
+	groupList, err := dcl.ServerGroups()
+	if err != nil {
+		return false, err
+	}
+
+	for _, sg := range groupList.Groups {
+		if sg.Name == elasticsearchGroup {
+			groupAPIList, err := dcl.ServerResourcesForGroupVersion(sg.PreferredVersion.GroupVersion)
+			if err != nil {
+				return false, err
+			}
+			apiLists = append(apiLists, groupAPIList)
+		}
+	}
+
+	for _, r := range apiLists {
+		if strings.HasPrefix(r.GroupVersion, elasticsearchGroup) {
+			for _, api := range r.APIResources {
+				if api.Kind == elasticsearchKind {
+					return true, nil
+				}
+			}
+		}
+	}
+	return false, nil
 }

--- a/controllers/elasticsearch/elasticsearch_controller.go
+++ b/controllers/elasticsearch/elasticsearch_controller.go
@@ -10,14 +10,14 @@ import (
 	"github.com/jaegertracing/jaeger-operator/pkg/controller/elasticsearch"
 )
 
-// ElasticsearchReconciler reconciles a Deployment object
-type ElasticsearchReconciler struct {
+// Reconciler reconciles a Deployment object
+type Reconciler struct {
 	reconcilier *elasticsearch.ReconcileElasticsearch
 }
 
-// NewElasticsearchReconciler creates a new deployment reconciler controller
-func NewElasticsearchReconciler(client client.Client, clientReader client.Reader) *ElasticsearchReconciler {
-	return &ElasticsearchReconciler{
+// NewReconciler creates a new deployment reconciler controller
+func NewReconciler(client client.Client, clientReader client.Reader) *Reconciler {
+	return &Reconciler{
 		reconcilier: elasticsearch.New(client, clientReader),
 	}
 }
@@ -25,12 +25,12 @@ func NewElasticsearchReconciler(client client.Client, clientReader client.Reader
 // +kubebuilder:rbac:groups=logging.openshift.io,resources=elasticsearch,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile deployment resource
-func (r *ElasticsearchReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
+func (r *Reconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
 	return r.reconcilier.Reconcile(ctx, request)
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *ElasticsearchReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&esv1.Elasticsearch{}).
 		Complete(r)

--- a/controllers/elasticsearch/elasticsearch_controller.go
+++ b/controllers/elasticsearch/elasticsearch_controller.go
@@ -1,0 +1,37 @@
+package elasticsearch
+
+import (
+	"context"
+
+	esv1 "github.com/openshift/elasticsearch-operator/apis/logging/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/jaegertracing/jaeger-operator/pkg/controller/elasticsearch"
+)
+
+// ElasticsearchReconciler reconciles a Deployment object
+type ElasticsearchReconciler struct {
+	reconcilier *elasticsearch.ReconcileElasticsearch
+}
+
+// NewElasticsearchReconciler creates a new deployment reconciler controller
+func NewElasticsearchReconciler(client client.Client, clientReader client.Reader) *ElasticsearchReconciler {
+	return &ElasticsearchReconciler{
+		reconcilier: elasticsearch.New(client, clientReader),
+	}
+}
+
+// +kubebuilder:rbac:groups=logging.openshift.io,resources=elasticsearch,verbs=get;list;watch;create;update;patch;delete
+
+// Reconcile deployment resource
+func (r *ElasticsearchReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
+	return r.reconcilier.Reconcile(ctx, request)
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *ElasticsearchReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&esv1.Elasticsearch{}).
+		Complete(r)
+}

--- a/pkg/autodetect/main.go
+++ b/pkg/autodetect/main.go
@@ -106,6 +106,7 @@ func (b *Background) autoDetectCapabilities() {
 	b.cleanDeployments(ctx)
 }
 
+// AvailableAPIs returns available list of CRDs from the cluster.
 func AvailableAPIs(discovery discovery.DiscoveryInterface, groups map[string]bool) ([]*metav1.APIResourceList, error) {
 	var apiLists []*metav1.APIResourceList
 	groupList, err := discovery.ServerGroups()
@@ -279,6 +280,7 @@ func isOpenShift(apiList []*metav1.APIResourceList) bool {
 	return false
 }
 
+// IsElasticsearchOperatorAvailable returns true if OpenShift Elasticsearch CRD is available in the cluster.
 func IsElasticsearchOperatorAvailable(apiList []*metav1.APIResourceList) bool {
 	for _, r := range apiList {
 		if strings.HasPrefix(r.GroupVersion, "logging.openshift.io") {

--- a/pkg/autodetect/main.go
+++ b/pkg/autodetect/main.go
@@ -87,7 +87,7 @@ func (b *Background) Stop() {
 func (b *Background) autoDetectCapabilities() {
 	ctx := context.Background()
 
-	apiList, err := b.availableAPIs(ctx)
+	apiList, err := AvailableAPIs(b.dcl, listenedGroupsMap)
 	if err != nil {
 		log.WithError(err).Info("failed to determine the platform capabilities, auto-detected properties will remain the same until next cycle.")
 	} else {
@@ -106,22 +106,17 @@ func (b *Background) autoDetectCapabilities() {
 	b.cleanDeployments(ctx)
 }
 
-func (b *Background) isInListenedGroups(group metav1.APIGroup) bool {
-	return listenedGroupsMap[group.Name]
-}
-
-func (b *Background) availableAPIs(_ context.Context) ([]*metav1.APIResourceList, error) {
-	apiLists := []*metav1.APIResourceList{}
-	groupList, err := b.dcl.ServerGroups()
+func AvailableAPIs(discovery discovery.DiscoveryInterface, groups map[string]bool) ([]*metav1.APIResourceList, error) {
+	var apiLists []*metav1.APIResourceList
+	groupList, err := discovery.ServerGroups()
 	if err != nil {
 		return apiLists, err
 	}
 
 	var errors error
-
 	for _, sg := range groupList.Groups {
-		if b.isInListenedGroups(sg) {
-			groupAPIList, err := b.dcl.ServerResourcesForGroupVersion(sg.PreferredVersion.GroupVersion)
+		if groups[sg.Name] {
+			groupAPIList, err := discovery.ServerResourcesForGroupVersion(sg.PreferredVersion.GroupVersion)
 			if err == nil {
 				apiLists = append(apiLists, groupAPIList)
 			} else {
@@ -153,7 +148,7 @@ func (b *Background) detectElasticsearch(ctx context.Context, apiList []*metav1.
 	if b.retryDetectEs {
 		log.Trace("Determining whether we should enable the Elasticsearch Operator integration")
 		previous := viper.GetString("es-provision")
-		if isElasticsearchOperatorAvailable(apiList) {
+		if IsElasticsearchOperatorAvailable(apiList) {
 			viper.Set("es-provision", v1.FlagProvisionElasticsearchYes)
 		} else {
 			viper.Set("es-provision", v1.FlagProvisionElasticsearchNo)
@@ -284,7 +279,7 @@ func isOpenShift(apiList []*metav1.APIResourceList) bool {
 	return false
 }
 
-func isElasticsearchOperatorAvailable(apiList []*metav1.APIResourceList) bool {
+func IsElasticsearchOperatorAvailable(apiList []*metav1.APIResourceList) bool {
 	for _, r := range apiList {
 		if strings.HasPrefix(r.GroupVersion, "logging.openshift.io") {
 			for _, api := range r.APIResources {

--- a/pkg/cmd/start/bootstrap.go
+++ b/pkg/cmd/start/bootstrap.go
@@ -34,6 +34,7 @@ import (
 	jaegertracingv1 "github.com/jaegertracing/jaeger-operator/apis/v1"
 	v1 "github.com/jaegertracing/jaeger-operator/apis/v1"
 	appsv1controllers "github.com/jaegertracing/jaeger-operator/controllers/appsv1"
+	esv1controllers "github.com/jaegertracing/jaeger-operator/controllers/elasticsearch"
 	jaegertracingcontrollers "github.com/jaegertracing/jaeger-operator/controllers/jaegertracing"
 	"github.com/jaegertracing/jaeger-operator/pkg/autodetect"
 	kafkav1beta2 "github.com/jaegertracing/jaeger-operator/pkg/kafka/v1beta2"
@@ -353,6 +354,11 @@ func setupControllers(ctx context.Context, mgr manager.Manager) {
 
 	if err := appsv1controllers.NewDeploymentReconciler(client, clientReader, schema).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Deployment")
+		os.Exit(1)
+	}
+
+	if err := esv1controllers.NewElasticsearchReconciler(client, clientReader).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "Elasticsearch")
 		os.Exit(1)
 	}
 }

--- a/pkg/cmd/start/bootstrap.go
+++ b/pkg/cmd/start/bootstrap.go
@@ -357,7 +357,7 @@ func setupControllers(ctx context.Context, mgr manager.Manager) {
 		os.Exit(1)
 	}
 
-	if err := esv1controllers.NewElasticsearchReconciler(client, clientReader).SetupWithManager(mgr); err != nil {
+	if err := esv1controllers.NewReconciler(client, clientReader).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Elasticsearch")
 		os.Exit(1)
 	}

--- a/pkg/controller/elasticsearch/elasticsearch_controller.go
+++ b/pkg/controller/elasticsearch/elasticsearch_controller.go
@@ -71,13 +71,6 @@ func (r *ReconcileElasticsearch) Reconcile(ctx context.Context, request reconcil
 	jaegers := &v1.JaegerList{}
 	err = r.rClient.List(ctx, jaegers, client.InNamespace(request.Namespace))
 	if err != nil {
-		if errors.IsNotFound(err) {
-			// Request object not found, could have been deleted after reconcile request.
-			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
-			// Return and don't requeue
-			return reconcile.Result{}, nil
-		}
-		// Error reading the object - requeue the request.
 		return reconcile.Result{}, tracing.HandleError(err, span)
 	}
 

--- a/pkg/controller/elasticsearch/elasticsearch_controller.go
+++ b/pkg/controller/elasticsearch/elasticsearch_controller.go
@@ -92,7 +92,7 @@ func (r *ReconcileElasticsearch) Reconcile(ctx context.Context, request reconcil
 				logger.WithField("jaeger", jaeger.Name).WithField("old-es-node-count", jaeger.Spec.Storage.Elasticsearch.NodeCount).WithField("new-es-node-count", esNodeCount).Info("Updating Jaeger CR because OpenShift ES number of nodes changed")
 				jaeger.Spec.Storage.Elasticsearch.NodeCount = esNodeCount
 				if err := r.client.Update(ctx, jaeger); err != nil {
-					log.WithError(err).Error("failed to update deployment with sidecar")
+					log.WithError(err).Error("failed to update Jaeger instance")
 					return reconcile.Result{}, tracing.HandleError(err, span)
 				}
 			}

--- a/pkg/controller/elasticsearch/elasticsearch_controller.go
+++ b/pkg/controller/elasticsearch/elasticsearch_controller.go
@@ -1,0 +1,103 @@
+package elasticsearch
+
+import (
+	"context"
+
+	esv1 "github.com/openshift/elasticsearch-operator/apis/logging/v1"
+	log "github.com/sirupsen/logrus"
+	"go.opentelemetry.io/otel"
+	otelattribute "go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	v1 "github.com/jaegertracing/jaeger-operator/apis/v1"
+	"github.com/jaegertracing/jaeger-operator/pkg/tracing"
+)
+
+// ReconcileElasticsearch reconciles a Elasticsearch object
+type ReconcileElasticsearch struct {
+	// This client, initialized using mgr.Client() above, is a split client
+	// that reads objects from the cache and writes to the apiserver
+	client client.Client
+
+	// this avoid the cache, which we need to bypass because the default client will attempt to place
+	// a watch on Namespace at cluster scope, which isn't desirable to us...
+	rClient client.Reader
+}
+
+// New creates new Elasticsearch controller
+func New(client client.Client, clientReader client.Reader) *ReconcileElasticsearch {
+	return &ReconcileElasticsearch{
+		client:  client,
+		rClient: clientReader,
+	}
+}
+
+// Reconcile reads that state of the cluster for a Namespace object and makes changes based on the state read
+// and what is in the Namespace.Spec
+// Note:
+// The Controller will requeue the Request to be processed again if the returned error is non-nil or
+// Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
+func (r *ReconcileElasticsearch) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	logger := log.WithFields(log.Fields{
+		"namespace": request.Namespace,
+		"name":      request.Name,
+	})
+	logger.Trace("Reconciling Elasticsearch")
+
+	tracer := otel.GetTracerProvider().Tracer(v1.ReconciliationTracer)
+	ctx, span := tracer.Start(ctx, "reconcileElasticsearch")
+	defer span.End()
+
+	span.SetAttributes(otelattribute.String("name", request.Name), otelattribute.String("namespace", request.Namespace))
+
+	es := &esv1.Elasticsearch{}
+	err := r.rClient.Get(ctx, request.NamespacedName, es)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Request object not found, could have been deleted after reconcile request.
+			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
+			// Return and don't requeue
+			span.SetStatus(codes.Error, err.Error())
+			return reconcile.Result{}, nil
+		}
+		// Error reading the object - requeue the request.
+		return reconcile.Result{}, tracing.HandleError(err, span)
+	}
+
+	// Fetch Jaeger instance
+	jaegers := &v1.JaegerList{}
+	err = r.rClient.List(ctx, jaegers, client.InNamespace(request.Namespace))
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Request object not found, could have been deleted after reconcile request.
+			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
+			// Return and don't requeue
+			return reconcile.Result{}, nil
+		}
+		// Error reading the object - requeue the request.
+		return reconcile.Result{}, tracing.HandleError(err, span)
+	}
+
+	esNodeCount := v1.OpenShiftElasticsearchNodeCount(es.Spec)
+	// iterate over jaeger instances and if ES is used then update node count
+	// Jaeger instance will be updated in cluster and Jaeger reconciliation will be triggered to
+	// update Jaeger deployments (e.g. --es.num-shards).
+	for i := 0; i < len(jaegers.Items); i++ {
+		jaeger := &jaegers.Items[i]
+		if v1.ShouldInjectOpenShiftElasticsearchConfiguration(jaeger.Spec.Storage) {
+			if jaeger.Spec.Storage.Elasticsearch.Name == es.Name && jaeger.Spec.Storage.Elasticsearch.NodeCount != esNodeCount {
+				logger.WithField("jaeger", jaeger.Name).WithField("old-es-node-count", jaeger.Spec.Storage.Elasticsearch.NodeCount).WithField("new-es-node-count", esNodeCount).Info("Updating Jaeger CR because OpenShift ES number of nodes changed")
+				jaeger.Spec.Storage.Elasticsearch.NodeCount = esNodeCount
+				if err := r.client.Update(ctx, jaeger); err != nil {
+					log.WithError(err).Error("failed to update deployment with sidecar")
+					return reconcile.Result{}, tracing.HandleError(err, span)
+				}
+			}
+		}
+	}
+
+	return reconcile.Result{}, nil
+}

--- a/pkg/controller/elasticsearch/elasticsearch_controller_test.go
+++ b/pkg/controller/elasticsearch/elasticsearch_controller_test.go
@@ -17,7 +17,7 @@ import (
 	v1 "github.com/jaegertracing/jaeger-operator/apis/v1"
 )
 
-func TestElasticsearchController(t *testing.T) {
+func TestControllerReconcile(t *testing.T) {
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "prod",
@@ -75,4 +75,20 @@ func TestElasticsearchController(t *testing.T) {
 		Name:      "jaeger",
 	}, updated)
 	assert.Equal(t, int32(3), updated.Spec.Storage.Elasticsearch.NodeCount)
+}
+
+func TestControllerReconcile_not_found(t *testing.T) {
+	esv1.AddToScheme(scheme.Scheme)
+	v1.AddToScheme(scheme.Scheme)
+	cl := fake.NewClientBuilder().WithRuntimeObjects().Build()
+	reconciler := New(cl, cl)
+
+	result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: "prod",
+			Name:      "my-es",
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, result)
 }

--- a/pkg/controller/elasticsearch/elasticsearch_controller_test.go
+++ b/pkg/controller/elasticsearch/elasticsearch_controller_test.go
@@ -1,0 +1,78 @@
+package elasticsearch
+
+import (
+	"context"
+	"testing"
+
+	esv1 "github.com/openshift/elasticsearch-operator/apis/logging/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	v1 "github.com/jaegertracing/jaeger-operator/apis/v1"
+)
+
+func TestElasticsearchController(t *testing.T) {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "prod",
+		},
+	}
+	es := &esv1.Elasticsearch{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-es",
+			Namespace: "prod",
+		},
+		Spec: esv1.ElasticsearchSpec{
+			Nodes: []esv1.ElasticsearchNode{
+				{
+					Roles:     []esv1.ElasticsearchNodeRole{esv1.ElasticsearchRoleMaster, esv1.ElasticsearchRoleClient, esv1.ElasticsearchRoleData},
+					NodeCount: 3,
+				},
+			},
+		},
+	}
+	jaeger := &v1.Jaeger{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "jaeger",
+			Namespace: "prod",
+		},
+		Spec: v1.JaegerSpec{
+			Strategy: v1.DeploymentStrategyProduction,
+			Storage: v1.JaegerStorageSpec{
+				Type: "elasticsearch",
+				Elasticsearch: v1.ElasticsearchSpec{
+					// this will be updated
+					NodeCount: 1,
+					Name:      "my-es",
+				},
+			},
+		},
+	}
+
+	esv1.AddToScheme(scheme.Scheme)
+	v1.AddToScheme(scheme.Scheme)
+	cl := fake.NewClientBuilder().WithRuntimeObjects(ns, es, jaeger).Build()
+	reconciler := New(cl, cl)
+
+	result, err := reconciler.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: "prod",
+			Name:      "my-es",
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, result)
+
+	updated := &v1.Jaeger{}
+	cl.Get(context.Background(), types.NamespacedName{
+		Namespace: "prod",
+		Name:      "jaeger",
+	}, updated)
+	assert.Equal(t, int32(3), updated.Spec.Storage.Elasticsearch.NodeCount)
+}

--- a/pkg/metrics/instances.go
+++ b/pkg/metrics/instances.go
@@ -12,7 +12,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1 "github.com/jaegertracing/jaeger-operator/apis/v1"
-	"github.com/jaegertracing/jaeger-operator/pkg/storage"
 )
 
 const metricPrefix = "jaeger_operator_instances"
@@ -125,7 +124,7 @@ func (i *instancesMetric) Setup(ctx context.Context) error {
 		"Number of instances using autoprovisioning",
 		"type",
 		func(jaeger v1.Jaeger) string {
-			if storage.ShouldInjectElasticsearchConfiguration(jaeger.Spec.Storage) {
+			if v1.ShouldInjectOpenShiftElasticsearchConfiguration(jaeger.Spec.Storage) {
 				return "elasticsearch"
 			}
 			return ""

--- a/pkg/storage/elasticsearch.go
+++ b/pkg/storage/elasticsearch.go
@@ -22,15 +22,6 @@ const (
 	certPath        = volumeMountPath + "/tls.crt"
 )
 
-// ShouldInjectElasticsearchConfiguration determines whether a new instance of Elasticsearch should be deployed
-func ShouldInjectElasticsearchConfiguration(s v1.JaegerStorageSpec) bool {
-	if s.Type != v1.JaegerESStorage {
-		return false
-	}
-	_, ok := s.Options.Map()["es.server-urls"]
-	return !ok
-}
-
 // ElasticsearchDeployment represents an ES deployment for Jaeger
 type ElasticsearchDeployment struct {
 	Jaeger     *v1.Jaeger

--- a/pkg/storage/elasticsearch_test.go
+++ b/pkg/storage/elasticsearch_test.go
@@ -14,21 +14,6 @@ import (
 	v1 "github.com/jaegertracing/jaeger-operator/apis/v1"
 )
 
-func TestShouldDeployElasticsearch(t *testing.T) {
-	tests := []struct {
-		j        v1.JaegerStorageSpec
-		expected bool
-	}{
-		{j: v1.JaegerStorageSpec{}},
-		{j: v1.JaegerStorageSpec{Type: v1.JaegerCassandraStorage}},
-		{j: v1.JaegerStorageSpec{Type: v1.JaegerESStorage, Options: v1.NewOptions(map[string]interface{}{"es.server-urls": "foo"})}},
-		{j: v1.JaegerStorageSpec{Type: v1.JaegerESStorage}, expected: true},
-	}
-	for _, test := range tests {
-		assert.Equal(t, test.expected, ShouldInjectElasticsearchConfiguration(test.j))
-	}
-}
-
 func TestCreateElasticsearchCR(t *testing.T) {
 	storageClassName := "floppydisk"
 	genuuid1 := "myprojectfoo"

--- a/pkg/strategy/controller.go
+++ b/pkg/strategy/controller.go
@@ -15,7 +15,6 @@ import (
 
 	v1 "github.com/jaegertracing/jaeger-operator/apis/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/cronjob"
-	"github.com/jaegertracing/jaeger-operator/pkg/storage"
 )
 
 var (
@@ -146,7 +145,7 @@ func normalizeSparkDependencies(spec *v1.JaegerStorageSpec) {
 	// auto enable only for supported storages
 	if cronjob.SupportedStorage(spec.Type) &&
 		spec.Dependencies.Enabled == nil &&
-		!storage.ShouldInjectElasticsearchConfiguration(*spec) &&
+		!v1.ShouldInjectOpenShiftElasticsearchConfiguration(*spec) &&
 		tlsIsNotEnabled {
 		trueVar := true
 		spec.Dependencies.Enabled = &trueVar

--- a/pkg/strategy/production.go
+++ b/pkg/strategy/production.go
@@ -123,7 +123,7 @@ func newProductionStrategy(ctx context.Context, jaeger *v1.Jaeger) S {
 	c.dependencies = storage.Dependencies(jaeger)
 
 	// assembles the pieces for an elasticsearch self-provisioned deployment via the elasticsearch operator
-	if storage.ShouldInjectElasticsearchConfiguration(jaeger.Spec.Storage) {
+	if v1.ShouldInjectOpenShiftElasticsearchConfiguration(jaeger.Spec.Storage) {
 		var jobs []*corev1.PodSpec
 		for i := range c.dependencies {
 			jobs = append(jobs, &c.dependencies[i].Spec.Template.Spec)

--- a/pkg/strategy/streaming.go
+++ b/pkg/strategy/streaming.go
@@ -143,7 +143,7 @@ func newStreamingStrategy(ctx context.Context, jaeger *v1.Jaeger) S {
 	manifest.dependencies = storage.Dependencies(jaeger)
 
 	// assembles the pieces for an elasticsearch self-provisioned deployment via the elasticsearch operator
-	if storage.ShouldInjectElasticsearchConfiguration(jaeger.Spec.Storage) {
+	if v1.ShouldInjectOpenShiftElasticsearchConfiguration(jaeger.Spec.Storage) {
 		var jobs []*corev1.PodSpec
 		for i := range manifest.dependencies {
 			jobs = append(jobs, &manifest.dependencies[i].Spec.Template.Spec)

--- a/pkg/upgrade/v1_31_0.go
+++ b/pkg/upgrade/v1_31_0.go
@@ -9,14 +9,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1 "github.com/jaegertracing/jaeger-operator/apis/v1"
-	"github.com/jaegertracing/jaeger-operator/pkg/storage"
 )
 
 func upgrade1_31_0(ctx context.Context, c client.Client, jaeger v1.Jaeger) (v1.Jaeger, error) {
 
 	// Delete ES instance if self-provisioned ES is used.
 	// The newly created instance will use cert-management from EO operator.
-	if storage.ShouldInjectElasticsearchConfiguration(jaeger.Spec.Storage) {
+	if v1.ShouldInjectOpenShiftElasticsearchConfiguration(jaeger.Spec.Storage) {
 		es := esv1.Elasticsearch{
 			ObjectMeta: metav1.ObjectMeta{
 				// The only possible name


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <p.loffay@gmail.com>


Resolves #1720 

Notable changes:
* defaulting webhook - set ES number of nodes from the referenced ES instance
* validating webhook - validate if references ES instance exists
* ES controller - watch for changes and update ES nodes in Jaeger CR accordingly.


Test data:
```
kubectl apply -f - <<EOF
apiVersion: logging.openshift.io/v1
kind: Elasticsearch
metadata:
  annotations:
    logging.openshift.io/elasticsearch-cert-management: "true"
    logging.openshift.io/elasticsearch-cert.jaeger-shared-es: user.jaeger
  name: shared-es
spec:
  managementState: Managed
  nodeSpec:
    resources:
      limits:
        memory: 1Gi
      requests:
        cpu: 200m
        memory: 1Gi
  nodes:
    - nodeCount: 1
      proxyResources: {}
      resources: {}
      roles:
        - master
        - client
        - data
      storage: {}
  redundancyPolicy: ZeroRedundancy
EOF

kubectl apply -f - <<EOF
apiVersion: jaegertracing.io/v1
kind: Jaeger
metadata:
  name: tenant1-jaeger
spec:
  strategy: production
  query:
    strategy:
      type: RollingUpdate
  collector:
    strategy:
      type: RollingUpdate
  ingress:
    openshift:
      sar: "" # allow login for all OCP users for testing
  storage:
    type: elasticsearch
    options:
      es:
        index-prefix: tenant1
    elasticsearch:
      name: shared-es
      doNotProvision: true
      nodeCount: 1
      resources:
        requests:
          cpu: 200m
          memory: 1Gi
        limits:
          memory: 1Gi
EOF
```