### PR TITLE
fix: make uninstall and undeploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -297,9 +297,7 @@ ci: ensure-generate-is-noop check format lint security build unit-tests
 
 ##@ Deployment
 
-ifndef ignore-not-found
-  ignore-not-found = false
-endif
+ignore-not-found ?= false
 
 .PHONY: install
 install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
@@ -307,7 +305,7 @@ install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~
 
 .PHONY: uninstall
 uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/crd | kubectl delete -ignore-not-found=$(ignore-not-found) -f -
+	$(KUSTOMIZE) build config/crd | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
 .PHONY: deploy
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
@@ -316,7 +314,7 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 
 .PHONY: undeploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/default | kubectl delete -ignore-not-found=$(ignore-not-found) -f -
+	$(KUSTOMIZE) build config/default | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
 .PHONY: operatorhub
 operatorhub: check-operatorhub-pr-template


### PR DESCRIPTION
Signed-off-by: Benedikt Bongartz <bongartz@klimlive.de>

## Which problem is this PR solving?
- `make undeploy` & `make uninstall` work as expected.

## Short description of the changes
- `make undeploy` will result in `build config/default | kubectl delete --ignore-not-found=false -f -`
- `make undeploy ignore-not-found=true` will result in `build config/default | kubectl delete --ignore-not-found=true -f -`

## Additional

```
kubectl delete -h 2&>1 | grep ignore-not-found 
      --ignore-not-found=false: Treat "resource not found" as a successful delete. Defaults to "true" when --all is specified.
```

---

cc @kevinearls 