### PR TITLE
Add E2E test to test upgrading from an allinone Jaeger Instance to production

### DIFF
--- a/tests/e2e/elasticsearch/es-from-aio-to-production/README.md
+++ b/tests/e2e/elasticsearch/es-from-aio-to-production/README.md
@@ -2,4 +2,4 @@
 ## What is this test case testing?
 
 This test checks there are not issues when a Jaeger instance deployed using
-`allInOne` strategy is upgrade to use `production` deployment strategy.
+`allInOne` strategy is upgraded to use `production` deployment strategy.

--- a/tests/e2e/elasticsearch/es-from-aio-to-production/README.md
+++ b/tests/e2e/elasticsearch/es-from-aio-to-production/README.md
@@ -1,0 +1,5 @@
+# Elasticsearch - From "All In One" to "Production"
+## What is this test case testing?
+
+This test checks there are not issues when a Jaeger instance deployed using
+`allInOne` strategy is upgrade to use `production` deployment strategy.

--- a/tests/e2e/elasticsearch/render.sh
+++ b/tests/e2e/elasticsearch/render.sh
@@ -2,6 +2,16 @@
 
 source $(dirname "$0")/../render-utils.sh
 
+start_test "es-from-aio-to-production"
+jaeger_name="my-jaeger"
+render_install_jaeger "$jaeger_name" "allInOne" "00"
+render_smoke_test "$jaeger_name" "allInOne" "01"
+render_install_elasticsearch "02"
+render_install_jaeger "$jaeger_name" "production" "03"
+render_smoke_test "$jaeger_name" "production" "04"
+
+
+
 if [ "$IS_OPENSHIFT" != true ]; then
     skip_test "es-increasing-replicas" "Test supported only in OpenShift"
 else


### PR DESCRIPTION
Signed-off-by: Israel Blancas <iblancas@redhat.com>
## Which problem is this PR solving?
- Part of solving #276

## Short description of the changes
- Add an E2E test to check there are not issues when a Jaeger instance deployed using `allInOne` strategy is upgraded to use `production` deployment strategy.
