### PR TITLE
Migrate CronJob from batch/v1beta1 to batch/v1

### DIFF
--- a/pkg/controller/jaeger/cronjob.go
+++ b/pkg/controller/jaeger/cronjob.go
@@ -5,7 +5,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"go.opentelemetry.io/otel"
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	batchv1 "k8s.io/api/batch/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1 "github.com/jaegertracing/jaeger-operator/apis/v1"
@@ -13,7 +13,7 @@ import (
 	"github.com/jaegertracing/jaeger-operator/pkg/tracing"
 )
 
-func (r *ReconcileJaeger) applyCronJobs(ctx context.Context, jaeger v1.Jaeger, desired []batchv1beta1.CronJob) error {
+func (r *ReconcileJaeger) applyCronJobs(ctx context.Context, jaeger v1.Jaeger, desired []batchv1.CronJob) error {
 	tracer := otel.GetTracerProvider().Tracer(v1.ReconciliationTracer)
 	ctx, span := tracer.Start(ctx, "applyCronJobs")
 	defer span.End()
@@ -25,7 +25,7 @@ func (r *ReconcileJaeger) applyCronJobs(ctx context.Context, jaeger v1.Jaeger, d
 			"app.kubernetes.io/managed-by": "jaeger-operator",
 		}),
 	}
-	list := &batchv1beta1.CronJobList{}
+	list := &batchv1.CronJobList{}
 	if err := r.rClient.List(ctx, list, opts...); err != nil {
 		return tracing.HandleError(err, span)
 	}

