### PR TITLE
Change the parameters for the auto-scale E2E test to help it to be more robust

### DIFF
--- a/tests/e2e/miscellaneous/collector-autoscale/03-assert.yaml
+++ b/tests/e2e/miscellaneous/collector-autoscale/03-assert.yaml
@@ -4,4 +4,4 @@ kind: Deployment
 metadata:
   name: simple-prod-collector
 status:
-  readyReplicas: 5
+  readyReplicas: 3

--- a/tests/e2e/miscellaneous/render.sh
+++ b/tests/e2e/miscellaneous/render.sh
@@ -41,37 +41,12 @@ $YQ e -i '.spec.collector.resources.requests.memory="300m"' 01-install.yaml
 # Enable autoscale
 $YQ e -i '.spec.collector.autoscale=true' 01-install.yaml
 $YQ e -i '.spec.collector.minReplicas=1' 01-install.yaml
-$YQ e -i '.spec.collector.maxReplicas=5' 01-install.yaml
+$YQ e -i '.spec.collector.maxReplicas=3' 01-install.yaml
 
 # Deploy Tracegen instance to generate load in the Jaeger collector
-render_install_tracegen "$jaeger_name" "3" "02"
+render_install_tracegen "$jaeger_name" "02"
 
 
-if [ $IS_OPENSHIFT = true ]; then
-    start_test "collector-autoscale"
-
-    jaeger_name="simple-prod"
-    ELASTICSEARCH_NODECOUNT="1"
-    render_install_jaeger "$jaeger_name" "production" "00"
-
-    $GOMPLATE -f $TEMPLATES_DIR/assert-tracegen.yaml.template -o ./01-assert.yaml
-
-    # Change the resource limits for the autoprovisioned deployment
-    $YQ e -i '.spec.collector.resources.requests.memory="20Mi"' 00-install.yaml
-    $YQ e -i '.spec.collector.resources.requests.memory="100m"' 00-install.yaml
-
-    # Enable autoscale
-    $YQ e -i '.spec.collector.autoscale=true' 00-install.yaml
-    $YQ e -i '.spec.collector.minReplicas=1' 00-install.yaml
-    $YQ e -i '.spec.collector.maxReplicas=5' 00-install.yaml
-
-    # Deploy a Tracegen instance to generate load in the Jaeger collector
-    cp $EXAMPLES_DIR/tracegen.yaml ./01-install.yaml
-
-
-else
-    skip_test "collector-autoscale" "Test only supported in OpenShift"
-fi
 
 # Helper function to generate the same tests multiple times but with different
 # reporting protocols

--- a/tests/e2e/render-utils.sh
+++ b/tests/e2e/render-utils.sh
@@ -523,21 +523,23 @@ function render_find_service() {
 
 
 # Render a tracegen deployment.
-#   render_install_tracegen <jaeger_name> <replicas> <test_step>
+#   render_install_tracegen <jaeger_name> <test_step>
 #
 # Example:
-#   render_install_tracegen "prod" "1" "00"
+#   render_install_tracegen "prod" "00"
 # Generates the `00-install.yaml` and `00-assert.yaml` files. It will deploy
-# 1 replica of the tracegen deployment
+# 1 replica of the tracegen deployment.
 function render_install_tracegen() {
-    if [ "$#" -ne 3 ]; then
-        error "Wrong number of parameters used for render_install_tracegen. Usage: render_install_tracegen <jaeger_name> <replicas> <test_step>"
+    if [ "$#" -ne 2 ]; then
+        error "Wrong number of parameters used for render_install_tracegen. Usage: render_install_tracegen <jaeger_name> <test_step>"
         exit 1
     fi
 
     jaeger=$1
-    replicas=$2
-    step=$3
+    step=$2
+
+    # We detected this value is good enough to make the operator scale
+    replicas=3
 
     $GOMPLATE -f $EXAMPLES_DIR/tracegen.yaml -o ./$step-install.yaml
     $YQ e -i ".spec.replicas=$replicas" ./$step-install.yaml

--- a/tests/e2e/streaming/render.sh
+++ b/tests/e2e/streaming/render.sh
@@ -60,4 +60,4 @@ render_assert_kafka "true" "$jaeger_name" "03"
 
 # Create the tracegen deployment
 # Deploy Tracegen instance to generate load in the Jaeger collector
-render_install_tracegen "$jaeger_name" "4" "06"
+render_install_tracegen "$jaeger_name" "06"

--- a/tests/e2e/streaming/render.sh
+++ b/tests/e2e/streaming/render.sh
@@ -46,11 +46,11 @@ $YQ e -i '.spec.ingester.resources.requests.memory="500m"' ./02-install.yaml
 # Enable autoscale
 $YQ e -i '.spec.ingester.autoscale=true' ./02-install.yaml
 $YQ e -i '.spec.ingester.minReplicas=1' ./02-install.yaml
-$YQ e -i '.spec.ingester.maxReplicas=5' ./02-install.yaml
+$YQ e -i '.spec.ingester.maxReplicas=3' ./02-install.yaml
 
 # Assert the autoprovisioned Kafka deployment
 render_assert_kafka "true" "$jaeger_name" "03"
 
 # Create the tracegen deployment
 # Deploy Tracegen instance to generate load in the Jaeger collector
-render_install_tracegen "$jaeger_name" "3" "06"
+render_install_tracegen "$jaeger_name" "06"

--- a/tests/e2e/streaming/streaming-with-autoprovisioning-autoscale/07-assert.yaml
+++ b/tests/e2e/streaming/streaming-with-autoprovisioning-autoscale/07-assert.yaml
@@ -4,4 +4,4 @@ kind: Deployment
 metadata:
   name: auto-provisioned-ingester
 status:
-  readyReplicas: 1
+  readyReplicas: 3


### PR DESCRIPTION
## Which problem is this PR solving?
- Make the auto-scale E2E tests more robust

## Short description of the changes
- Decrease the number of max replicas. Usually, the replicas are 5 (the maximum) but others, the collector doesn't scale enough because the load is not enough. But increasing the load can be a problem because the resource limits in the CI environment. Decreasing the number of max replicas to 3 ensures the scale is tested properly while the load for the cluster is not too high
- Fix the assert for the auto-scale in the `streaming/streaming-with-autoprovisioning-autoscale` E2E test
- Remove the `replicas` parameter from the `render_install_tracegen` macro because it was not really used