### PR TITLE
fix: jaeger streaming e2e test for upcoming release 1.34

### DIFF
--- a/tests/e2e/streaming/streaming-with-tls/05-install.yaml
+++ b/tests/e2e/streaming/streaming-with-tls/05-install.yaml
@@ -15,6 +15,7 @@ spec:
           topic: jaeger-spans
           brokers: my-cluster-kafka-bootstrap:9093
           tls:
+            enabled: true
             ca: /var/run/secrets/cluster-ca/ca.crt
             cert: /var/run/secrets/kafkauser/user.crt
             key: /var/run/secrets/kafkauser/user.key
@@ -26,6 +27,7 @@ spec:
           topic: jaeger-spans
           brokers: my-cluster-kafka-bootstrap:9093
           tls:
+            enabled: true
             ca: /var/run/secrets/cluster-ca/ca.crt
             cert: /var/run/secrets/kafkauser/user.crt
             key: /var/run/secrets/kafkauser/user.key


### PR DESCRIPTION
Signed-off-by: Benedikt Bongartz <bongartz@klimlive.de>

<!--
Please delete this comment before posting.

We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Updating Jaeger to 1.34 will make our streaming with tls e2e tests fail https://github.com/jaegertracing/jaeger/pull/3030

## Short description of the changes
- Set requiered enable tls value
