### PR TITLE
Update the operator-sdk to 1.17.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ GOROOT ?= "$(shell go env GOROOT)"
 ECHO ?= @echo $(echo_prefix)
 SED ?= "sed"
 CERTMANAGER_VERSION ?= 1.6.1
-OPERATOR_SDK_VERSION ?= 1.13.1
+OPERATOR_SDK_VERSION ?= 1.17.0
 
 USE_KIND_CLUSTER ?= true
 export OLM ?= false
@@ -63,7 +63,7 @@ ENVTEST_K8S_VERSION = 1.22
 KUBE_VERSION ?= 1.20
 KIND_CONFIG ?= kind-$(KUBE_VERSION).yaml
 
-SCORECARD_TEST_IMG ?= quay.io/operator-framework/scorecard-test:v1.13.1
+SCORECARD_TEST_IMG ?= quay.io/operator-framework/scorecard-test:v$(OPERATOR_SDK_VERSION)
 
 .DEFAULT_GOAL := build
 


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com>

## Which problem is this PR solving?
- This updates the operator-sdk to 1.17.0

## Short description of the changes
- Updated the Makefile to use a newer operator-sdk
