### PR TITLE
fix olm-csv link in contributing description

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,7 @@ With OLM, users can:
 
 OLM also enforces some constraints on the components it manages in order to ensure a good user experience.
 
-The Jaeger community provides and maintains a [ClusterServiceVersion (CSV) YAML](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/Documentation/design/building-your-csv.md/) to integrate with OLM.
+The Jaeger community provides and maintains a [ClusterServiceVersion (CSV) YAML](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/building-your-csv.md) to integrate with OLM.
 
 Starting from operator-sdk v0.5.0, one can generate and update CSVs based on the yaml files in the deploy folder.
 The Jaeger CSV can be updated to version 1.9.0 with the following command:


### PR DESCRIPTION
Signed-off-by: Benedikt Bongartz <bongartz@klimlive.de>

<!--
Please delete this comment before posting.

We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- documentation link works again

## Short description of the changes
- link adaption
