### PR TITLE
fix: skip dependencies on openshift platform

### DIFF
--- a/pkg/cronjob/es_rollover.go
+++ b/pkg/cronjob/es_rollover.go
@@ -213,6 +213,13 @@ func EsScriptEnvVars(opts v1.Options) []corev1.EnvVar {
 			envs = append(envs, corev1.EnvVar{Name: x.envVar, Value: val})
 		}
 	}
+
+	if val, ok := options["skip-dependencies"]; ok {
+		envs = append(envs, corev1.EnvVar{Name: "SKIP_DEPENDENCIES", Value: val})
+	} else if !ok && viper.GetString("platform") == v1.FlagPlatformOpenShift {
+		envs = append(envs, corev1.EnvVar{Name: "SKIP_DEPENDENCIES", Value: "true"})
+	}
+
 	return envs
 }
 


### PR DESCRIPTION
Signed-off-by: Benedikt Bongartz <bongartz@klimlive.de>

<!--
Please delete this comment before posting.

We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Prevent write to dependency store on openshift platform. (currently this does not work because permissions are limited)

## Short description of the changes
- When using openshift, the dependency index rollover is disabled. 

---

cc @rubenvp8510 