### PR TITLE
Replace instances of deprecated NewFakeClient function

### DIFF
--- a/controllers/appsv1/deployment_webhook_test.go
+++ b/controllers/appsv1/deployment_webhook_test.go
@@ -89,7 +89,7 @@ func TestReconcileConfigMaps(t *testing.T) {
 			}
 
 			cl := &failingClient{
-				WithWatch: fake.NewFakeClient(tC.existing...),
+				WithWatch: fake.NewClientBuilder().WithRuntimeObjects(tC.existing...).Build(),
 				errors:    tC.errors,
 			}
 
@@ -367,7 +367,7 @@ func TestReconcilieDeployment(t *testing.T) {
 			}
 
 			cl := &failingClient{
-				WithWatch: fake.NewFakeClient(res...),
+				WithWatch: fake.NewClientBuilder().WithRuntimeObjects(res...).Build(),
 				errors:    tc.errors,
 			}
 

--- a/pkg/autodetect/main_test.go
+++ b/pkg/autodetect/main_test.go
@@ -36,7 +36,7 @@ func TestStart(t *testing.T) {
 
 	// prepare
 	dcl := &fakeDiscoveryClient{}
-	cl := fake.NewFakeClient()
+	cl := fake.NewClientBuilder().Build()
 	b := WithClients(cl, dcl, cl)
 
 	done := make(chan bool)
@@ -123,7 +123,7 @@ func TestAutoDetectWithServerGroupsError(t *testing.T) {
 	defer viper.Reset()
 
 	dcl := &fakeDiscoveryClient{}
-	cl := fake.NewFakeClient()
+	cl := fake.NewClientBuilder().Build()
 	b := WithClients(cl, dcl, cl)
 
 	// sanity check
@@ -152,7 +152,7 @@ func TestAutoDetectWithServerResourcesForGroupVersionError(t *testing.T) {
 	defer viper.Reset()
 
 	dcl := &fakeDiscoveryClient{}
-	cl := fake.NewFakeClient()
+	cl := fake.NewClientBuilder().Build()
 	b := WithClients(cl, dcl, cl)
 
 	// sanity check
@@ -187,7 +187,7 @@ func TestAutoDetectOpenShift(t *testing.T) {
 	defer viper.Reset()
 
 	dcl := &fakeDiscoveryClient{}
-	cl := fake.NewFakeClient()
+	cl := fake.NewClientBuilder().Build()
 	b := WithClients(cl, dcl, cl)
 
 	dcl.ServerResourcesForGroupVersionFunc = func(_ string) (apiGroupList *metav1.APIResourceList, err error) {
@@ -224,7 +224,7 @@ func TestAutoDetectKubernetes(t *testing.T) {
 	defer viper.Reset()
 
 	dcl := &fakeDiscoveryClient{}
-	cl := fake.NewFakeClient()
+	cl := fake.NewClientBuilder().Build()
 	b := WithClients(cl, dcl, cl)
 
 	// test
@@ -240,7 +240,7 @@ func TestExplicitPlatform(t *testing.T) {
 	defer viper.Reset()
 
 	dcl := &fakeDiscoveryClient{}
-	cl := fake.NewFakeClient()
+	cl := fake.NewClientBuilder().Build()
 	b := WithClients(cl, dcl, cl)
 
 	// test
@@ -256,7 +256,7 @@ func TestAutoDetectEsProvisionNoEsOperator(t *testing.T) {
 	defer viper.Reset()
 
 	dcl := &fakeDiscoveryClient{}
-	cl := fake.NewFakeClient()
+	cl := fake.NewClientBuilder().Build()
 	b := WithClients(cl, dcl, cl)
 
 	// test
@@ -272,7 +272,7 @@ func TestAutoDetectEsProvisionWithEsOperator(t *testing.T) {
 	defer viper.Reset()
 
 	dcl := &fakeDiscoveryClient{}
-	cl := fake.NewFakeClient()
+	cl := fake.NewClientBuilder().Build()
 	b := WithClients(cl, dcl, cl)
 
 	dcl.ServerGroupsFunc = func() (apiGroupList *metav1.APIGroupList, err error) {
@@ -320,7 +320,7 @@ func TestAutoDetectKafkaProvisionNoKafkaOperator(t *testing.T) {
 	defer viper.Reset()
 
 	dcl := &fakeDiscoveryClient{}
-	cl := fake.NewFakeClient()
+	cl := fake.NewClientBuilder().Build()
 	b := WithClients(cl, dcl, cl)
 
 	// test
@@ -336,7 +336,7 @@ func TestAutoDetectKafkaProvisionWithKafkaOperator(t *testing.T) {
 	defer viper.Reset()
 
 	dcl := &fakeDiscoveryClient{}
-	cl := fake.NewFakeClient()
+	cl := fake.NewClientBuilder().Build()
 	b := WithClients(cl, dcl, cl)
 
 	dcl.ServerGroupsFunc = func() (apiGroupList *metav1.APIGroupList, err error) {
@@ -362,7 +362,7 @@ func TestAutoDetectKafkaExplicitYes(t *testing.T) {
 	defer viper.Reset()
 
 	dcl := &fakeDiscoveryClient{}
-	cl := fake.NewFakeClient()
+	cl := fake.NewClientBuilder().Build()
 	b := WithClients(cl, dcl, cl)
 
 	// test
@@ -378,7 +378,7 @@ func TestAutoDetectKafkaExplicitNo(t *testing.T) {
 	defer viper.Reset()
 
 	dcl := &fakeDiscoveryClient{}
-	cl := fake.NewFakeClient()
+	cl := fake.NewClientBuilder().Build()
 	b := WithClients(cl, dcl, cl)
 
 	// test
@@ -394,7 +394,7 @@ func TestAutoDetectKafkaDefaultNoOperator(t *testing.T) {
 	defer viper.Reset()
 
 	dcl := &fakeDiscoveryClient{}
-	cl := fake.NewFakeClient()
+	cl := fake.NewClientBuilder().Build()
 	b := WithClients(cl, dcl, cl)
 
 	// test
@@ -410,7 +410,7 @@ func TestAutoDetectKafkaDefaultWithOperator(t *testing.T) {
 	defer viper.Reset()
 
 	dcl := &fakeDiscoveryClient{}
-	cl := fake.NewFakeClient()
+	cl := fake.NewClientBuilder().Build()
 	b := WithClients(cl, dcl, cl)
 	dcl.ServerGroupsFunc = func() (apiGroupList *metav1.APIGroupList, err error) {
 		return &metav1.APIGroupList{Groups: []metav1.APIGroup{{
@@ -589,7 +589,7 @@ func TestCleanDeployments(t *testing.T) {
 			s := scheme.Scheme
 			s.AddKnownTypes(v1.GroupVersion, &v1.Jaeger{})
 			s.AddKnownTypes(v1.GroupVersion, &v1.JaegerList{})
-			cl := fake.NewFakeClient(objs...)
+			cl := fake.NewClientBuilder().WithRuntimeObjects(objs...).Build()
 			b := WithClients(cl, &fakeDiscoveryClient{}, cl)
 
 			// test
@@ -621,7 +621,7 @@ type fakeClient struct {
 }
 
 func customFakeClient() *fakeClient {
-	c := fake.NewFakeClient()
+	c := fake.NewClientBuilder().Build()
 	return &fakeClient{Client: c, CreateFunc: c.Create}
 }
 

--- a/pkg/controller/jaeger/jaeger_controller_test.go
+++ b/pkg/controller/jaeger/jaeger_controller_test.go
@@ -171,7 +171,7 @@ func TestSyncOnJaegerChanges(t *testing.T) {
 	)
 
 	cl := &modifiedClient{
-		Client:  fake.NewFakeClient(objs...),
+		Client:  fake.NewClientBuilder().WithRuntimeObjects(objs...).Build(),
 		listErr: errList,
 		getErr:  errGet,
 	}
@@ -246,7 +246,7 @@ func TestDeletedInstance(t *testing.T) {
 	s.AddKnownTypes(v1.GroupVersion, jaeger)
 
 	// no known objects
-	cl := fake.NewFakeClient()
+	cl := fake.NewClientBuilder().Build()
 
 	r := &ReconcileJaeger{client: cl, scheme: s, rClient: cl}
 
@@ -280,7 +280,8 @@ func TestSetOwnerOnNewInstance(t *testing.T) {
 
 	s := scheme.Scheme
 	s.AddKnownTypes(v1.GroupVersion, jaeger)
-	cl := fake.NewFakeClient(jaeger)
+	cl := fake.NewClientBuilder().WithObjects(jaeger).Build()
+
 	r := &ReconcileJaeger{client: cl, scheme: s, rClient: cl}
 	req := reconcile.Request{NamespacedName: nsn}
 
@@ -308,7 +309,7 @@ func TestSkipOnNonOwnedCR(t *testing.T) {
 
 	s := scheme.Scheme
 	s.AddKnownTypes(v1.GroupVersion, jaeger)
-	cl := fake.NewFakeClient(jaeger)
+	cl := fake.NewClientBuilder().WithObjects(jaeger).Build()
 	r := &ReconcileJaeger{client: cl, scheme: s, rClient: cl}
 	req := reconcile.Request{NamespacedName: nsn}
 
@@ -338,8 +339,8 @@ func TestGetResourceFromNonCachedClient(t *testing.T) {
 	// we trigger the reconciliation and expect it to finish without errors, while we expect to not have an instance afterwards
 	// if the code is using the cached client, we would end up either with an error (trying to update an instance that does not exist)
 	// or we'd end up with an instance
-	cachedClient := fake.NewFakeClient(jaeger)
-	client := fake.NewFakeClient()
+	cachedClient := fake.NewClientBuilder().WithObjects(jaeger).Build()
+	client := fake.NewClientBuilder().Build()
 
 	r := &ReconcileJaeger{client: cachedClient, scheme: s, rClient: client}
 	req := reconcile.Request{NamespacedName: nsn}
@@ -433,7 +434,7 @@ func getReconciler(objs []runtime.Object) (*ReconcileJaeger, client.Client) {
 	// Kafka
 	s.AddKnownTypes(v1beta2.GroupVersion, &v1beta2.Kafka{}, &v1beta2.KafkaList{}, &v1beta2.KafkaUser{}, &v1beta2.KafkaUserList{})
 
-	cl := fake.NewFakeClient(objs...)
+	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 	r := New(cl, cl, s)
 	r.certGenerationScript = "../../../scripts/cert_generation.sh"
 	return r, cl

--- a/pkg/controller/namespace/namespace_controller_test.go
+++ b/pkg/controller/namespace/namespace_controller_test.go
@@ -183,7 +183,7 @@ func TestReconcilieDeployment(t *testing.T) {
 			for _, b := range tc.bundle {
 				objs = append(objs, b.dep)
 			}
-			cl := fake.NewFakeClient(objs...)
+			cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 			r := &ReconcileNamespace{
 				client:  &failingClient{Client: cl, err: tc.errReconcile},
 				rClient: cl,

--- a/pkg/metrics/instances_test.go
+++ b/pkg/metrics/instances_test.go
@@ -120,7 +120,7 @@ func TestValueObservedMetrics(t *testing.T) {
 		newExpectedMetric(agentStrategiesMetric, attribute.String("type", "daemonset"), 1),
 	}
 
-	cl := fake.NewFakeClientWithScheme(s, objs...)
+	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 
 	meter, provider := oteltest.NewMeterProvider()
 	global.SetMeterProvider(provider)
@@ -201,7 +201,7 @@ func TestAutoProvisioningESObservedMetric(t *testing.T) {
 		&autoprovisioningInstance,
 	}
 
-	cl := fake.NewFakeClientWithScheme(s, objs...)
+	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 	meter, provider := oteltest.NewMeterProvider()
 	global.SetMeterProvider(provider)
 
@@ -271,7 +271,7 @@ func TestManagerByMetric(t *testing.T) {
 		&nonManaged,
 	}
 
-	cl := fake.NewFakeClientWithScheme(s, objs...)
+	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 	meter, provider := oteltest.NewMeterProvider()
 	global.SetMeterProvider(provider)
 

--- a/pkg/upgrade/upgrade_test.go
+++ b/pkg/upgrade/upgrade_test.go
@@ -28,7 +28,7 @@ func TestVersionUpgradeToLatest(t *testing.T) {
 	s := scheme.Scheme
 	s.AddKnownTypes(v1.GroupVersion, &v1.Jaeger{})
 	s.AddKnownTypes(v1.GroupVersion, &v1.JaegerList{})
-	cl := fake.NewFakeClient(objs...)
+	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 
 	// test
 	assert.NoError(t, ManagedInstances(context.Background(), cl, cl, opver.Get().Jaeger))
@@ -56,7 +56,7 @@ func TestVersionUpgradeToLatestMultinamespace(t *testing.T) {
 	s := scheme.Scheme
 	s.AddKnownTypes(v1.GroupVersion, &v1.Jaeger{})
 	s.AddKnownTypes(v1.GroupVersion, &v1.JaegerList{})
-	cl := fake.NewFakeClient(objs...)
+	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 
 	// test
 	assert.NoError(t, ManagedInstances(context.Background(), cl, cl, opver.Get().Jaeger))
@@ -84,7 +84,7 @@ func TestVersionUpgradeToLatestOwnedResource(t *testing.T) {
 	s := scheme.Scheme
 	s.AddKnownTypes(v1.GroupVersion, &v1.Jaeger{})
 	s.AddKnownTypes(v1.GroupVersion, &v1.JaegerList{})
-	cl := fake.NewFakeClient(objs...)
+	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 
 	// test
 	assert.NoError(t, ManagedInstances(context.Background(), cl, cl, opver.Get().Jaeger))
@@ -106,7 +106,7 @@ func TestUnknownVersion(t *testing.T) {
 	s := scheme.Scheme
 	s.AddKnownTypes(v1.GroupVersion, &v1.Jaeger{})
 	s.AddKnownTypes(v1.GroupVersion, &v1.JaegerList{})
-	cl := fake.NewFakeClient(objs...)
+	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 
 	// test
 	assert.NoError(t, ManagedInstances(context.Background(), cl, cl, opver.Get().Jaeger))
@@ -134,7 +134,7 @@ func TestSkipForNonOwnedInstances(t *testing.T) {
 	s := scheme.Scheme
 	s.AddKnownTypes(v1.GroupVersion, &v1.Jaeger{})
 	s.AddKnownTypes(v1.GroupVersion, &v1.JaegerList{})
-	cl := fake.NewFakeClient(objs...)
+	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 
 	// test
 	assert.NoError(t, ManagedInstances(context.Background(), cl, cl, opver.Get().Jaeger))
@@ -171,7 +171,7 @@ func TestSkipUpgradeForVersionsGreaterThanLatest(t *testing.T) {
 	s := scheme.Scheme
 	s.AddKnownTypes(v1.GroupVersion, &v1.Jaeger{})
 	s.AddKnownTypes(v1.GroupVersion, &v1.JaegerList{})
-	cl := fake.NewFakeClient(objs...)
+	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 
 	// test
 	assert.NoError(t, ManagedInstances(context.Background(), cl, cl, opver.Get().Jaeger))

--- a/pkg/upgrade/v1_15_0_test.go
+++ b/pkg/upgrade/v1_15_0_test.go
@@ -26,7 +26,7 @@ func TestUpgradeDeprecatedOptionsv1_15_0(t *testing.T) {
 	s := scheme.Scheme
 	s.AddKnownTypes(v1.GroupVersion, &v1.Jaeger{})
 	s.AddKnownTypes(v1.GroupVersion, &v1.JaegerList{})
-	cl := fake.NewFakeClient(objs...)
+	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 
 	// test
 	assert.NoError(t, ManagedInstances(context.Background(), cl, cl, latestVersion))

--- a/pkg/upgrade/v1_17_0_test.go
+++ b/pkg/upgrade/v1_17_0_test.go
@@ -34,7 +34,7 @@ func TestUpgradeDeprecatedOptionsv1_17_0(t *testing.T) {
 	s := scheme.Scheme
 	s.AddKnownTypes(v1.GroupVersion, &v1.Jaeger{})
 	s.AddKnownTypes(v1.GroupVersion, &v1.JaegerList{})
-	cl := fake.NewFakeClient(objs...)
+	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 
 	// test
 	assert.NoError(t, ManagedInstances(context.Background(), cl, cl, latestVersion))

--- a/pkg/upgrade/v1_18_0_test.go
+++ b/pkg/upgrade/v1_18_0_test.go
@@ -42,7 +42,7 @@ func TestUpgradeDeprecatedOptionsv1_18_0(t *testing.T) {
 	s := scheme.Scheme
 	s.AddKnownTypes(v1.GroupVersion, &v1.Jaeger{})
 	s.AddKnownTypes(v1.GroupVersion, &v1.JaegerList{})
-	cl := fake.NewFakeClient(objs...)
+	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 
 	// test
 	assert.NoError(t, ManagedInstances(context.Background(), cl, cl, latestVersion))
@@ -85,7 +85,7 @@ func TestUpgradeAgentWithTChannelEnablev1_18_0_(t *testing.T) {
 	s := scheme.Scheme
 	s.AddKnownTypes(v1.GroupVersion, &v1.Jaeger{})
 	s.AddKnownTypes(v1.GroupVersion, &v1.JaegerList{})
-	cl := fake.NewFakeClient(objs...)
+	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 
 	assert.NoError(t, ManagedInstances(context.Background(), cl, cl, latestVersion))
 

--- a/pkg/upgrade/v1_20_0_test.go
+++ b/pkg/upgrade/v1_20_0_test.go
@@ -27,7 +27,7 @@ func TestUpgradeDeprecatedOptionsv1_20_0NonConflicting(t *testing.T) {
 	s := scheme.Scheme
 	s.AddKnownTypes(v1.GroupVersion, &v1.Jaeger{})
 	s.AddKnownTypes(v1.GroupVersion, &v1.JaegerList{})
-	cl := fake.NewFakeClient(objs...)
+	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 
 	// test
 	assert.NoError(t, ManagedInstances(context.Background(), cl, cl, latestVersion))

--- a/pkg/upgrade/v1_22_0_test.go
+++ b/pkg/upgrade/v1_22_0_test.go
@@ -42,7 +42,7 @@ func TestUpgradeJaegerTagssv1_22_0(t *testing.T) {
 	s := scheme.Scheme
 	s.AddKnownTypes(v1.GroupVersion, &v1.Jaeger{})
 	s.AddKnownTypes(v1.GroupVersion, &v1.JaegerList{})
-	cl := fake.NewFakeClient(objs...)
+	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 
 	// test
 	assert.NoError(t, ManagedInstances(context.Background(), cl, cl, latestVersion))
@@ -89,7 +89,7 @@ func TestDeleteQueryRemovedFlags(t *testing.T) {
 	s := scheme.Scheme
 	s.AddKnownTypes(v1.GroupVersion, &v1.Jaeger{})
 	s.AddKnownTypes(v1.GroupVersion, &v1.JaegerList{})
-	cl := fake.NewFakeClient(objs...)
+	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 	assert.NoError(t, ManagedInstances(context.Background(), cl, cl, latestVersion))
 
 	persisted := &v1.Jaeger{}
@@ -139,7 +139,7 @@ func TestCassandraVerifyHostFlags(t *testing.T) {
 			s := scheme.Scheme
 			s.AddKnownTypes(v1.GroupVersion, &v1.Jaeger{})
 			s.AddKnownTypes(v1.GroupVersion, &v1.JaegerList{})
-			cl := fake.NewFakeClient(objs...)
+			cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 			assert.NoError(t, ManagedInstances(context.Background(), cl, cl, latestVersion))
 
 			persisted := &v1.Jaeger{}
@@ -246,7 +246,7 @@ func TestMigrateQueryHostPortFlagsv1_22_0(t *testing.T) {
 		s := scheme.Scheme
 		s.AddKnownTypes(v1.GroupVersion, &v1.Jaeger{})
 		s.AddKnownTypes(v1.GroupVersion, &v1.JaegerList{})
-		cl := fake.NewFakeClient(objs...)
+		cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 		assert.NoError(t, ManagedInstances(context.Background(), cl, cl, latestVersion))
 
 		persisted := &v1.Jaeger{}


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com>

## Which problem is this PR solving?
- Fixes #1854 

## Short description of the changes
- This PR replaces calls to the deprecated NewFakeClient() function (from igs.k8s.io/controller-runtime/pkg/client/fake) with NewClientBuilder()
