### PR TITLE
fix: openshift es-rollover

### DIFF
--- a/pkg/storage/elasticsearch.go
+++ b/pkg/storage/elasticsearch.go
@@ -126,7 +126,7 @@ func (ed *ElasticsearchDeployment) InjectSecretsConfiguration(p *corev1.PodSpec)
 		Name: volumeName,
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
-				SecretName: jaegerESSecretName(*ed.Jaeger),
+				SecretName: curatorSecret.instanceName(ed.Jaeger),
 			},
 		},
 	})

--- a/pkg/storage/elasticsearch_test.go
+++ b/pkg/storage/elasticsearch_test.go
@@ -469,7 +469,7 @@ func TestInjectJobs(t *testing.T) {
 				}},
 				Volumes: []corev1.Volume{{Name: "certs", VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
-						SecretName: "jtest-jaeger-elasticsearch"}}},
+						SecretName: "jtest-curator"}}},
 				}},
 		},
 		{
@@ -521,7 +521,7 @@ func TestInjectJobs(t *testing.T) {
 				}},
 				Volumes: []corev1.Volume{{Name: "certs", VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
-						SecretName: "jaeger-elasticsearch"}}},
+						SecretName: "jtest-curator"}}},
 				}},
 		},
 	}


### PR DESCRIPTION
## Which problem is this PR solving?
- Closes https://github.com/jaegertracing/jaeger-operator/issues/1932

## Short description of the changes
- Use [sg_role_curator](https://github.com/openshift/origin-aggregated-logging/blob/11a17d44877e178ac8dc6aefd6dda6c8dba5888e/elasticsearch/sgconfig/roles.yml#L65) instead of [sg_role_jaeger](https://github.com/openshift/origin-aggregated-logging/blob/11a17d44877e178ac8dc6aefd6dda6c8dba5888e/elasticsearch/sgconfig/roles.yml#L86)

## Additional
I tried to use `sg_role_curator` only for `es-rollover`. ~Right now ive no clue why it didnt work. Do you have some concerns to keep it like this?~

![image](https://user-images.githubusercontent.com/10403402/171884409-a32438de-715e-4b50-9c1d-fa47e77b6b40.png)

To use the secret only for the es-rollover job, I used these snippets.
```golang
func isESRollover(container ...corev1.Container) bool {
	if len(container) == 0 {
		return false
	}
	for _, c := range container {
		if strings.HasSuffix(c.Name, "es-rollover") {
			return true
		}
	}
	return false
}

// InjectSecretsConfiguration changes the given spec to include the options for the index cleaner
func (ed *ElasticsearchDeployment) InjectSecretsConfiguration(p *corev1.PodSpec) {
	secretName := jaegerESSecretName(*ed.Jaeger)
	if isESRollover(p.Containers...) {
		secretName = curatorSecret.instanceName(ed.Jaeger)
	}
	p.Volumes = append(p.Volumes, corev1.Volume{
		Name: volumeName,
		VolumeSource: corev1.VolumeSource{
			Secret: &corev1.SecretVolumeSource{
				SecretName: secretName,
			},
		},
	})
...
}
```

---

### update
It keeps failing because `sg_role_jaeger` has no permission to write dependencies. With this change we rely on https://github.com/jaegertracing/jaeger/commit/3499c88f640e8d9c54cde37c7b0de32c98bc80e5.

---
cc @rubenvp8510 @pavolloffay 