### PR TITLE
Operator sdk version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,10 +37,10 @@ Once minikube has finished starting, get the Operator running:
 
 ```
 make cert-manager
-export IMG_PREFIX=docker.io/<dockerusername>
-export IMG=${IMG_PREFIX}/jaeger-operator:latest
-make generate bundle docker push deploy
+IMG=docker.io/$USER/jaeger-operator:latest make generate bundle docker push deploy
 ```
+
+NOTE: If your registry username is not the same as $USER, modify the previous command before executing it.  Also change *docker.io* if you are using a different image registry.
 
 At this point, a Jaeger instance can be installed:
 
@@ -55,7 +55,7 @@ To verify the Jaeger instance is running, execute *minikube ip* and open that ad
 export MINIKUBE_IP=`minikube ip`
 curl http://{$MINIKUBE_IP}/api/services
 ```
-(Note: you may have to execute the *curl* command twice to get a non-empty result)
+NOTE: you may have to execute the *curl* command twice to get a non-empty result
 
 Tests should be simple unit tests and/or end-to-end tests. For small changes, unit tests should be sufficient, but every new feature should be accompanied with end-to-end tests as well. Tests can be executed with:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,27 +12,34 @@ This project is a regular [Kubernetes Operator](https://coreos.com/operators/)  
 
 ### Installing the Operator SDK command line tool
 
-Follow the installation guidelines from [Operator SDK GitHub page](https://github.com/operator-framework/operator-sdk) or run `make install-sdk`.
+Follow the installation guidelines from [Operator SDK GitHub page](https://github.com/operator-framework/operator-sdk)
 
 ### Developing
 
 As usual for operators following the Operator SDK in recent versions, the dependencies are managed using [`go modules`](https://golang.org/doc/go1.11#modules). Refer to that project's documentation for instructions on how to add or update dependencies.
 
-The first step is to get a local Kubernetes instance up and running. The recommended approach is using `minikube`. Refer to the Kubernetes'  [documentation](https://kubernetes.io/docs/tasks/tools/install-minikube/) for instructions on how to install it.
+The first step is to get a local Kubernetes instance up and running. The recommended approach for development is using `minikube` with *ingress* enabled. Refer to the Kubernetes'  [documentation](https://kubernetes.io/docs/tasks/tools/install-minikube/) for instructions on how to install it.
 
 Once `minikube` is installed, it can be started with:
 
 ```
-minikube start
+minikube start --addons=ingress
 ```
 
 NOTE: Make sure to read the documentation to learn the performance switches that can be applied to your platform.
+
+Log into docker (or another image registry):
+```
+docker login --username <dockerusername>
+```
 
 Once minikube has finished starting, get the Operator running:
 
 ```
 make cert-manager
-IMG=docker.io/$USER/jaeger-operator:latest make generate bundle docker push deploy
+export IMG_PREFIX=docker.io/<dockerusername>
+export IMG=${IMG_PREFIX}/jaeger-operator:latest
+make generate bundle docker push deploy
 ```
 
 At this point, a Jaeger instance can be installed:
@@ -40,14 +47,15 @@ At this point, a Jaeger instance can be installed:
 ```
 kubectl apply -f examples/simplest.yaml
 kubectl get jaegers
-kubectl get pods
+kubectl get pods 
 ```
 
-To remove the instance:
-
+To verify the Jaeger instance is running, execute *minikube ip* and open that address in a browser, or follow the steps below
 ```
-kubectl delete -f examples/simplest.yaml
+export MINIKUBE_IP=`minikube ip`
+curl http://{$MINIKUBE_IP}/api/services
 ```
+(Note: you may have to execute the *curl* command twice to get a non-empty result)
 
 Tests should be simple unit tests and/or end-to-end tests. For small changes, unit tests should be sufficient, but every new feature should be accompanied with end-to-end tests as well. Tests can be executed with:
 
@@ -55,37 +63,18 @@ Tests should be simple unit tests and/or end-to-end tests. For small changes, un
 make test
 ```
 
