### PR TITLE
Fix/ocp es rollover #1932

### DIFF
--- a/pkg/storage/elasticsearch.go
+++ b/pkg/storage/elasticsearch.go
@@ -126,7 +126,7 @@ func (ed *ElasticsearchDeployment) InjectSecretsConfiguration(p *corev1.PodSpec)
 		Name: volumeName,
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
-				SecretName: jaegerESSecretName(*ed.Jaeger),
+				SecretName: curatorSecret.instanceName(ed.Jaeger),
 			},
 		},
 	})

--- a/pkg/storage/elasticsearch.go
+++ b/pkg/storage/elasticsearch.go
@@ -122,18 +122,11 @@ func (ed *ElasticsearchDeployment) InjectStorageConfiguration(p *corev1.PodSpec)
 
 // InjectSecretsConfiguration changes the given spec to include the options for the index cleaner
 func (ed *ElasticsearchDeployment) InjectSecretsConfiguration(p *corev1.PodSpec) {
-
-	curatorSecretName := curatorSecret.instanceName(ed.Jaeger)
-	useCertManager := ed.Jaeger.Spec.Storage.Elasticsearch.UseCertManagement
-	if useCertManager != nil && *useCertManager == true {
-		curatorSecretName = fmt.Sprintf("curator-%s", ed.Jaeger.Spec.Storage.Elasticsearch.Name)
-	}
-
 	p.Volumes = append(p.Volumes, corev1.Volume{
 		Name: volumeName,
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
-				SecretName: curatorSecretName,
+				SecretName: curatorSecret.instanceName(ed.Jaeger),
 			},
 		},
 	})

--- a/pkg/storage/elasticsearch.go
+++ b/pkg/storage/elasticsearch.go
@@ -122,14 +122,22 @@ func (ed *ElasticsearchDeployment) InjectStorageConfiguration(p *corev1.PodSpec)
 
 // InjectSecretsConfiguration changes the given spec to include the options for the index cleaner
 func (ed *ElasticsearchDeployment) InjectSecretsConfiguration(p *corev1.PodSpec) {
+
+	curatorSecretName := curatorSecret.instanceName(ed.Jaeger)
+	useCertManager := ed.Jaeger.Spec.Storage.Elasticsearch.UseCertManagement
+	if useCertManager != nil && *useCertManager == true {
+		curatorSecretName = fmt.Sprintf("curator-%s", ed.Jaeger.Spec.Storage.Elasticsearch.Name)
+	}
+
 	p.Volumes = append(p.Volumes, corev1.Volume{
 		Name: volumeName,
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
-				SecretName: curatorSecret.instanceName(ed.Jaeger),
+				SecretName: curatorSecretName,
 			},
 		},
 	})
