### PR TITLE
Use the auto provisioning Kafka example to run the E2E test

### DIFF
--- a/tests/e2e/examples/render.sh
+++ b/tests/e2e/examples/render.sh
@@ -10,6 +10,18 @@ render_install_example "$example_name" "01"
 render_smoke_test_example "$example_name" "02"
 
 
+start_test "examples-auto-provision-kafka"
+example_name="auto-provision-kafka"
+render_install_elasticsearch "00"
+render_install_kafka_operator "01"
+render_install_example "$example_name" "02"
+# The Kafka cluster will be started before the Jaeger components. So, we do the
+# Jaeger assertion later and the Kafka cluster assertion now
+mv ./02-assert.yaml ./05-assert.yaml
+render_assert_kafka "true" "$example_name" "02"
+render_smoke_test_example "$example_name" "06"
+
+
 start_test "examples-business-application-injected-sidecar"
 example_name="simplest"
 cp $EXAMPLES_DIR/business-application-injected-sidecar.yaml ./00-install.yaml

--- a/tests/e2e/render-utils.sh
+++ b/tests/e2e/render-utils.sh
@@ -361,6 +361,8 @@ function render_install_example() {
         $GOMPLATE -f $TEMPLATES_DIR/allinone-jaeger-assert.yaml.template -o ./$test_step-assert.yaml
     elif [ $jaeger_strategy = "production" ]; then
         $GOMPLATE -f $TEMPLATES_DIR/production-jaeger-assert.yaml.template -o ./$test_step-assert.yaml
+    elif [ $jaeger_strategy = "streaming" ]; then
+        $GOMPLATE -f $TEMPLATES_DIR/streaming-jaeger-assert.yaml.template -o ./$test_step-assert.yaml
     else
         error "render_install_example: No strategy declared in the example $example_name. Impossible to determine the assert file to use"
         return 1
@@ -395,6 +397,30 @@ function render_smoke_test_example() {
     fi
 
     render_smoke_test "$jaeger_name" "$is_secured" "$test_step"
+}
+
+
+
+# Render a the Kafka Operator installation
+#   render_install_kafka_operator <test_step>
+#
+# Example:
+#   render_install_kafka_opreator "01"
+# Generates the `01-install.yaml` and `01-assert.yaml` files to install the Kafka
+# operator and ensure it is deployed properly.
+# Note: the Kafka Operator will not be installed if KAFKA_OLM is `true`.
+function render_install_kafka_operator(){
+    if [ "$#" -ne 1 ]; then
+        error "Wrong number of parameters used for render_install_kafka_operator. Usage: render_install_kafka_operator <test_step>"
+        exit 1
+    fi
+
+    test_step=$1
+
+    if [ $KAFKA_OLM != true ]; then
+        $GOMPLATE -f $TEMPLATES_DIR/kafka-operator-install.yaml.template -o ./$test_step-install.yaml
+        $GOMPLATE -f $TEMPLATES_DIR/kafka-operator-assert.yaml.template -o ./$test_step-assert.yaml
+    fi
 }
 
 
@@ -562,7 +588,7 @@ function get_jaeger_name() {
 
     deployment_file=$1
 
-    jaeger_name=$($YQ e '.metadata.name' $deployment_file)
+    jaeger_name=$($YQ e '. | select(.kind == "Jaeger").metadata.name' $deployment_file)
 
     if [ -z "$jaeger_name" ]; then
         error "No name for Jaeger deployment in file $deployment_file"
@@ -589,14 +615,14 @@ function get_jaeger_strategy() {
 
     deployment_file=$1
 
-    strategy=$($YQ e '.spec.strategy' $deployment_file)
+    strategy=$($YQ e '. | select(.kind == "Jaeger").spec.strategy' $deployment_file)
 
-    if [ "$strategy" != "null" ]; then
+    if [ "$strategy" = "production" ] || [ "$strategy" = "streaming" ]; then
         echo $strategy
         return 0
     fi
 
-    strategy=$($YQ e '.spec.agent.strategy' $deployment_file)
+    strategy=$($YQ e '. | select(.kind == "Jaeger").spec.agent.strategy' $deployment_file)
     if [ "$strategy" = "null" ]; then
         echo "allInOne"
         return 0

--- a/tests/e2e/streaming/render.sh
+++ b/tests/e2e/streaming/render.sh
@@ -22,21 +22,6 @@ render_install_elasticsearch "03"
 render_smoke_test "tls-streaming" "$is_secured" "05"
 
 
-
-start_test "streaming-with-autoprovisioning"
-jaeger_name="auto-provisioned"
-
-if [ $IS_OPENSHIFT = true ]; then
-    # Remove the installation of the operator
-    rm ./00-install.yaml ./00-assert.yaml
-fi
-
-render_install_elasticsearch "01"
-render_assert_kafka "true" "$jaeger_name" "03"
-render_smoke_test "$jaeger_name" "$is_secured" "07"
-
-
-
 start_test "streaming-with-autoprovisioning-autoscale"
 if [ $IS_OPENSHIFT = true ]; then
     # Remove the installation of the operator

--- a/tests/templates/kafka-operator-assert.yaml.template
+++ b/tests/templates/kafka-operator-assert.yaml.template
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: strimzi-cluster-operator
+status:
+  readyReplicas: 1

--- a/tests/templates/kafka-operator-install.yaml.template
+++ b/tests/templates/kafka-operator-install.yaml.template
@@ -1,0 +1,6 @@
+# Start Kafka
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: "cd {{ .Env.ROOT_DIR }} && KAFKA_NAMESPACE=$NAMESPACE make undeploy-kafka-operator KAFKA_OLM={{ .Env.KAFKA_OLM }}"
+  - script: "cd {{ .Env.ROOT_DIR }} && KAFKA_NAMESPACE=$NAMESPACE make deploy-kafka-operator KAFKA_OLM={{ .Env.KAFKA_OLM }}"


### PR DESCRIPTION
Signed-off-by: Israel Blancas <iblancas@redhat.com>

## Which problem is this PR solving?
- Use the `auto-provision-kafka` example to test the autoprovisioned Kafka feature instead of creating the CRD in our side

## Short description of the changes
- Create macros to generate the files to assert the cluster and operator
