### PR TITLE
Skip running the CI for changes in documentation #1791

### DIFF
--- a/.github/workflows/base-checks.yaml
+++ b/.github/workflows/base-checks.yaml
@@ -3,8 +3,12 @@ name: "CI Workflow"
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - '**.md'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - '**.md'
 
 jobs:
   basic-checks:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,12 @@ name: "CodeQL"
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - '**.md'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - '**.md'
 
 jobs:
   codeql-analyze:

--- a/.github/workflows/e2e-allinone.yaml
+++ b/.github/workflows/e2e-allinone.yaml
@@ -3,8 +3,12 @@ name: All in One E2E tests
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - '**.md'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - '**.md'
 
 concurrency:
   group: e2e-tests-${{ github.ref }}-allinone

--- a/.github/workflows/e2e-cassandra.yaml
+++ b/.github/workflows/e2e-cassandra.yaml
@@ -3,8 +3,12 @@ name: Cassandra E2E tests
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - '**.md'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - '**.md'
 
 concurrency:
   group: e2e-tests-${{ github.ref }}-cassandra

--- a/.github/workflows/e2e-elasticsearch.yaml
+++ b/.github/workflows/e2e-elasticsearch.yaml
@@ -3,8 +3,12 @@ name: Elasticsearch E2E tests
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - '**.md'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - '**.md'
 
 concurrency:
   group: e2e-tests-${{ github.ref }}-elasticsearch

--- a/.github/workflows/e2e-examples.yaml
+++ b/.github/workflows/e2e-examples.yaml
@@ -3,8 +3,12 @@ name: Examples E2E tests
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - '**.md'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - '**.md'
 
 concurrency:
   group: e2e-tests-${{ github.ref }}-examples

--- a/.github/workflows/e2e-generate.yaml
+++ b/.github/workflows/e2e-generate.yaml
@@ -3,8 +3,12 @@ name: Generate E2E tests
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - '**.md'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - '**.md'
 
 concurrency:
   group: e2e-tests-${{ github.ref }}-generate

--- a/.github/workflows/e2e-istio.yaml
+++ b/.github/workflows/e2e-istio.yaml
@@ -3,8 +3,12 @@ name: Istio E2E tests
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - '**.md'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - '**.md'
 
 concurrency:
   group: e2e-tests-${{ github.ref }}-istio

--- a/.github/workflows/e2e-outside-cluster.yaml
+++ b/.github/workflows/e2e-outside-cluster.yaml
@@ -3,8 +3,12 @@ name: Outside cluster E2E tests
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - '**.md'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - '**.md'
 
 concurrency:
   group: e2e-tests-${{ github.ref }}-outside-cluster

--- a/.github/workflows/e2e-smoke.yaml
+++ b/.github/workflows/e2e-smoke.yaml
@@ -3,8 +3,12 @@ name: Smoke E2E tests
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - '**.md'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - '**.md'
 
 concurrency:
   group: e2e-tests-${{ github.ref }}-smoke

--- a/.github/workflows/e2e-streaming.yaml
+++ b/.github/workflows/e2e-streaming.yaml
@@ -3,8 +3,12 @@ name: Streaming E2E tests
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - '**.md'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - '**.md'
 
 concurrency:
   group: e2e-tests-${{ github.ref }}-streaming

--- a/.github/workflows/e2e-upgrade.yaml
+++ b/.github/workflows/e2e-upgrade.yaml
@@ -3,8 +3,12 @@ name: Upgrade E2E tests
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - '**.md'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - '**.md'
 
 concurrency:
   group: e2e-tests-${{ github.ref }}-upgrade

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -3,6 +3,8 @@ name: "Publish images"
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - '**.md'
 
 jobs:
   publish:

--- a/.github/workflows/sdk-scorecard.yaml
+++ b/.github/workflows/sdk-scorecard.yaml
@@ -3,8 +3,12 @@ name: "Operator-SDK Scorecard"
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - '**.md'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - '**.md'
 
 jobs:
   operator-sdk-scorecard:


### PR DESCRIPTION
Signed-off-by: Israel Blancas <iblancas@redhat.com>

## Which problem is this PR solving?
- #1791

## Short description of the changes
- Use [the paths-ignore GitHub Actions Workflow](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore) feature to save resources when the changes are done just in Markdown files.