-NOTE: you can adjust the Docker image namespace by overriding the variable `NAMESPACE`, like: `make test NAMESPACE=quay.io/my-username`. The full Docker image name can be customized by overriding `BUILD_IMAGE` instead, like: `make test BUILD_IMAGE=quay.io/my-username/jaeger-operator:0.0.1`
+#### Cleaning up
+To remove the instance:
+
+```
+kubectl delete -f examples/simplest.yaml
+```
+
+
 
 #### Model changes
 
 The Operator SDK generates the `pkg/apis/jaegertracing/v1/zz_generated.*.go` files via the command `make generate`. This should be executed whenever there's a model change (`pkg/apis/jaegertracing/v1/jaeger_types.go`)
-
-#### Ingress configuration
-
-Kubernetes comes with no ingress provider by default. For development purposes, when running `minikube`, the following command can be executed to install an ingress provider:
-
-```
-make ingress
-```
-
-This will install the `NGINX` ingress provider. It's recommended to wait for the ingress pods to be in the `READY` and `RUNNING` state before starting the operator. You can check it by running:
-
-```
-kubectl get pods -n ingress-nginx
-```
-
-To verify that it's working, deploy the `simplest.yaml` and check the ingress routes:
-
-```
-$ kubectl apply -f examples/simplest.yaml
-jaeger.jaegertracing.io/simplest created
-$ kubectl get ingress
-NAME             HOSTS     ADDRESS          PORTS     AGE
-simplest-query   *         192.168.122.69   80        12s
-```
-
-Accessing the provided "address" in your web browser should display the Jaeger UI.
 
 #### Storage configuration
 

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ GOROOT ?= "$(shell go env GOROOT)"
 ECHO ?= @echo $(echo_prefix)
 SED ?= "sed"
 CERTMANAGER_VERSION ?= 1.6.1
+OPERATOR_SDK_VERSION ?= 1.17.0
 
 PROMETHEUS_OPERATOR_TAG ?= v0.39.0
 PROMETHEUS_BUNDLE ?= https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/${PROMETHEUS_OPERATOR_TAG}/bundle.yaml
@@ -349,7 +350,7 @@ rm -rf $$TMP_DIR ;\
 endef
 
 .PHONY: bundle
-bundle: manifests kustomize ## Generate bundle manifests and metadata, then validate generated files.
+bundle: manifests kustomize operator-sdk ## Generate bundle manifests and metadata, then validate generated files.
 	operator-sdk generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle -q --overwrite --manifests --version $(VERSION) $(BUNDLE_METADATA_OPTS)
@@ -486,7 +487,7 @@ install-tools:
 prepare-release:
 	$(VECHO)./.ci/prepare-release.sh
 
-scorecard-tests:
+scorecard-tests: operator-sdk
 	operator-sdk scorecard bundle -w 600s || (echo "scorecard test failed" && exit 1)
 
 scorecard-tests-local: kind
@@ -495,3 +496,13 @@ scorecard-tests-local: kind
 	$(VECHO)$(KIND) load docker-image $(SCORECARD_TEST_IMG)
 	$(VECHO)kubectl wait --timeout=5m --for=condition=available deployment/coredns -n kube-system
 	$(VECHO)$(MAKE) scorecard-tests
+
+OPERATOR_SDK = $(shell pwd)/bin/operator-sdk
+.PHONY: operator-sdk
+operator-sdk:
+	@{ \
+	set -e ;\
+	[ -d bin ] || mkdir bin ;\
+	curl -L -o $(OPERATOR_SDK) https://github.com/operator-framework/operator-sdk/releases/download/v${OPERATOR_SDK_VERSION}/operator-sdk_`go env GOOS`_`go env GOARCH`;\
+	chmod +x $(OPERATOR_SDK) ;\
+	}


### PR DESCRIPTION
## Which problem is this PR solving?
- Make sure we always use the correct version of the operator-sdk in builds.  Suggested in chat by @pavolloffay   I can open an issue if needed.

## Short description of the changes
- Added a Makefile target to install the operator-sdk, mostly copied from Pavol's equivalent change to the open-telemetry collector: https://github.com/open-telemetry/opentelemetry-operator/pull/728
-
