### PR TITLE
Avoid reevaluation of the ASSERT_IMG Make variable

### DIFF
--- a/tests/build-utils/build-assert-e2e-img.sh
+++ b/tests/build-utils/build-assert-e2e-img.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+#
+# Get the name to use for the E2E assert job
+#
+set -xe
+
+image_name=$1
+timestamp_file=$2
+docker build -t "$image_name" -f Dockerfile.asserts . $DOCKER_BUILD_OPTIONS
+echo "$image_name" > "$timestamp_file"

--- a/tests/build-utils/get-assert-e2e-img.sh
+++ b/tests/build-utils/get-assert-e2e-img.sh
@@ -4,7 +4,7 @@
 #
 ASSERT_JOB_TAG=$(cat build-assert-job 2> /dev/null)
 if [ $? != 0 ] || [ "$ASSERT_JOB_TAG" = "" ]; then
-    echo $ASSERT_IMG
+    echo "$ASSERT_IMG"
 else
-    echo $ASSERT_JOB_TAG
+    echo "$ASSERT_JOB_TAG"
 fi

--- a/tests/e2e/Makefile
+++ b/tests/e2e/Makefile
@@ -38,8 +38,8 @@ endif
 
 build-assert-job: Dockerfile.asserts $(shell find tests/assert-jobs -type f)
 	$(ECHO) Building E2E asserts image
-	$(VECHO)docker build -t $(ASSERT_IMG)  -f Dockerfile.asserts . $(DOCKER_BUILD_OPTIONS)
-	$(VECHO)echo $(ASSERT_IMG) > $@
+	$(VECHO) DOCKER_BUILD_OPTIONS=$(DOCKER_BUILD_OPTIONS) \
+		./tests/build-utils/build-assert-e2e-img.sh $(ASSERT_IMG) $@
 
 
 .PHONY: load-assert-job

--- a/tests/e2e/Makefile
+++ b/tests/e2e/Makefile
@@ -38,7 +38,7 @@ endif
 
 build-assert-job: Dockerfile.asserts $(shell find tests/assert-jobs -type f)
 	$(ECHO) Building E2E asserts image
-	$(VECHO) DOCKER_BUILD_OPTIONS=$(DOCKER_BUILD_OPTIONS) \
+	$(VECHO) DOCKER_BUILD_OPTIONS="$(DOCKER_BUILD_OPTIONS)" \
 		./tests/build-utils/build-assert-e2e-img.sh $(ASSERT_IMG) $@
 
 


### PR DESCRIPTION
Signed-off-by: Israel Blancas <iblancas@redhat.com>

## Which problem is this PR solving?
Sometimes, this error appears ([full log](https://github.com/jaegertracing/jaeger-operator/runs/7411403010?check_suite_focus=true)):
```sh
Loading the quay.io/runner/asserts-e2e:1658241386 container image in the KIND cluster
ERROR: image: "quay.io/runner/asserts-e2e:1658241386" not present locally
```
In this case, the built image is `quay.io/runner/asserts-e2e:1658241385`. This error is not easy to reproduce. It happens because the `ASSERT_IMG` make variable depends on the timestamp:
```make
export ASSERT_IMG ?= ${IMG_PREFIX}/asserts-e2e:$(shell date +%s)
```

Sometimes, it is reevaluated in the `build-assert-job` make target:
```make
	$(VECHO)docker build -t $(ASSERT_IMG)  -f Dockerfile.asserts . $(DOCKER_BUILD_OPTIONS)
	$(VECHO)echo $(ASSERT_IMG) > $@
```

## Short description of the changes
- Move the build of the image to a script to avoid the variable reevaluation of the image