--- a/pkg/controller/jaeger/cronjob_test.go
+++ b/pkg/controller/jaeger/cronjob_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -31,7 +31,7 @@ func TestCronJobsCreate(t *testing.T) {
 
 	r, cl := getReconciler(objs)
 	r.strategyChooser = func(ctx context.Context, jaeger *v1.Jaeger) strategy.S {
-		s := strategy.New().WithCronJobs([]batchv1beta1.CronJob{{
+		s := strategy.New().WithCronJobs([]batchv1.CronJob{{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: nsn.Name,
 			},
@@ -46,7 +46,7 @@ func TestCronJobsCreate(t *testing.T) {
 	assert.NoError(t, err)
 	assert.False(t, res.Requeue, "We don't requeue for now")
 
-	persisted := &batchv1beta1.CronJob{}
+	persisted := &batchv1.CronJob{}
 	persistedName := types.NamespacedName{
 		Name:      nsn.Name,
 		Namespace: nsn.Namespace,
@@ -62,7 +62,7 @@ func TestCronJobsUpdate(t *testing.T) {
 		Name: "TestCronJobsUpdate",
 	}
 
-	orig := batchv1beta1.CronJob{}
+	orig := batchv1.CronJob{}
 	orig.Name = nsn.Name
 	orig.Annotations = map[string]string{"key": "value"}
 	orig.Labels = map[string]string{
@@ -77,11 +77,11 @@ func TestCronJobsUpdate(t *testing.T) {
 
 	r, cl := getReconciler(objs)
 	r.strategyChooser = func(ctx context.Context, jaeger *v1.Jaeger) strategy.S {
-		updated := batchv1beta1.CronJob{}
+		updated := batchv1.CronJob{}
 		updated.Name = orig.Name
 		updated.Annotations = map[string]string{"key": "new-value"}
 
-		s := strategy.New().WithCronJobs([]batchv1beta1.CronJob{updated})
+		s := strategy.New().WithCronJobs([]batchv1.CronJob{updated})
 		return s
 	}
 
@@ -90,7 +90,7 @@ func TestCronJobsUpdate(t *testing.T) {
 	assert.NoError(t, err)
 
 	// verify
-	persisted := &batchv1beta1.CronJob{}
+	persisted := &batchv1.CronJob{}
 	persistedName := types.NamespacedName{
 		Name:      orig.Name,
 		Namespace: orig.Namespace,
@@ -106,7 +106,7 @@ func TestCronJobsDelete(t *testing.T) {
 		Name: "TestCronJobsDelete",
 	}
 
-	orig := batchv1beta1.CronJob{}
+	orig := batchv1.CronJob{}
 	orig.Name = nsn.Name
 	orig.Labels = map[string]string{
 		"app.kubernetes.io/instance":   orig.Name,
@@ -128,7 +128,7 @@ func TestCronJobsDelete(t *testing.T) {
 	assert.NoError(t, err)
 
 	// verify
-	persisted := &batchv1beta1.CronJob{}
+	persisted := &batchv1.CronJob{}
 	persistedName := types.NamespacedName{
 		Name:      orig.Name,
 		Namespace: orig.Namespace,
@@ -152,7 +152,7 @@ func TestCronJobsCreateExistingNameInAnotherNamespace(t *testing.T) {
 	objs := []runtime.Object{
 		v1.NewJaeger(nsn),
 		v1.NewJaeger(nsnExisting),
-		&batchv1beta1.CronJob{
+		&batchv1.CronJob{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      nsnExisting.Name,
 				Namespace: nsnExisting.Namespace,
@@ -166,7 +166,7 @@ func TestCronJobsCreateExistingNameInAnotherNamespace(t *testing.T) {
 
 	r, cl := getReconciler(objs)
 	r.strategyChooser = func(ctx context.Context, jaeger *v1.Jaeger) strategy.S {
-		s := strategy.New().WithCronJobs([]batchv1beta1.CronJob{{
+		s := strategy.New().WithCronJobs([]batchv1.CronJob{{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      nsn.Name,
 				Namespace: nsn.Namespace,
@@ -182,13 +182,13 @@ func TestCronJobsCreateExistingNameInAnotherNamespace(t *testing.T) {
 	assert.NoError(t, err)
 	assert.False(t, res.Requeue, "We don't requeue for now")
 
-	persisted := &batchv1beta1.CronJob{}
+	persisted := &batchv1.CronJob{}
 	err = cl.Get(context.Background(), nsn, persisted)
 	assert.NoError(t, err)
 	assert.Equal(t, nsn.Name, persisted.Name)
 	assert.Equal(t, nsn.Namespace, persisted.Namespace)
 
-	persistedExisting := &batchv1beta1.CronJob{}
+	persistedExisting := &batchv1.CronJob{}
 	err = cl.Get(context.Background(), nsnExisting, persistedExisting)
 	assert.NoError(t, err)
 	assert.Equal(t, nsnExisting.Name, persistedExisting.Name)

--- a/pkg/cronjob/es_index_cleaner.go
+++ b/pkg/cronjob/es_index_cleaner.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	batchv1 "k8s.io/api/batch/v1"
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -18,7 +17,7 @@ import (
 // CreateEsIndexCleaner returns a new cronjob for the Elasticsearch Index Cleaner operation
 
 // CreateEsIndexCleaner returns a new cronjob for the Elasticsearch Index Cleaner operation
-func CreateEsIndexCleaner(jaeger *v1.Jaeger) *batchv1beta1.CronJob {
+func CreateEsIndexCleaner(jaeger *v1.Jaeger) *batchv1.CronJob {
 	esUrls := util.GetEsHostname(jaeger.Spec.Storage.Options.Map())
 	trueVar := true
 	one := int32(1)
@@ -45,7 +44,7 @@ func CreateEsIndexCleaner(jaeger *v1.Jaeger) *batchv1beta1.CronJob {
 
 	ca.Update(jaeger, commonSpec)
 
-	return &batchv1beta1.CronJob{
+	return &batchv1.CronJob{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
 			Namespace:   jaeger.Namespace,
@@ -61,10 +60,10 @@ func CreateEsIndexCleaner(jaeger *v1.Jaeger) *batchv1beta1.CronJob {
 				},
 			},
 		},
-		Spec: batchv1beta1.CronJobSpec{
+		Spec: batchv1.CronJobSpec{
 			Schedule:                   jaeger.Spec.Storage.EsIndexCleaner.Schedule,
 			SuccessfulJobsHistoryLimit: jaeger.Spec.Storage.EsIndexCleaner.SuccessfulJobsHistoryLimit,
-			JobTemplate: batchv1beta1.JobTemplateSpec{
+			JobTemplate: batchv1.JobTemplateSpec{
 				Spec: batchv1.JobSpec{
 					Parallelism:             &one,
 					TTLSecondsAfterFinished: jaeger.Spec.Storage.EsIndexCleaner.TTLSecondsAfterFinished,

--- a/pkg/cronjob/spark_dependencies.go
+++ b/pkg/cronjob/spark_dependencies.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	batchv1 "k8s.io/api/batch/v1"
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -25,7 +24,7 @@ func SupportedStorage(storage v1.JaegerStorageType) bool {
 }
 
 // CreateSparkDependencies creates a new cronjob for the Spark Dependencies task
-func CreateSparkDependencies(jaeger *v1.Jaeger) *batchv1beta1.CronJob {
+func CreateSparkDependencies(jaeger *v1.Jaeger) *batchv1.CronJob {
 	logTLSNotSupported(jaeger)
 	envVars := []corev1.EnvVar{
 		{Name: "STORAGE", Value: string(jaeger.Spec.Storage.Type)},
@@ -64,7 +63,7 @@ func CreateSparkDependencies(jaeger *v1.Jaeger) *batchv1beta1.CronJob {
 		image = viper.GetString("jaeger-spark-dependencies-image")
 	}
 
-	return &batchv1beta1.CronJob{
+	return &batchv1.CronJob{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: jaeger.Namespace,
@@ -79,11 +78,11 @@ func CreateSparkDependencies(jaeger *v1.Jaeger) *batchv1beta1.CronJob {
 				},
 			},
 		},
-		Spec: batchv1beta1.CronJobSpec{
-			ConcurrencyPolicy:          batchv1beta1.ForbidConcurrent,
+		Spec: batchv1.CronJobSpec{
+			ConcurrencyPolicy:          batchv1.ForbidConcurrent,
 			Schedule:                   jaeger.Spec.Storage.Dependencies.Schedule,
 			SuccessfulJobsHistoryLimit: jaeger.Spec.Storage.Dependencies.SuccessfulJobsHistoryLimit,
-			JobTemplate: batchv1beta1.JobTemplateSpec{
+			JobTemplate: batchv1.JobTemplateSpec{
 				Spec: batchv1.JobSpec{
 					Parallelism:  &one,
 					BackoffLimit: jaeger.Spec.Storage.Dependencies.BackoffLimit,

--- a/pkg/inventory/cronjob.go
+++ b/pkg/inventory/cronjob.go
@@ -3,21 +3,21 @@ package inventory
 import (
 	"fmt"
 
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	batchv1 "k8s.io/api/batch/v1"
 
 	"github.com/jaegertracing/jaeger-operator/pkg/util"
 )
 
 // CronJob represents the inventory of cronjobs based on the current and desired states
 type CronJob struct {
-	Create []batchv1beta1.CronJob
-	Update []batchv1beta1.CronJob
-	Delete []batchv1beta1.CronJob
+	Create []batchv1.CronJob
+	Update []batchv1.CronJob
+	Delete []batchv1.CronJob
 }
 
 // ForCronJobs builds an inventory of cronjobs based on the existing and desired states
-func ForCronJobs(existing []batchv1beta1.CronJob, desired []batchv1beta1.CronJob) CronJob {
-	update := []batchv1beta1.CronJob{}
+func ForCronJobs(existing []batchv1.CronJob, desired []batchv1.CronJob) CronJob {
+	update := []batchv1.CronJob{}
 	mcreate := jobsMap(desired)
 	mdelete := jobsMap(existing)
 
@@ -51,16 +51,16 @@ func ForCronJobs(existing []batchv1beta1.CronJob, desired []batchv1beta1.CronJob
 	}
 }
 
-func jobsMap(deps []batchv1beta1.CronJob) map[string]batchv1beta1.CronJob {
-	m := map[string]batchv1beta1.CronJob{}
+func jobsMap(deps []batchv1.CronJob) map[string]batchv1.CronJob {
+	m := map[string]batchv1.CronJob{}
 	for _, d := range deps {
 		m[fmt.Sprintf("%s.%s", d.Namespace, d.Name)] = d
 	}
 	return m
 }
 
-func jobsList(m map[string]batchv1beta1.CronJob) []batchv1beta1.CronJob {
-	l := []batchv1beta1.CronJob{}
+func jobsList(m map[string]batchv1.CronJob) []batchv1.CronJob {
+	l := []batchv1.CronJob{}
 	for _, v := range m {
 		l = append(l, v)
 	}

--- a/pkg/inventory/cronjob_test.go
+++ b/pkg/inventory/cronjob_test.go
@@ -4,42 +4,42 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestCronJobInventory(t *testing.T) {
-	toCreate := batchv1beta1.CronJob{
+	toCreate := batchv1.CronJob{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "to-create",
 		},
 	}
-	toUpdate := batchv1beta1.CronJob{
+	toUpdate := batchv1.CronJob{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "to-update",
 		},
-		Spec: batchv1beta1.CronJobSpec{
+		Spec: batchv1.CronJobSpec{
 			Schedule: "0 1 * * *",
 		},
 	}
-	updated := batchv1beta1.CronJob{
+	updated := batchv1.CronJob{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "to-update",
 			Annotations: map[string]string{"gopher": "jaeger"},
 			Labels:      map[string]string{"gopher": "jaeger"},
 		},
-		Spec: batchv1beta1.CronJobSpec{
+		Spec: batchv1.CronJobSpec{
 			Schedule: "0 2 * * *",
 		},
 	}
-	toDelete := batchv1beta1.CronJob{
+	toDelete := batchv1.CronJob{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "to-delete",
 		},
 	}
 
-	existing := []batchv1beta1.CronJob{toUpdate, toDelete}
-	desired := []batchv1beta1.CronJob{updated, toCreate}
+	existing := []batchv1.CronJob{toUpdate, toDelete}
+	desired := []batchv1.CronJob{updated, toCreate}
 
 	inv := ForCronJobs(existing, desired)
 	assert.Len(t, inv.Create, 1)
@@ -54,7 +54,7 @@ func TestCronJobInventory(t *testing.T) {
 }
 
 func TestCronJobInventoryWithSameNameInstances(t *testing.T) {
-	create := []batchv1beta1.CronJob{{
+	create := []batchv1.CronJob{{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "to-create",
 			Namespace: "tenant1",
@@ -66,7 +66,7 @@ func TestCronJobInventoryWithSameNameInstances(t *testing.T) {
 		},
 	}}
 
-	inv := ForCronJobs([]batchv1beta1.CronJob{}, create)
+	inv := ForCronJobs([]batchv1.CronJob{}, create)
 	assert.Len(t, inv.Create, 2)
 	assert.Contains(t, inv.Create, create[0])
 	assert.Contains(t, inv.Create, create[1])

--- a/pkg/strategy/production.go
+++ b/pkg/strategy/production.go
@@ -7,7 +7,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	appsv1 "k8s.io/api/apps/v1"
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 
 	v1 "github.com/jaegertracing/jaeger-operator/apis/v1"
@@ -103,7 +103,7 @@ func newProductionStrategy(ctx context.Context, jaeger *v1.Jaeger) S {
 		}
 	}
 
-	var indexCleaner *batchv1beta1.CronJob
+	var indexCleaner *batchv1.CronJob
 	if isBoolTrue(jaeger.Spec.Storage.EsIndexCleaner.Enabled) {
 		if jaeger.Spec.Storage.Type == v1.JaegerESStorage {
 			indexCleaner = cronjob.CreateEsIndexCleaner(jaeger)
@@ -112,7 +112,7 @@ func newProductionStrategy(ctx context.Context, jaeger *v1.Jaeger) S {
 		}
 	}
 
-	var esRollover []batchv1beta1.CronJob
+	var esRollover []batchv1.CronJob
 	if storage.EnableRollover(jaeger.Spec.Storage) {
 		esRollover = cronjob.CreateRollover(jaeger)
 	}

--- a/pkg/strategy/strategy.go
+++ b/pkg/strategy/strategy.go
@@ -6,7 +6,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
 	batchv1 "k8s.io/api/batch/v1"
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	rbac "k8s.io/api/rbac/v1"
@@ -28,7 +27,7 @@ type S struct {
 	clusterRoleBindings      []rbac.ClusterRoleBinding
 	configMaps               []corev1.ConfigMap
 	consoleLinks             []osconsolev1.ConsoleLink
-	cronJobs                 []batchv1beta1.CronJob
+	cronJobs                 []batchv1.CronJob
 	daemonSets               []appsv1.DaemonSet
 	dependencies             []batchv1.Job
 	deployments              []appsv1.Deployment
@@ -77,7 +76,7 @@ func (s S) WithConfigMaps(c []corev1.ConfigMap) S {
 }
 
 // WithCronJobs returns the strategy with the given list of cron jobs
-func (s S) WithCronJobs(c []batchv1beta1.CronJob) S {
+func (s S) WithCronJobs(c []batchv1.CronJob) S {
 	s.cronJobs = c
 	return s
 }
@@ -169,7 +168,7 @@ func (s S) ConsoleLinks(routes []osv1.Route) []osconsolev1.ConsoleLink {
 }
 
 // CronJobs returns the list of cron jobs for this strategy
-func (s S) CronJobs() []batchv1beta1.CronJob {
+func (s S) CronJobs() []batchv1.CronJob {
 	return s.cronJobs
 }
 

--- a/pkg/strategy/strategy_test.go
+++ b/pkg/strategy/strategy_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	rbac "k8s.io/api/rbac/v1"
@@ -43,7 +42,7 @@ func TestWithConfigMaps(t *testing.T) {
 }
 
 func TestWithCronJobs(t *testing.T) {
-	c := New().WithCronJobs([]batchv1beta1.CronJob{{}})
+	c := New().WithCronJobs([]batchv1.CronJob{{}})
 	assert.Len(t, c.CronJobs(), 1)
 	assert.Len(t, c.All(), 1)
 }

--- a/pkg/strategy/streaming.go
+++ b/pkg/strategy/streaming.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/viper"
 	"go.opentelemetry.io/otel"
 	appsv1 "k8s.io/api/apps/v1"
-	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 
 	v1 "github.com/jaegertracing/jaeger-operator/apis/v1"
@@ -116,7 +116,7 @@ func newStreamingStrategy(ctx context.Context, jaeger *v1.Jaeger) S {
 		}
 	}
 
-	var indexCleaner *batchv1beta1.CronJob
+	var indexCleaner *batchv1.CronJob
 	if isBoolTrue(jaeger.Spec.Storage.EsIndexCleaner.Enabled) {
 		if jaeger.Spec.Storage.Type == v1.JaegerESStorage {
 			indexCleaner = cronjob.CreateEsIndexCleaner(jaeger)
@@ -125,7 +125,7 @@ func newStreamingStrategy(ctx context.Context, jaeger *v1.Jaeger) S {
 		}
 	}
 
-	var esRollover []batchv1beta1.CronJob
+	var esRollover []batchv1.CronJob
 	if storage.EnableRollover(jaeger.Spec.Storage) {
 		esRollover = cronjob.CreateRollover(jaeger)
 	}

--- a/tests/cmd-utils/wait-cronjob/main.go
+++ b/tests/cmd-utils/wait-cronjob/main.go
@@ -44,7 +44,7 @@ func checkCronJobExists(clientset *kubernetes.Clientset) error {
 		ctxWithTimeout, cancel := context.WithTimeout(context.Background(), timeout)
 		defer cancel()
 
-		cronjobs, err := clientset.BatchV1beta1().CronJobs(namespace).List(ctxWithTimeout, metav1.ListOptions{})
+		cronjobs, err := clientset.BatchV1().CronJobs(namespace).List(ctxWithTimeout, metav1.ListOptions{})
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				logrus.Debug("No cronjobs were found")


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com>

## Which problem is this PR solving?
- Resolves #1585

## Short description of the changes
- Update Cronjob to use batch/v1 instead of batch/v1beta1
