### PR TITLE
Add more variables to configure if install or not some operators

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,6 +158,24 @@ Other targets include `run-e2e-tests-cassandra` and `run-e2e-tests-elasticsearch
 $ make e2e-test-suites
 ```
 
+**Note**: there are some variables you need to take into account in order to
+improve your experience running the E2E tests.
+
+| Variable name     | Description                                         | Example usage                      |
+|-------------------|-----------------------------------------------------|------------------------------------|
+| KUTTL_OPTIONS     | Options to pass directly to the KUTTL call          | KUTTL_OPTIONS="--test es-rollover" |
+| E2E_TESTS_TIMEOUT | Timeout for each step in the E2E tests. In seconds  | E2E_TESTS_TIMEOUT=500              |
+| USE_KIND_CLUSTER  | Start a KIND cluster to run the E2E tests           | USE_KIND_CLUSTER=true              |
+| KIND_KEEP_CLUSTER | Not remove the KIND cluster after running the tests | KIND_KEEP_CLUSTER=true             |
+
+Also, you can enable/disable the installation of the different operators needed
+to run the tests:
+| Variable name  | Description                                 | Example usage       |
+|----------------|---------------------------------------------|---------------------|
+| JAEGER_OLM     | Jaeger Operator was installed using OLM     | JAEGER_OLM=true     |
+| KAFKA_OLM      | Kafka Operator was installed using OLM      | KAFKA_OLM=true      |
+| PROMETHEUS_OLM | Prometheus Operator was installed using OLM | PROMETHEUS_OLM=true |
+
 #### An external cluster (like OpenShift)
 The commands from the previous section are valid when running the E2E tests in an
 external cluster like OpenShift, minikube or other Kubernetes environment. The only

--- a/hack/run-e2e-test-suite.sh
+++ b/hack/run-e2e-test-suite.sh
@@ -9,13 +9,13 @@ if [ "$VERBOSE" = true ]; then
 fi
 
 if [ "$#" -ne 3 ]; then
-    echo "$0 <test_suite_name> <use_kind_cluster> <olm>"
+    echo "$0 <test_suite_name> <use_kind_cluster> <Jaeger Operator installed using OLM>"
     exit 1
 fi
 
 test_suite_name=$1
 use_kind_cluster=$2
-olm=$3
+jaeger_olm=$3
 
 root_dir=$current_dir/../
 reports_dir=$root_dir/reports
@@ -36,8 +36,8 @@ if [ "$use_kind_cluster" == true ]; then
 	kubectl wait --namespace ingress-nginx --for=condition=ready pod --selector=app.kubernetes.io/component=controller --timeout=5m
 fi
 
-if [ "$olm" = true ]; then
-    echo "Skipping Jaeger Operator installation because OLM=true"
+if [ "$jaeger_olm" = true ]; then
+    echo "Skipping Jaeger Operator installation because JAEGER_OLM=true"
 else
 	echo Installing Jaeger Operator...
 	make cert-manager deploy

--- a/tests/e2e/Makefile
+++ b/tests/e2e/Makefile
@@ -4,9 +4,13 @@ export VERTX_IMG ?= jaegertracing/vertx-create-span:operator-e2e-tests
 export ELASTIC_IMG ?= docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.6
 export OPERATOR_IMAGE_NEXT ?= ${IMG_PREFIX}/jaeger-operator:next
 export ASSERT_IMG ?= ${IMG_PREFIX}/asserts-e2e:$(shell date +%s)
-USE_KIND_CLUSTER ?= true
 
+# Use a KIND cluster for the E2E tests
+USE_KIND_CLUSTER ?= true
+# Skip E2E tests where ES external instance is used
+SKIP_ES_EXTERNAL ?= false
 export E2E_TESTS_TIMEOUT ?= 330
+
 
 .PHONY: prepare-e2e-tests
 prepare-e2e-tests: kuttl build generate-e2e-files
@@ -94,7 +98,7 @@ e2e-test-suites: list-test-suites
 		echo -e "\t $$test_suite" ; \
 	done
 
-	@echo "You can run a test suite with make run-e2e-tests-<suite name>. E.g: make run-e2e-tests-smoke"
+	@echo "You can run a test suite with make run-e2e-tests-<suite name>. E.g: make run-e2e-tests-elasticsearch"
 
 run-suite-tests: start-kind prepare-e2e-tests load-operator-image
-	./hack/run-e2e-test-suite.sh $(TEST_SUITE_NAME) $(USE_KIND_CLUSTER) $(OLM)
+	KAFKA_OLM=$(KAFKA_OLM) ./hack/run-e2e-test-suite.sh $(TEST_SUITE_NAME) $(USE_KIND_CLUSTER) $(JAEGER_OLM)

--- a/tests/templates/kafka-install.yaml.template
+++ b/tests/templates/kafka-install.yaml.template
@@ -2,5 +2,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - script: "cd {{ .Env.ROOT_DIR }} && make undeploy-kafka KAFKA_NAMESPACE=$NAMESPACE OLM={{ .Env.OLM }}"
-  - script: "cd {{ .Env.ROOT_DIR }} && make kafka KAFKA_NAMESPACE=$NAMESPACE OLM={{ .Env.OLM }}"
+  - script: "cd {{ .Env.ROOT_DIR }} && make undeploy-kafka KAFKA_NAMESPACE=$NAMESPACE KAFKA_OLM={{ .Env.KAFKA_OLM }}"
+  - script: "cd {{ .Env.ROOT_DIR }} && make kafka KAFKA_NAMESPACE=$NAMESPACE KAFKA_OLM={{ .Env.KAFKA_OLM }}"


### PR DESCRIPTION
Signed-off-by: Israel Blancas <iblancas@redhat.com>

## Which problem is this PR solving?
- For some operations, it is interesting to just install some operators or reuse the ones installed in the cluster. Currently, we only have the {{OLM}} variable to decide to install or not all the operators (included the Jaeger Operator).

## Short description of the changes
- Add `JAEGER_OLM`, `KAFKA_OLM` and `PROMETHEUS_OLM` variables
