### PR TITLE
Make sure that we always use the correct operator-sdk version

### DIFF
--- a/.github/workflows/base-checks.yaml
+++ b/.github/workflows/base-checks.yaml
@@ -24,10 +24,6 @@ jobs:
     - name: "install kustomize"
       run: ./hack/install-kustomize.sh
 
-    - uses: jpkrohling/setup-operator-sdk@v1.1.0
-      with:
-        operator-sdk-version: v1.13.1
-
     - name: "basic checks"
       run: make install-tools ci
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,9 +22,6 @@ jobs:
     - name: "install kustomize"
       run: ./hack/install-kustomize.sh
 
-    - uses: jpkrohling/setup-operator-sdk@v1.1.0
-      with:
-        operator-sdk-version: v1.13.1
     - uses: docker/setup-qemu-action@v1.2.0
     - uses: docker/setup-buildx-action@v1.6.0
 

--- a/.github/workflows/sdk-scorecard.yaml
+++ b/.github/workflows/sdk-scorecard.yaml
@@ -13,9 +13,6 @@ jobs:
     steps:
       - name: "Check out code"
         uses: actions/checkout@v2.4.0
-      - uses: jpkrohling/setup-operator-sdk@v1.1.0
-        with:
-          operator-sdk-version: v1.13.1
       - name: "Install KIND"
         run: ./.ci/install-kind.sh
       - name: "Install KUTTL"

--- a/Makefile
+++ b/Makefile
@@ -351,10 +351,10 @@ endef
 
 .PHONY: bundle
 bundle: manifests kustomize operator-sdk ## Generate bundle manifests and metadata, then validate generated files.
-	operator-sdk generate kustomize manifests -q
+	$(OPERATOR_SDK) generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
-	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle -q --overwrite --manifests --version $(VERSION) $(BUNDLE_METADATA_OPTS)
-	operator-sdk bundle validate ./bundle
+	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle -q --overwrite --manifests --version $(VERSION) $(BUNDLE_METADATA_OPTS)
+	$(OPERATOR_SDK) bundle validate ./bundle
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.
@@ -488,7 +488,8 @@ prepare-release:
 	$(VECHO)./.ci/prepare-release.sh
 
 scorecard-tests: operator-sdk
-	operator-sdk scorecard bundle -w 600s || (echo "scorecard test failed" && exit 1)
+	echo "Operator sdk is " $(OPERATOR_SDK)
+	$(OPERATOR_SDK) scorecard bundle -w 600s || (echo "scorecard test failed" && exit 1)
 
 scorecard-tests-local: kind
 	$(VECHO)$(KIND) create cluster --config $(KIND_CONFIG) 2>&1 | grep -v "already exists" || true


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com>

## Which problem is this PR solving?
- Make sure we always use the correct version of the operator-sdk in builds. Suggested in chat by @pavolloffay 

## Short description of the changes
- - Added a Makefile target to install the operator-sdk, mostly copied from Pavol's [equivalent change](https://github.com/open-telemetry/opentelemetry-operator/pull/728) to the open-telemetry collector:   
