### PR TITLE
fix panic caused by an invalid type assertion

### DIFF
--- a/apis/v1/options_test.go
+++ b/apis/v1/options_test.go
@@ -76,6 +76,10 @@ func TestUnmarshalToArgs(t *testing.T) {
 			in:   `{"a": 5000000000, "b": 15.222, "c":true, "d": "foo"}`,
 			args: []string{"--a=5000000000", "--b=15.222", "--c=true", "--d=foo"},
 		},
+		{
+			in:  `{"a": {"b": {"c": [{"d": "e", "f": {"g": {"h": "i"}}}]}}}`,
+			err: "invalid option type, expect: string, got: map[string]interface {}",
+		},
 	}
 	for _, test := range tests {
 		opts := Options{}


### PR DESCRIPTION
Signed-off-by: Benedikt Bongartz <bongartz@klimlive.de>

Closes #1733 
<!--
Please delete this comment before posting.

We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- option fields not of type string, [make the operator panic](https://github.com/jaegertracing/jaeger-operator/issues/1649#issuecomment-1001271023). 

## Short description of the changes
- Check type before making a type association in `(*Options).UnmarshalJSON` method.
- Return error if the elements of the argument list are not of type `string`.
- If `Options` cant be decoded [error 400](https://github.com/kubernetes-sigs/controller-runtime/blob/master/pkg/webhook/admission/http_test.go#L78) is returned.

```bash
controller-runtime.webhook.webhooks	received request	{"webhook": "/mutate-jaegertracing-io-v1-jaeger", "UID": "6c77a050-a28d-4172-abc4-56f61670baef", "kind": "jaegertracing.io/v1, Kind=Jaeger", "resource": {"group":"jaegertracing.io","version":"v1","resource":"jaegers"}}
controller-runtime.webhook.webhooks	wrote response	{"webhook": "/mutate-jaegertracing-io-v1-jaeger", "code": 400, "reason": "", "UID": "6c77a050-a28d-4172-abc4-56f61670baef", "allowed": false}
```