+
 	// we assume jaeger containers are first
 	if len(p.Containers) > 0 {
 		// the size of arguments array should be always 2

--- a/pkg/storage/elasticsearch.go
+++ b/pkg/storage/elasticsearch.go
@@ -174,6 +174,7 @@ func (ed *ElasticsearchDeployment) Elasticsearch() *esv1.Elasticsearch {
 		// The value has to match searchguard configuration
 		// https://github.com/openshift/origin-aggregated-logging/blob/50126fb8e0c602e9c623d6a8599857aaf98f80f8/elasticsearch/sgconfig/roles_mapping.yml#L34
 		annotations[fmt.Sprintf("logging.openshift.io/elasticsearch-cert.%s", jaegerESSecretName(*ed.Jaeger))] = "user.jaeger"
+		annotations[fmt.Sprintf("logging.openshift.io/elasticsearch-cert.curator-%s", ed.Jaeger.Spec.Storage.Elasticsearch.Name)] = "system.logging.curator"
 	}
 	return &esv1.Elasticsearch{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/storage/elasticsearch.go
+++ b/pkg/storage/elasticsearch.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 
@@ -122,11 +123,35 @@ func (ed *ElasticsearchDeployment) InjectStorageConfiguration(p *corev1.PodSpec)
 
 // InjectSecretsConfiguration changes the given spec to include the options for the index cleaner
 func (ed *ElasticsearchDeployment) InjectSecretsConfiguration(p *corev1.PodSpec) {
+	// TODO(frzifus): remove curator permissions as soon as writing dependencies
+	// can be disabled. Requieres a Jaeger release including jaegertracing/jaeger@3499c88
+	// probably v1.36.0.
+	secretName := curatorSecret.instanceName(ed.Jaeger)
+
+	// NOTE: If the permissions are more finely granulated, the writing of the
+	// dependency store must be skipped, since these are not currently granted
+	// to the sg_jaeger role.
+	// This implies a Jaeger version higher than 1.35.1.
+	// Since this will not be shipped with the next operator version, this
+	// feature is optional for now. In the future, this exception may be removed.
+	if v, ok := os.LookupEnv("JAEGER_OPERATOR_USE_CURATOR_ROLE"); ok && v == "true" {
+		secretName = jaegerESSecretName(*ed.Jaeger)
+		// TODO(frzifus): Remove the check once sg_jaeger permissions have been
+		// granted and rolled out. JaegerES secret will be the new default.
+		if isESRolloverJob(p.Containers...) {
+			// NOTE: we grant the default es-rollover job based on the pods
+			// name enhanced permissions to be able to delete entries.
+			// SEE: https://github.com/openshift/origin-aggregated-logging/
+			//      blob/b621a482eedea4bde0cdd6d646de2324e837e19f/elasticsearch/sgconfig/roles.yml#L65
+			secretName = curatorSecret.instanceName(ed.Jaeger)
+		}
+	}
+
 	p.Volumes = append(p.Volumes, corev1.Volume{
 		Name: volumeName,
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
-				SecretName: curatorSecret.instanceName(ed.Jaeger),
+				SecretName: secretName,
 			},
 		},
 	})
@@ -259,4 +284,16 @@ func jaegerESSecretName(jaeger v1.Jaeger) string {
 		prefix = jaeger.Name + "-"
 	}
 	return fmt.Sprintf("%sjaeger-%s", prefix, jaeger.Spec.Storage.Elasticsearch.Name)
+}
+
+func isESRolloverJob(container ...corev1.Container) bool {
+	if len(container) == 0 {
+		return false
+	}
+	for _, c := range container {
+		if strings.HasSuffix(c.Name, "es-rollover") {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/storage/elasticsearch_secrets.go
+++ b/pkg/storage/elasticsearch_secrets.go
@@ -31,6 +31,12 @@ func (s secret) instanceName(jaeger *v1.Jaeger) string {
 	if s.name == esSecret.name {
 		return esSecret.name
 	}
+
+	useCertManager := jaeger.Spec.Storage.Elasticsearch.UseCertManagement
+	if useCertManager != nil && *useCertManager == true {
+		return fmt.Sprintf("curator-%s", jaeger.Spec.Storage.Elasticsearch.Name)
+	}
+
 	return fmt.Sprintf("%s-%s", jaeger.Name, s.name)
 }
 

--- a/pkg/storage/elasticsearch_test.go
+++ b/pkg/storage/elasticsearch_test.go
@@ -81,8 +81,9 @@ func TestCreateElasticsearchCR(t *testing.T) {
 					Name:      "elasticsearch",
 					Namespace: "myproject",
 					Annotations: map[string]string{
-						"logging.openshift.io/elasticsearch-cert-management":           "true",
-						"logging.openshift.io/elasticsearch-cert.jaeger-elasticsearch": "user.jaeger",
+						"logging.openshift.io/elasticsearch-cert-management":            "true",
+						"logging.openshift.io/elasticsearch-cert.jaeger-elasticsearch":  "user.jaeger",
+						"logging.openshift.io/elasticsearch-cert.curator-elasticsearch": "system.logging.curator",
 					},
 				},
 				Spec: esv1.ElasticsearchSpec{

--- a/pkg/storage/elasticsearch_test.go
+++ b/pkg/storage/elasticsearch_test.go
@@ -469,7 +469,7 @@ func TestInjectJobs(t *testing.T) {
 				}},
 				Volumes: []corev1.Volume{{Name: "certs", VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
-						SecretName: "jtest-jaeger-elasticsearch"}}},
+						SecretName: "jtest-curator"}}},
 				}},
 		},
 		{
@@ -521,7 +521,7 @@ func TestInjectJobs(t *testing.T) {
 				}},
 				Volumes: []corev1.Volume{{Name: "certs", VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
-						SecretName: "jaeger-elasticsearch"}}},
+						SecretName: "jtest-curator"}}},
 				}},
 		},
 	}

