### PR TITLE
Allow setting the log level and minimal Kafka deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -317,6 +317,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	kubectl create namespace observability 2>&1 | grep -v "already exists" || true
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	./hack/enable-operator-features.sh
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
 
 .PHONY: undeploy

--- a/hack/enable-operator-features.sh
+++ b/hack/enable-operator-features.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+export ROOT_DIR=$(realpath $(dirname ${BASH_SOURCE[0]})/../)
+$ROOT_DIR/hack/install/install-yq.sh > /dev/null
+source $ROOT_DIR/hack/common.sh
+
+set -e
+
+if [ ! -z "$JAEGER_OPERATOR_VERBOSITY"  ]; then
+    $YQ -i e \
+    '.spec.template.spec.containers[0].env += {"name": "LOG-LEVEL", "value": "DEBUG"}' \
+    $ROOT_DIR/config/manager/manager.yaml
+fi
+
+if [ "$JAEGER_OPERATOR_KAFKA_MINIMAL" = true  ]; then
+    $YQ -i e \
+        '.spec.template.spec.containers[0].env += {"name": "KAFKA-PROVISIONING-MINIMAL", "value": "true"} ' \
+        $ROOT_DIR/config/manager/manager.yaml
+fi


### PR DESCRIPTION
Signed-off-by: Israel Blancas <iblancas@redhat.com>

## Which problem is this PR solving?
- Add a way to set the `LOG-LEVEL` and `KAFKA-PROVISIONING-MINIMAL` when doing `make deploy`

This will help the autoprovisioned Kafka E2E tests in environments with low resources like CI or a local machine.

This will probably fix #1990