### PR TITLE
adapt tls flag usage for upcoming release

### DIFF
--- a/apis/v1/jaeger_webhook_test.go
+++ b/apis/v1/jaeger_webhook_test.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -127,6 +128,39 @@ func TestDefault(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "missing tls enable flag",
+			j: &Jaeger{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "project1",
+				},
+				Spec: JaegerSpec{
+					Storage: JaegerStorageSpec{
+						Type:    JaegerMemoryStorage,
+						Options: NewOptions(map[string]interface{}{"stuff.tls.test": "something"}),
+					},
+				},
+			},
+			expected: &Jaeger{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "project1",
+				},
+				Spec: JaegerSpec{
+					Storage: JaegerStorageSpec{
+						Type: JaegerMemoryStorage,
+						Options: NewOptions(
+							map[string]interface{}{
+								"stuff.tls.test":    "something",
+								"stuff.tls.enabled": "true",
+							},
+						),
+						Elasticsearch: ElasticsearchSpec{
+							Name: defaultElasticsearchName,
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -140,6 +174,10 @@ func TestDefault(t *testing.T) {
 			assert.Equal(t, test.expected, test.j)
 		})
 	}
+}
+
+func TestValidateDelete(t *testing.T) {
+	assert.Nil(t, new(Jaeger).ValidateDelete())
 }
 
 func TestValidate(t *testing.T) {
@@ -211,6 +249,23 @@ func TestValidate(t *testing.T) {
 			},
 			err: `elasticsearch instance not found: elasticsearchs.logging.openshift.io "my-es" not found`,
 		},
+		{
+			name: "missing tls options",
+			current: &Jaeger{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "project1",
+				},
+				Spec: JaegerSpec{
+					Storage: JaegerStorageSpec{
+						Options: NewOptions(map[string]interface{}{
+							"something.tls.else": "fails",
+						}),
+						Type: JaegerMemoryStorage,
+					},
+				},
+			},
+			err: `tls flags incomplete, got: [--something.tls.else=fails]`,
+		},
 	}
 
 	for _, test := range tests {
@@ -222,6 +277,7 @@ func TestValidate(t *testing.T) {
 
 			err := test.current.ValidateCreate()
 			if test.err != "" {
+				assert.NotNil(t, err)
 				assert.Equal(t, test.err, err.Error())
 			} else {
 				assert.Nil(t, err)
@@ -243,6 +299,62 @@ func TestShouldDeployElasticsearch(t *testing.T) {
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			assert.Equal(t, test.expected, ShouldInjectOpenShiftElasticsearchConfiguration(test.j))
+		})
+	}
+}
+
+func TestGetAdditionalTLSFlags(t *testing.T) {
+	tt := []struct {
+		name   string
+		args   []string
+		expect map[string]interface{}
+	}{
+		{
+			name:   "no tls flag",
+			args:   []string{"--something.else"},
+			expect: nil,
+		},
+		{
+			name:   "already enabled",
+			args:   []string{"--something.tls.enabled=true", "--something.tls.else=abc"},
+			expect: nil,
+		},
+		{
+			name:   "is disabled",
+			args:   []string{"--tls.enabled=false", "--something.else", "--something.tls.else=abc"},
+			expect: nil,
+		},
+		{
+			name: "must be enabled",
+			args: []string{"--something.tls.else=abc"},
+			expect: map[string]interface{}{
+				"something.tls.enabled": "true",
+			},
+		},
+		{
+			// NOTE: we want to avoid something like:
+			// --kafka.consumer.authentication=tls.enabled=true
+			name: "enable consumer tls",
+			args: []string{
+				"--es.server-urls=http://elasticsearch:9200",
+				"--kafka.consumer.authentication=tls",
+				"--kafka.consumer.brokers=my-cluster-kafka-bootstrap:9093",
+				"--kafka.consumer.tls.ca=/var/run/secrets/cluster-ca/ca.crt",
+				"--kafka.consumer.tls.cert=/var/run/secrets/kafkauser/user.crt",
+				"--kafka.consumer.tls.key=/var/run/secrets/kafkauser/user.key",
+			},
+			expect: map[string]interface{}{
+				"kafka.consumer.tls.enabled": "true",
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			got := getAdditionalTLSFlags(tc.args)
+			if !cmp.Equal(tc.expect, got) {
+				t.Error("err:", cmp.Diff(tc.expect, got))
+			}
 		})
 	}
 }

--- a/apis/v1/options.go
+++ b/apis/v1/options.go
@@ -88,6 +88,7 @@ func (o Options) MarshalJSON() ([]byte, error) {
 }
 
 func (o *Options) parse(entries map[string]interface{}) error {
+	o.json = nil
 	o.opts = make(map[string]interface{})
 	var err error
 	for k, v := range entries {


### PR DESCRIPTION
Signed-off-by: Benedikt Bongartz <bongartz@klimlive.de>

## Which problem is this PR solving?
- From the upcoming version 1.34 the tls enabled flag is required when using tls options. https://github.com/jaegertracing/jaeger/pull/3030 

## Short description of the changes
- to avoid breaking existing setups, tls flags are extended by the missing enable flag if necessary.

---
cc @rubenvp8510 @pavolloffay 