--- a/pkg/storage/elasticsearch_test.go
+++ b/pkg/storage/elasticsearch_test.go
@@ -521,7 +521,7 @@ func TestInjectJobs(t *testing.T) {
 				}},
 				Volumes: []corev1.Volume{{Name: "certs", VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
-						SecretName: "jtest-curator"}}},
+						SecretName: "curator-elasticsearch"}}},
 				}},
 		},
 	}

--- a/pkg/storage/elasticsearch_test.go
+++ b/pkg/storage/elasticsearch_test.go
@@ -2,8 +2,6 @@ package storage
 
 import (
 	"fmt"
-	"os"
-	"strconv"
 	"testing"
 
 	esv1 "github.com/openshift/elasticsearch-operator/apis/logging/v1"
@@ -418,11 +416,10 @@ func TestInject(t *testing.T) {
 func TestInjectJobs(t *testing.T) {
 	trueVar := true
 	tests := []struct {
-		name            string
-		granulatedSGEnv string
-		pod             *corev1.PodSpec
-		expected        *corev1.PodSpec
-		es              v1.ElasticsearchSpec
+		name     string
+		pod      *corev1.PodSpec
+		expected *corev1.PodSpec
+		es       v1.ElasticsearchSpec
 	}{
 		{
 			name: "jaeger-provisions-certs",
@@ -527,121 +524,10 @@ func TestInjectJobs(t *testing.T) {
 						SecretName: "jtest-curator"}}},
 				}},
 		},
