### PR TITLE
simplify namespace reconcile

### DIFF
--- a/pkg/controller/jaeger/jaeger_controller.go
+++ b/pkg/controller/jaeger/jaeger_controller.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"strconv"
 	"strings"
 	"time"
 
@@ -381,7 +380,7 @@ func syncOnJaegerChanges(rClient client.Reader, client client.Client, jaegerName
 		}
 
 		// if the deployment has the sidecar annotation, trigger a reconciliation
-		if ok := increaseRevision(dep.Annotations); ok {
+		if ok := inject.IncreaseRevision(dep.Annotations); ok {
 			deps = append(deps, dep)
 			continue
 		}
@@ -397,35 +396,22 @@ func syncOnJaegerChanges(rClient client.Reader, client client.Client, jaegerName
 		}
 
 		// if the namespace has the sidecar annotation, trigger a reconciliation
-		if ok := increaseRevision(ns.Annotations); ok {
+		if ok := inject.IncreaseRevision(ns.Annotations); ok {
 			nssupdate = append(nssupdate, ns)
 			continue
 		}
 	}
 	for _, dep := range deps {
 		if err := client.Update(context.Background(), &dep); err != nil {
-			log.WithField("compoennt", "jaeger-cr-sync").Error(err)
+			log.WithField("component", "jaeger-cr-sync").Error(err)
 			return err
 		}
 	}
 	for _, ns := range nssupdate {
 		if err := client.Update(context.Background(), &ns); err != nil {
-			log.WithField("compoennt", "jaeger-cr-sync").Error(err)
+			log.WithField("component", "jaeger-cr-sync").Error(err)
 			return err
 		}
 	}
 	return nil
-}
-
-func increaseRevision(annotations map[string]string) bool {
-	if _, ok := annotations[inject.Annotation]; ok {
-		revStr := "0"
-		v := annotations[inject.AnnotationRev]
-		if rev, err := strconv.Atoi(v); err == nil {
-			revStr = strconv.Itoa(rev + 1)
-		}
-		annotations[inject.AnnotationRev] = revStr
-		return true
-	}
-	return false
 }

--- a/pkg/controller/namespace/namespace_controller.go
+++ b/pkg/controller/namespace/namespace_controller.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	log "github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 	"go.opentelemetry.io/otel"
 	otelattribute "go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -55,10 +54,11 @@ func (r *ReconcileNamespace) Reconcile(request reconcile.Request) (reconcile.Res
 	defer span.End()
 
 	span.SetAttributes(otelattribute.String("name", request.Name), otelattribute.String("namespace", request.Namespace))
-	log.WithFields(log.Fields{
+	logger := log.WithFields(log.Fields{
 		"namespace": request.Namespace,
 		"name":      request.Name,
-	}).Trace("Reconciling Namespace")
+	})
+	logger.Trace("Reconciling Namespace")
 
 	ns := &corev1.Namespace{}
 	err := r.rClient.Get(ctx, request.NamespacedName, ns)
@@ -99,60 +99,10 @@ func (r *ReconcileNamespace) Reconcile(request reconcile.Request) (reconcile.Res
 			continue
 		}
 
