### PR TITLE
Preparing release v1.35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 Changes by Version
 ==================
 
+1.35.0 (2022-06-16)
+-------------------
+
+* fix: point to a newer openshift oauth image 4.12 ([#1955](https://github.com/jaegertracing/jaeger-operator/pull/1955), [@frzifus](https://github.com/frzifus))
+* Expose OTLP collector and allInOne ports ([#1948](https://github.com/jaegertracing/jaeger-operator/pull/1948), [@rubenvp8510](https://github.com/rubenvp8510))
+* Add support for ImagePullSecrets in cronjobs ([#1935](https://github.com/jaegertracing/jaeger-operator/pull/1935), [@alexandrevilain](https://github.com/alexandrevilain))
+* fix: ocp es rollover #1932 ([#1937](https://github.com/jaegertracing/jaeger-operator/pull/1937), [@frzifus](https://github.com/frzifus))
+* add kafkaSecretName for collector and ingester ([#1910](https://github.com/jaegertracing/jaeger-operator/pull/1910), [@luohua13](https://github.com/luohua13))
+* Add autoscalability E2E test for OpenShift ([#1936](https://github.com/jaegertracing/jaeger-operator/pull/1936), [@iblancasa](https://github.com/iblancasa))
+* Fix version in Docker container. ([#1924](https://github.com/jaegertracing/jaeger-operator/pull/1924), [@iblancasa](https://github.com/iblancasa))
+* Verify namespace permissions before adding ns controller ([#1914](https://github.com/jaegertracing/jaeger-operator/pull/1914), [@rubenvp8510](https://github.com/rubenvp8510))
+* fix: skip dependencies on openshift platform ([#1921](https://github.com/jaegertracing/jaeger-operator/pull/1921), [@frzifus](https://github.com/frzifus))
+* fix: remove common name label ([#1920](https://github.com/jaegertracing/jaeger-operator/pull/1920), [@frzifus](https://github.com/frzifus))
+* Ignore not found error on 1.31.0 upgrade routine ([#1913](https://github.com/jaegertracing/jaeger-operator/pull/1913), [@rubenvp8510](https://github.com/rubenvp8510))
+
 1.34.1 (2022-05-24)
 -------------------
 Fix: storage.es.tls.enabled flag not passed to es-index-cleaner ([#1896](https://github.com/jaegertracing/jaeger-operator/pull/1896), [@indigostar-kr](https://github.com/indigostar-kr))

--- a/bundle/manifests/jaeger-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/jaeger-operator.clusterserviceversion.yaml
@@ -27,7 +27,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/jaegertracing/jaeger-operator
     support: Jaeger Community
-  name: jaeger-operator.v1.34.1
+  name: jaeger-operator.v1.35.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -401,7 +401,7 @@ spec:
                       fieldPath: metadata.namespace
                 - name: OPERATOR_NAME
                   value: jaeger-operator
-                image: quay.io/jaegertracing/jaeger-operator:1.34.1
+                image: quay.io/jaegertracing/jaeger-operator:1.35.0
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -516,11 +516,11 @@ spec:
   maturity: alpha
   provider:
     name: CNCF
-  replaces: jaeger-operator.v1.34.0
+  replaces: jaeger-operator.v1.34.1
   selector:
     matchLabels:
       name: jaeger-operator
-  version: 1.34.1
+  version: 1.35.0
   webhookdefinitions:
   - admissionReviewVersions:
     - v1

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/jaegertracing/jaeger-operator
-  newTag: 1.34.1
+  newTag: 1.35.0

--- a/config/manifests/bases/jaeger-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/jaeger-operator.clusterserviceversion.yaml
@@ -124,7 +124,7 @@ spec:
   maturity: alpha
   provider:
     name: CNCF
-  replaces: jaeger-operator.v1.34.0
+  replaces: jaeger-operator.v1.34.1
   selector:
     matchLabels:
       name: jaeger-operator

--- a/examples/operator-with-tracing.yaml
+++ b/examples/operator-with-tracing.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: jaeger-operator
       containers:
       - name: jaeger-operator
-        image: jaegertracing/jaeger-operator:1.34.0
+        image: jaegertracing/jaeger-operator:1.35.0
         ports:
         - containerPort: 8383
           name: http-metrics
@@ -41,7 +41,7 @@ spec:
         - name: OPERATOR_NAME
           value: "jaeger-operator"
       - name: jaeger-agent
-        image: jaegertracing/jaeger-agent:1.34.1
+        image: jaegertracing/jaeger-agent:1.35.2
         env:
         - name: POD_NAMESPACE
           valueFrom:

--- a/examples/statefulset-manual-sidecar.yaml
+++ b/examples/statefulset-manual-sidecar.yaml
@@ -23,7 +23,7 @@ spec:
             - containerPort: 8080
               protocol: TCP
         - name: jaeger-agent
-          image: jaegertracing/jaeger-agent:1.34.1
+          image: jaegertracing/jaeger-agent:1.35.2
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 5775

--- a/examples/tracegen.yaml
+++ b/examples/tracegen.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: tracegen
-        image: jaegertracing/jaeger-tracegen:1.34.1
+        image: jaegertracing/jaeger-tracegen:1.35.2
         args:
         - -duration=30m
         - -workers=10

--- a/versions.txt
+++ b/versions.txt
@@ -1,7 +1,7 @@
 # The Jaeger version to use by default. This is updated manually. Make sure to update the changelog
 # and add an upgrade procedure (pkg/upgrade) for the new version.
-jaeger=1.34.1
+jaeger=1.35.2
 
 # DO NOT EDIT the next value, it is updated automatically during the release.
 # Represents the current (latest) release of the Jaeger Operator.
-operator=1.34.1
+operator=1.35.0


### PR DESCRIPTION
Signed-off-by: Benedikt Bongartz <bongartz@klimlive.de>

Closes https://github.com/jaegertracing/jaeger-operator/issues/1927

blocked by: https://github.com/jaegertracing/jaeger-operator/pull/1948

...and the release of https://github.com/jaegertracing/jaeger/commit/dfcded2f962f8895e437b7eb6391955b942590a3  in v1.35.2

#### TODO
- [x] Successful run e2e test on OpenShift 4.10 `IMG_PREFIX="ghcr.io/frzifus" USE_KIND_CLUSTER=false E2E_TESTS_TIMEOUT=600 make run-e2e-tests` (Except tests which still need fixes to run on OpenShift)