-		{
-			name:            "granulatedSGEnv es-rollover",
-			granulatedSGEnv: "true",
-			es: v1.ElasticsearchSpec{
-				Name:      "elasticsearch",
-				NodeCount: 3,
-			},
-			pod: &corev1.PodSpec{
-				Containers: []corev1.Container{{
-					Name:         "some-build-es-rollover",
-					Args:         []string{"init", "url"},
-					VolumeMounts: []corev1.VolumeMount{{Name: "lol"}},
-				}},
-			},
-			expected: &corev1.PodSpec{
-				Containers: []corev1.Container{{
-					Name: "some-build-es-rollover",
-					Args: []string{"init", "https://elasticsearch:9200"},
-					Env: []corev1.EnvVar{
-						{
-							Name:  "ES_TLS_ENABLED",
-							Value: "true",
-						},
-						{
-							Name:  "ES_TLS_CA",
-							Value: caPath,
-						},
-						{
-							Name:  "ES_TLS_KEY",
-							Value: keyPath,
-						},
-						{
-							Name:  "ES_TLS_CERT",
-							Value: certPath,
-						},
-						{
-							Name:  "SHARDS",
-							Value: "3",
-						},
-						{
-							Name:  "REPLICAS",
-							Value: "1",
-						},
-					},
-					VolumeMounts: []corev1.VolumeMount{
-						{Name: "lol"},
-						{Name: volumeName, ReadOnly: true, MountPath: volumeMountPath},
-					},
-				}},
-				Volumes: []corev1.Volume{{Name: "certs", VolumeSource: corev1.VolumeSource{
-					Secret: &corev1.SecretVolumeSource{
-						SecretName: "jtest-curator"}}},
-				}},
-		},
-		{
-			name:            "granulatedSGEnv other",
-			granulatedSGEnv: "true",
-			es: v1.ElasticsearchSpec{
-				Name:      "elasticsearch",
-				NodeCount: 3,
-			},
-			pod: &corev1.PodSpec{
-				Containers: []corev1.Container{{
-					Name:         "something-else",
-					Args:         []string{"init", "url"},
-					VolumeMounts: []corev1.VolumeMount{{Name: "lol"}},
-				}},
-			},
-			expected: &corev1.PodSpec{
-				Containers: []corev1.Container{{
-					Name: "something-else",
-					Args: []string{"init", "https://elasticsearch:9200"},
-					Env: []corev1.EnvVar{
-						{
-							Name:  "ES_TLS_ENABLED",
-							Value: "true",
-						},
-						{
-							Name:  "ES_TLS_CA",
-							Value: caPath,
-						},
-						{
-							Name:  "ES_TLS_KEY",
-							Value: keyPath,
-						},
-						{
-							Name:  "ES_TLS_CERT",
-							Value: certPath,
-						},
-						{
-							Name:  "SHARDS",
-							Value: "3",
-						},
-						{
-							Name:  "REPLICAS",
-							Value: "1",
-						},
-					},
-					VolumeMounts: []corev1.VolumeMount{
-						{Name: "lol"},
-						{Name: volumeName, ReadOnly: true, MountPath: volumeMountPath},
-					},
-				}},
-				Volumes: []corev1.Volume{{Name: "certs", VolumeSource: corev1.VolumeSource{
-					Secret: &corev1.SecretVolumeSource{
-						SecretName: "jtest-jaeger-elasticsearch"}}},
-				}},
-		},
 	}
 
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			if err := os.Setenv("JAEGER_OPERATOR_USE_CURATOR_ROLE", test.granulatedSGEnv); err != nil {
-				t.Fatal(err)
-			}
 			es := &ElasticsearchDeployment{Jaeger: v1.NewJaeger(types.NamespacedName{Name: "jtest"})}
 			es.Jaeger.Spec.Storage.Elasticsearch = test.es
 			es.InjectSecretsConfiguration(test.pod)
@@ -667,34 +553,5 @@ func TestCalculateReplicaShards(t *testing.T) {
 	}
 	for _, test := range tests {
 		assert.Equal(t, test.shards, calculateReplicaShards(test.redType, test.dataNodes))
-	}
-}
-
-func TestIsEsRolloverJob(t *testing.T) {
-	tt := []struct {
-		containers []corev1.Container
-		expect     bool
-	}{
-		{
-			// No container == false
-		},
-		{
-			containers: []corev1.Container{
-				{Name: "nope"},
-			},
-		},
-		{
-			containers: []corev1.Container{
-				{Name: "nope"},
-				{Name: "yes-es-rollover"},
-			},
-			expect: true,
-		},
-	}
-
-	for i, tc := range tt {
-		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			assert.Equal(t, tc.expect, isESRolloverJob(tc.containers...))
-		})
 	}
 }


### PR DESCRIPTION
## Which problem is this PR solving?
- Closes https://github.com/jaegertracing/jaeger-operator/issues/1932

## Short description of the changes
- Introduce temporary environment variable `JAEGER_OPERATOR_GRANULATED_SG` that is used to grant `sg_role_curator` permission only to `es-rollover` jobs. Requieres https://github.com/jaegertracing/jaeger/commit/3499c88f640e8d9c54cde37c7b0de32c98bc80e5 since writing to the dependency store needs to be disabled.
- By default use [sg_role_curator](https://github.com/openshift/origin-aggregated-logging/blob/11a17d44877e178ac8dc6aefd6dda6c8dba5888e/elasticsearch/sgconfig/roles.yml#L65) instead of [sg_role_jaeger](https://github.com/openshift/origin-aggregated-logging/blob/11a17d44877e178ac8dc6aefd6dda6c8dba5888e/elasticsearch/sgconfig/roles.yml#L86)


## Note
alternative to https://github.com/jaegertracing/jaeger-operator/pull/1933