### PR TITLE
fix: remove common name label

### DIFF
--- a/bundle/manifests/jaeger-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/jaeger-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -3,7 +3,6 @@ kind: ClusterRole
 metadata:
   creationTimestamp: null
   labels:
-    app.kubernetes.io/name: jaeger-operator
     name: jaeger-operator
   name: jaeger-operator-metrics-reader
 rules:

--- a/bundle/manifests/jaeger-operator-metrics_v1_service.yaml
+++ b/bundle/manifests/jaeger-operator-metrics_v1_service.yaml
@@ -4,7 +4,6 @@ metadata:
   creationTimestamp: null
   labels:
     app.kubernetes.io/component: metrics
-    app.kubernetes.io/name: jaeger-operator
     name: jaeger-operator
   name: jaeger-operator-metrics
 spec:
@@ -14,7 +13,6 @@ spec:
     protocol: TCP
     targetPort: https
   selector:
-    app.kubernetes.io/name: jaeger-operator
     name: jaeger-operator
 status:
   loadBalancer: {}

--- a/bundle/manifests/jaeger-operator-webhook-service_v1_service.yaml
+++ b/bundle/manifests/jaeger-operator-webhook-service_v1_service.yaml
@@ -3,7 +3,6 @@ kind: Service
 metadata:
   creationTimestamp: null
   labels:
-    app.kubernetes.io/name: jaeger-operator
     name: jaeger-operator
   name: jaeger-operator-webhook-service
 spec:
@@ -12,7 +11,6 @@ spec:
     protocol: TCP
     targetPort: 9443
   selector:
-    app.kubernetes.io/name: jaeger-operator
     name: jaeger-operator
 status:
   loadBalancer: {}

--- a/bundle/manifests/jaeger-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/jaeger-operator.clusterserviceversion.yaml
@@ -376,13 +376,11 @@ spec:
           replicas: 1
           selector:
             matchLabels:
-              app.kubernetes.io/name: jaeger-operator
               name: jaeger-operator
           strategy: {}
           template:
             metadata:
               labels:
-                app.kubernetes.io/name: jaeger-operator
                 name: jaeger-operator
             spec:
               containers:
@@ -532,7 +530,7 @@ spec:
     generateName: deployment.sidecar-injector.jaegertracing.io
     objectSelector:
       matchExpressions:
-      - key: app.kubernetes.io/name
+      - key: name
         operator: NotIn
         values:
         - jaeger-operator

--- a/bundle/manifests/jaegertracing.io_jaegers.yaml
+++ b/bundle/manifests/jaegertracing.io_jaegers.yaml
@@ -6,7 +6,6 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   labels:
-    app.kubernetes.io/name: jaeger-operator
     name: jaeger-operator
   name: jaegers.jaegertracing.io
 spec:

--- a/bundle/manifests/prometheus_rbac.authorization.k8s.io_v1_role.yaml
+++ b/bundle/manifests/prometheus_rbac.authorization.k8s.io_v1_role.yaml
@@ -6,7 +6,6 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
   creationTimestamp: null
   labels:
-    app.kubernetes.io/name: jaeger-operator
     name: jaeger-operator
   name: prometheus
 rules:

--- a/bundle/manifests/prometheus_rbac.authorization.k8s.io_v1_rolebinding.yaml
+++ b/bundle/manifests/prometheus_rbac.authorization.k8s.io_v1_rolebinding.yaml
@@ -6,7 +6,6 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
   creationTimestamp: null
   labels:
-    app.kubernetes.io/name: jaeger-operator
     name: jaeger-operator
   name: prometheus
 roleRef:

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -15,7 +15,6 @@ namespace: observability
 # https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/#labels
 commonLabels:
   name: jaeger-operator
-  app.kubernetes.io/name: jaeger-operator
 
 bases:
 - ../crd

--- a/config/webhook/deployment_inject_patch.yaml
+++ b/config/webhook/deployment_inject_patch.yaml
@@ -6,7 +6,7 @@ webhooks:
   - name: deployment.sidecar-injector.jaegertracing.io
     objectSelector: # Skip resources with the name jaeger-operator
       matchExpressions:
-        - key: app.kubernetes.io/name
+        - key: name
           operator: NotIn
           values:
             - "jaeger-operator"


### PR DESCRIPTION
Signed-off-by: Benedikt Bongartz <bongartz@klimlive.de>

## Which problem is this PR solving?
- closes https://github.com/jaegertracing/jaeger-operator/issues/1870

## Short description of the changes
- remove previously introduced common label
- use `name=jaeger-operator` to bypass the jaeger deployment webhook

---

cc @rubenvp8510 