### PR TITLE
Increase robustness of go dependencies download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,13 @@ FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.17 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
-RUN go mod download
+COPY hack/install/install-dependencies.sh hack/install/
+COPY hack/install/install-utils.sh hack/install/
+COPY go.mod .
+COPY go.sum .
+RUN ./hack/install/install-dependencies.sh
 
 # Copy the go source
 COPY main.go main.go

--- a/Makefile
+++ b/Makefile
@@ -130,6 +130,7 @@ security:
 .PHONY: build
 build: format
 	$(ECHO) Building...
+	$(VECHO)./hack/install/install-dependencies.sh
 	$(VECHO)${GO_FLAGS} go build -ldflags $(LD_FLAGS) -o $(OUTPUT_BINARY) main.go
 
 .PHONY: docker


### PR DESCRIPTION
Signed-off-by: Israel Blancas <iblancas@redhat.com>

## Which problem is this PR solving?
Sometimes, the Golang dependencies download fails during the build of the Jaeger Operator or the Jaeger Operator container image. These errors are usually caused due to network errors.

This PR adds a retry mechanism to avoid this issue.