### PR TITLE
Install controller-gen only when it is needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -336,7 +336,7 @@ changelog:
 
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 controller-gen: ## Download controller-gen locally if necessary.
-	$(VECHO) GOBIN=$(shell pwd)/bin go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.8.0
+	$(VECHO)./hack/install/install-controller-gen.sh
 
 ENVTEST = $(shell pwd)/bin/setup-envtest
 envtest: ## Download envtest-setup locally if necessary.

--- a/hack/install/install-controller-gen.sh
+++ b/hack/install/install-controller-gen.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+VERSION="0.8.0"
+
+echo "Installing controller-gen"
+
+current_dir=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source $current_dir/install-utils.sh
+
+PROGRAM="controller-gen"
+
+create_bin
+
+export GOBIN=$BIN
+
+check_tool "$BIN/$PROGRAM" "$VERSION" "--version"
+
+retry "go install sigs.k8s.io/controller-tools/cmd/controller-gen@v${VERSION}"

--- a/hack/install/install-utils.sh
+++ b/hack/install/install-utils.sh
@@ -22,7 +22,7 @@ function retry() {
     n=0
     until [ "$n" -ge 5 ]
     do
-        echo "Try $n..."
+        echo "Try $n... $command"
         $command && break
         n=$((n+1))
         sleep 5


### PR DESCRIPTION
## Which problem is this PR solving?
- #1814

## Short description of the changes
- Change the way to install `controller-gen` to use the mechanisms from the `hack/install` folder
