### PR TITLE
Skip E2E tests when the feature is not supported by the Elasticsearch OpenShift Operator

### DIFF
--- a/tests/e2e/elasticsearch/render.sh
+++ b/tests/e2e/elasticsearch/render.sh
@@ -115,9 +115,9 @@ else
     skip_test "es-index-cleaner-autoprov" "Test only supported in OpenShift"
 fi
 
-get_elasticsearch_openshift_operator_version
 
 if [ "$IS_OPENSHIFT" = true ]; then
+    get_elasticsearch_openshift_operator_version
     if [ -n "$(version_ge "$ESO_OPERATOR_VERSION" "5.4")" ]; then
         es_index_cleaner "-managed" "production_managed_es"
     else
@@ -212,6 +212,7 @@ else
 fi
 
 if [ "$IS_OPENSHIFT" = true ]; then
+    get_elasticsearch_openshift_operator_version
     if [ -n "$(version_ge "$ESO_OPERATOR_VERSION" "5.4")" ]; then
         es_rollover "-managed" "production_managed_es"
     else

--- a/tests/e2e/elasticsearch/render.sh
+++ b/tests/e2e/elasticsearch/render.sh
@@ -5,7 +5,6 @@ source $(dirname "$0")/../render-utils.sh
 is_secured="false"
 if [ $IS_OPENSHIFT = true ]; then
     is_secured="true"
-    echo "--------------------------------------------------------------------"
 fi
 
 
@@ -116,8 +115,14 @@ else
     skip_test "es-index-cleaner-autoprov" "Test only supported in OpenShift"
 fi
 
+get_elasticsearch_openshift_operator_version
+
 if [ "$IS_OPENSHIFT" = true ]; then
-    es_index_cleaner "-managed" "production_managed_es"
+    if [ -n "$(version_ge "$ESO_OPERATOR_VERSION" "5.4")" ]; then
+        es_index_cleaner "-managed" "production_managed_es"
+    else
+        skip_test "es-index-cleaner-managed" "Test only supported with Elasticsearch OpenShift Operator >= 5.4"
+    fi
 else
     skip_test "es-index-cleaner-managed" "Test only supported in OpenShift"
 fi
@@ -205,8 +210,13 @@ if [ "$IS_OPENSHIFT" = true ]; then
 else
     skip_test "es-rollover-autoprov" "Test only supported in OpenShift"
 fi
+
 if [ "$IS_OPENSHIFT" = true ]; then
-    es_rollover "-managed" "production_managed_es"
+    if [ -n "$(version_ge "$ESO_OPERATOR_VERSION" "5.4")" ]; then
+        es_rollover "-managed" "production_managed_es"
+    else
+        skip_test "es-rollover-managed" "Test only supported with Elasticsearch OpenShift Operator >= 5.4"
+    fi
 else
     skip_test "es-rollover-managed" "Test only supported in OpenShift"
 fi


### PR DESCRIPTION
Signed-off-by: Israel Blancas <iblancas@redhat.com>

## Which problem is this PR solving?
- Some E2E tests from the `elasticsearch` test suite are no supported for Elasticsearch OpenShift Operator versions older than 5.4. This PR skips them

## Short description of the changes
- Add the `get_elasticsearch_openshift_operator_version` to get the Elasticsearch OpenShift Operator
- Skip unsupported tests based on Elasticsearch OpenShift Operator version
