### PR TITLE
Update admission review versions

### DIFF
--- a/apis/v1/jaeger_webhook.go
+++ b/apis/v1/jaeger_webhook.go
@@ -32,7 +32,7 @@ func (j *Jaeger) SetupWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
-//+kubebuilder:webhook:path=/mutate-jaegertracing-io-v1-jaeger,mutating=true,failurePolicy=fail,sideEffects=None,groups=jaegertracing.io,resources=jaegers,verbs=create;update,versions=v1,name=mjaeger.kb.io,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:path=/mutate-jaegertracing-io-v1-jaeger,mutating=true,failurePolicy=fail,sideEffects=None,groups=jaegertracing.io,resources=jaegers,verbs=create;update,versions=v1,name=mjaeger.kb.io,admissionReviewVersions={v1}
 
 var _ webhook.Defaulter = &Jaeger{}
 
@@ -59,7 +59,7 @@ func (j *Jaeger) Default() {
 }
 
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
-//+kubebuilder:webhook:path=/validate-jaegertracing-io-v1-jaeger,mutating=false,failurePolicy=fail,sideEffects=None,groups=jaegertracing.io,resources=jaegers,verbs=create;update,versions=v1,name=vjaeger.kb.io,admissionReviewVersions={v1,v1beta1}
+//+kubebuilder:webhook:path=/validate-jaegertracing-io-v1-jaeger,mutating=false,failurePolicy=fail,sideEffects=None,groups=jaegertracing.io,resources=jaegers,verbs=create;update,versions=v1,name=vjaeger.kb.io,admissionReviewVersions={v1}
 
 var _ webhook.Validator = &Jaeger{}
 

--- a/apis/v1/jaeger_webhook.go
+++ b/apis/v1/jaeger_webhook.go
@@ -32,7 +32,7 @@ func (j *Jaeger) SetupWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
-//+kubebuilder:webhook:path=/mutate-jaegertracing-io-v1-jaeger,mutating=true,failurePolicy=fail,sideEffects=None,groups=jaegertracing.io,resources=jaegers,verbs=create;update,versions=v1,name=mjaeger.kb.io,admissionReviewVersions={v1}
+//+kubebuilder:webhook:path=/mutate-jaegertracing-io-v1-jaeger,mutating=true,failurePolicy=fail,sideEffects=None,groups=jaegertracing.io,resources=jaegers,verbs=create;update,versions=v1,name=mjaeger.kb.io,admissionReviewVersions={v1,v1beta1}
 
 var _ webhook.Defaulter = &Jaeger{}
 
@@ -59,7 +59,7 @@ func (j *Jaeger) Default() {
 }
 
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
-//+kubebuilder:webhook:path=/validate-jaegertracing-io-v1-jaeger,mutating=false,failurePolicy=fail,sideEffects=None,groups=jaegertracing.io,resources=jaegers,verbs=create;update,versions=v1,name=vjaeger.kb.io,admissionReviewVersions={v1}
+//+kubebuilder:webhook:path=/validate-jaegertracing-io-v1-jaeger,mutating=false,failurePolicy=fail,sideEffects=None,groups=jaegertracing.io,resources=jaegers,verbs=create;update,versions=v1,name=vjaeger.kb.io,admissionReviewVersions={v1,v1beta1}
 
 var _ webhook.Validator = &Jaeger{}
 

--- a/bundle/manifests/jaeger-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/jaeger-operator.clusterserviceversion.yaml
@@ -524,7 +524,6 @@ spec:
   webhookdefinitions:
   - admissionReviewVersions:
     - v1
-    - v1beta1
     containerPort: 443
     deploymentName: jaeger-operator
     failurePolicy: Fail
@@ -545,7 +544,6 @@ spec:
     webhookPath: /mutate-jaegertracing-io-v1-jaeger
   - admissionReviewVersions:
     - v1
-    - v1beta1
     containerPort: 443
     deploymentName: jaeger-operator
     failurePolicy: Fail

--- a/bundle/manifests/jaeger-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/jaeger-operator.clusterserviceversion.yaml
@@ -524,6 +524,7 @@ spec:
   webhookdefinitions:
   - admissionReviewVersions:
     - v1
+    - v1beta1
     containerPort: 443
     deploymentName: jaeger-operator
     failurePolicy: Fail
@@ -544,6 +545,7 @@ spec:
     webhookPath: /mutate-jaegertracing-io-v1-jaeger
   - admissionReviewVersions:
     - v1
+    - v1beta1
     containerPort: 443
     deploymentName: jaeger-operator
     failurePolicy: Fail

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -7,7 +7,6 @@ metadata:
 webhooks:
 - admissionReviewVersions:
   - v1
-  - v1beta1
   clientConfig:
     service:
       name: webhook-service
@@ -35,7 +34,6 @@ metadata:
 webhooks:
 - admissionReviewVersions:
   - v1
-  - v1beta1
   clientConfig:
     service:
       name: webhook-service

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -7,6 +7,7 @@ metadata:
 webhooks:
 - admissionReviewVersions:
   - v1
+  - v1beta1
   clientConfig:
     service:
       name: webhook-service
@@ -34,6 +35,7 @@ metadata:
 webhooks:
 - admissionReviewVersions:
   - v1
+  - v1beta1
   clientConfig:
     service:
       name: webhook-service


### PR DESCRIPTION
## Which problem is this PR solving?
- Final part of updating to operator-sdk 1.17.  This includes changes for admissionReviewVersions as specified in the [upgrade doc](https://sdk.operatorframework.io/docs/upgrading-sdk-version/v1.14.0/) for v1.14 that I couldn't find when doing #1825 

