### PR TITLE
Add http- prefix to port names in collector and agent services

### DIFF
--- a/pkg/service/agent.go
+++ b/pkg/service/agent.go
@@ -42,7 +42,7 @@ func NewAgentService(jaeger *v1.Jaeger, selector map[string]string) *corev1.Serv
 					Protocol: corev1.ProtocolUDP,
 				},
 				{
-					Name: "config-rest",
+					Name: "http-config-rest",
 					Port: 5778,
 				},
 				{

--- a/pkg/service/collector.go
+++ b/pkg/service/collector.go
@@ -69,7 +69,7 @@ func collectorService(jaeger *v1.Jaeger, selector map[string]string) *corev1.Ser
 					Port: 14250,
 				},
 				{
-					Name: "c-tchan-trft",
+					Name: "http-c-tchan-trft",
 					Port: 14267,
 				},
 				{


### PR DESCRIPTION
Signed-off-by: Karol Szwaj <karol.szwaj@gmail.com>

<!--
Please delete this comment before posting.

We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- https://github.com/jaegertracing/helm-charts/issues/344#issuecomment-1100166786 (partially)
## Short description of the changes
Adding a prefix to service port names, resolves issues with istioctl 
```bash
Info [IST0118] (Service tracing-jaeger-agent.kyma-system) Port name config-rest (port: 5778, targetPort: 5778) doesn't follow the naming convention of Istio port.
Info [IST0118] (Service tracing-jaeger-collector-headless.kyma-system) Port name c-tchan-trft (port: 14267, targetPort: 14267) doesn't follow the naming convention of Istio port.
Info [IST0118] (Service tracing-jaeger-collector.kyma-system) Port name c-tchan-trft (port: 14267, targetPort: 14267) doesn't follow the naming convention of Istio port.
```
Potentially possible problems similar to this old [issue](https://github.com/jaegertracing/jaeger-operator/issues/907).