-		if inject.Needed(dep, ns) {
-			jaegers := &v1.JaegerList{}
-			opts := []client.ListOption{}
-
-			if viper.GetString(v1.ConfigOperatorScope) == v1.OperatorScopeNamespace {
-				opts = append(opts, client.InNamespace(viper.GetString(v1.ConfigWatchNamespace)))
-			}
-
-			if err := r.rClient.List(ctx, jaegers, opts...); err != nil {
-				log.WithError(err).Error("failed to get the available Jaeger pods")
+		if inject.IncreaseRevision(dep.Annotations) {
+			if err := r.client.Update(context.Background(), dep); err != nil {
+				logger.Error(err)
 				return reconcile.Result{}, tracing.HandleError(err, span)
-			}
-			patch := client.MergeFrom(dep.DeepCopy())
-			jaeger := inject.Select(dep, ns, jaegers)
-			if jaeger != nil && jaeger.GetDeletionTimestamp() == nil {
-				// a suitable jaeger instance was found! let's inject a sidecar pointing to it then
-				// Verified that jaeger instance was found and is not marked for deletion.
-				log.WithFields(log.Fields{
-					"deployment":       dep.Name,
-					"namespace":        dep.Namespace,
-					"jaeger":           jaeger.Name,
-					"jaeger-namespace": jaeger.Namespace,
-				}).Info("Injecting Jaeger Agent sidecar")
-				dep = inject.Sidecar(jaeger, dep)
-				if err := r.client.Patch(ctx, dep, patch); err != nil {
-					log.WithField("deployment", dep).WithError(err).Error("failed to update")
-					return reconcile.Result{}, tracing.HandleError(err, span)
-				}
-			} else {
-				log.WithField("deployment", dep.Name).Info("No suitable Jaeger instances found to inject a sidecar")
-			}
-		} else {
-			// Don't need injection, may be need to remove the sidecar?
-			// If deployment don't have the annotation and has an hasAgent, this may be injected by the namespace
-			// we need to clean it.
-			hasAgent, _ := inject.HasJaegerAgent(dep)
-			_, hasDepAnnotation := dep.Annotations[inject.Annotation]
-			if hasAgent && !hasDepAnnotation {
-				jaegerInstance, hasLabel := dep.Labels[inject.Label]
-				if hasLabel {
-					log.WithFields(log.Fields{
-						"deployment": dep.Name,
-						"namespace":  dep.Namespace,
-						"jaeger":     jaegerInstance,
-					}).Info("Removing Jaeger Agent sidecar")
-					patch := client.MergeFrom(dep.DeepCopy())
-					inject.CleanSidecar(jaegerInstance, dep)
-					if err := r.client.Patch(ctx, dep, patch); err != nil {
-						log.WithFields(log.Fields{
-							"deploymentName":      dep.Name,
-							"deploymentNamespace": dep.Namespace,
-						}).WithError(err).Error("error cleaning orphaned deployment")
-					}
-				}
 			}
 		}
 	}

--- a/pkg/controller/namespace/namespace_controller_test.go
+++ b/pkg/controller/namespace/namespace_controller_test.go
@@ -2,15 +2,18 @@ package namespace
 
 import (
 	"context"
+	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -18,11 +21,25 @@ import (
 	"github.com/jaegertracing/jaeger-operator/pkg/inject"
 )
 
-func TestReconcilieDeployment(t *testing.T) {
-	depNamespacedName := types.NamespacedName{
-		Name:      "jaeger-query",
-		Namespace: "my-ns",
+type bundle struct {
+	dep              *appsv1.Deployment
+	expectedRevision int
+}
+
+type failingClient struct {
+	client.Client
+	err error
+}
+
+func (f *failingClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	if f.err != nil {
+		return f.err
 	}
+	return f.Client.Update(ctx, obj, opts...)
+}
+
+func TestReconcilieDeployment(t *testing.T) {
+	const depNamespace = "my-ns"
 
 	jaeger := v1.NewJaeger(types.NamespacedName{
 		Namespace: "observability",
@@ -33,87 +50,186 @@ func TestReconcilieDeployment(t *testing.T) {
 	s.AddKnownTypes(v1.GroupVersion, jaeger)
 	s.AddKnownTypes(v1.GroupVersion, &v1.JaegerList{})
 
+	errReconcile := fmt.Errorf("no no reconcile")
+
 	testCases := []struct {
-		desc              string
-		dep               *appsv1.Deployment
-		expectedContiners int
+		desc         string
+		bundle       []bundle
+		errReconcile error
 	}{
 		{
-			desc: "Should not remove the instance from a jaeger component",
-			dep: inject.Sidecar(jaeger, &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        depNamespacedName.Name,
-					Namespace:   depNamespacedName.Namespace,
-					Annotations: map[string]string{},
-					Labels: map[string]string{
-						"app": "jaeger",
-					},
-				},
-				Spec: appsv1.DeploymentSpec{
-					Template: corev1.PodTemplateSpec{
-						ObjectMeta: metav1.ObjectMeta{},
-						Spec: corev1.PodSpec{
-							Containers: []corev1.Container{{
-								Name: "only_container",
-							}},
+			desc: "Should set annotations to reevaluate deployments",
+			bundle: []bundle{
+				{
+					expectedRevision: -1,
+					dep: &appsv1.Deployment{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:        "jaeger-query",
+							Namespace:   depNamespace,
+							Annotations: map[string]string{},
+							Labels: map[string]string{
+								"app": "jaeger",
+							},
+						},
+						Spec: appsv1.DeploymentSpec{
+							Template: corev1.PodTemplateSpec{
+								ObjectMeta: metav1.ObjectMeta{},
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{{
+										Name: "only_container",
+									}},
+								},
+							},
 						},
 					},
 				},
-			}),
-			expectedContiners: 2,
+				{
+					expectedRevision: 0,
+					dep: &appsv1.Deployment{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "app1",
+							Namespace: depNamespace,
+							Annotations: map[string]string{
+								inject.Annotation: "true",
+							},
+							Labels: map[string]string{
+								"app": "app1",
+							},
+						},
+						Spec: appsv1.DeploymentSpec{
+							Template: corev1.PodTemplateSpec{
+								ObjectMeta: metav1.ObjectMeta{},
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{{
+										Name: "only_container",
+									}},
+								},
+							},
+						},
+					},
+				},
+				{
+					expectedRevision: 6,
+					dep: &appsv1.Deployment{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "app2",
+							Namespace: depNamespace,
+							Annotations: map[string]string{
+								inject.AnnotationRev: "5",
+								inject.Annotation:    "true",
+							},
+							Labels: map[string]string{
+								"app": "app2",
+							},
+						},
+						Spec: appsv1.DeploymentSpec{
+							Template: corev1.PodTemplateSpec{
+								ObjectMeta: metav1.ObjectMeta{},
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{{
+										Name: "only_container",
+									}},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 		{
-			desc: "Should remove the instance",
-			dep: inject.Sidecar(jaeger, &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        depNamespacedName.Name,
-					Namespace:   depNamespacedName.Namespace,
-					Annotations: map[string]string{},
-				},
-				Spec: appsv1.DeploymentSpec{
-					Template: corev1.PodTemplateSpec{
-						ObjectMeta: metav1.ObjectMeta{},
-						Spec: corev1.PodSpec{
-							Containers: []corev1.Container{{
-								Name: "only_container",
-							}},
+			desc:         "Should fail updating deployment",
+			errReconcile: errReconcile,
+			bundle: []bundle{
+				{
+					expectedRevision: 6,
+					dep: &appsv1.Deployment{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "app2",
+							Namespace: depNamespace,
+							Annotations: map[string]string{
+								inject.AnnotationRev: "5",
+								inject.Annotation:    "true",
+							},
+							Labels: map[string]string{
+								"app": "app2",
+							},
+						},
+						Spec: appsv1.DeploymentSpec{
+							Template: corev1.PodTemplateSpec{
+								ObjectMeta: metav1.ObjectMeta{},
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{{
+										Name: "only_container",
+									}},
+								},
+							},
 						},
 					},
 				},
-			}),
-			expectedContiners: 1,
+			},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 
-			assert.Equal(t, 2, len(tc.dep.Spec.Template.Spec.Containers))
 			ns := &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: depNamespacedName.Namespace,
+					Name: depNamespace,
 				},
 			}
 
-			cl := fake.NewFakeClient(tc.dep, ns)
+			objs := []runtime.Object{ns}
+			for _, b := range tc.bundle {
+				objs = append(objs, b.dep)
+			}
+			cl := fake.NewFakeClient(objs...)
 			r := &ReconcileNamespace{
-				client:  cl,
+				client:  &failingClient{Client: cl, err: tc.errReconcile},
 				rClient: cl,
 				scheme:  s,
 			}
 			req := reconcile.Request{
 				NamespacedName: types.NamespacedName{
-					Name: depNamespacedName.Namespace,
+					Name: depNamespace,
 				},
 			}
-
 			_, err := r.Reconcile(req)
-			persisted := &appsv1.Deployment{}
-			cl.Get(context.Background(), depNamespacedName, persisted)
+			assert.Equal(t, tc.errReconcile, err)
+			if tc.errReconcile != nil {
+				return
+			}
 
-			assert.Equal(t, tc.expectedContiners, len(persisted.Spec.Template.Spec.Containers))
+			persisted := &appsv1.DeploymentList{}
+			assert.Nil(t, cl.List(context.Background(), persisted))
 
-			require.NoError(t, err)
+			for _, p := range persisted.Items {
+				const notFound = -2
+				expectedRevision := notFound
+				appName, ok := p.Labels["app"]
+				assert.True(t, ok)
+				for _, b := range tc.bundle {
+					name, ok := b.dep.Labels["app"]
+					assert.True(t, ok)
+					if appName == name {
+						expectedRevision = b.expectedRevision
+						break
+					}
+				}
+				if expectedRevision == notFound {
+					t.Fatal("app not found")
+				}
+
+				revStr, ok := p.Annotations[inject.AnnotationRev]
+				if expectedRevision == -1 {
+					assert.False(t, ok)
+				} else {
+					assert.True(t, ok)
+					rev, err := strconv.Atoi(revStr)
+					assert.Nil(t, err)
+					assert.Equal(t, expectedRevision, rev)
+				}
+			}
 		})
 	}
 }

--- a/pkg/inject/sidecar.go
+++ b/pkg/inject/sidecar.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -95,6 +96,22 @@ func desired(dep *appsv1.Deployment, ns *corev1.Namespace) bool {
 		return true
 	}
 
+	return false
+}
+
+// IncreaseRevision increases the revision counter if a inject annoation exists.
+// returns true if counter could be set or increased.
+// returns false if inject annotation doesnt exist.
+func IncreaseRevision(annotations map[string]string) bool {
+	if _, ok := annotations[Annotation]; ok {
+		revStr := "0"
+		v := annotations[AnnotationRev]
+		if rev, err := strconv.Atoi(v); err == nil {
+			revStr = strconv.Itoa(rev + 1)
+		}
+		annotations[AnnotationRev] = revStr
+		return true
+	}
 	return false
 }
 

--- a/pkg/inject/sidecar_test.go
+++ b/pkg/inject/sidecar_test.go
@@ -32,6 +32,19 @@ func reset() {
 	setDefaults()
 }
 
+func TestIncreaseRevision(t *testing.T) {
+	assert.True(t, IncreaseRevision(map[string]string{
+		Annotation: "true",
+	}))
+	assert.True(t, IncreaseRevision(map[string]string{
+		Annotation:    "true",
+		AnnotationRev: "2",
+	}))
+	assert.False(t, IncreaseRevision(map[string]string{
+		AnnotationRev: "2",
+	}))
+}
+
 func TestInjectSidecar(t *testing.T) {
 	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
 	dep := dep(map[string]string{}, map[string]string{})


### PR DESCRIPTION
## Which problem is this PR solving?
- this pr removes the sidecar logic from the namespace reconciler. If an ns is changed, the reconciler now increments the revision number of the affected deployments. In the deployment webhook it is then evaluated if the PodSpec has to be modified or not.
- Belongs to https://github.com/jaegertracing/jaeger-operator/pull/1804
- Follow-up of https://github.com/jaegertracing/jaeger-operator/pull/1828

## Short description of the changes
- namespace reconciler is no longer adding or removing sidecars to deployments.
- namespace reconciler increases revision annotations of affected deployment by namespace change.