### PR TITLE
Wait until the deployments are there again in get-token.sh

### DIFF
--- a/tests/cmd-utils/get-token.sh
+++ b/tests/cmd-utils/get-token.sh
@@ -43,7 +43,7 @@ fi
 
 deployment_mode=$(kubectl get jaeger "$JAEGER_NAME" -n "$NAMESPACE" -o yaml | $YQ e '.spec.strategy')
 if [ "$deployment_mode" = "production" ] || [ "$deployment_mode" = "streaming" ]; then
-    kubectl wait --timeout=$timeout --for=condition=available deployment "$JAEGER_NAME"-query -n "$NAMESPACE"  /dev/null
+    kubectl wait --timeout=$timeout --for=condition=available deployment "$JAEGER_NAME-query" -n "$NAMESPACE" > /dev/null
 else
     kubectl wait --timeout=$timeout --for=condition=available deployment "$JAEGER_NAME" -n "$NAMESPACE" > /dev/null
 fi

--- a/tests/cmd-utils/get-token.sh
+++ b/tests/cmd-utils/get-token.sh
@@ -5,35 +5,45 @@ if [ "$#" -lt 2 ]; then
     exit 1
 fi
 
-export NAMESPACE=$1
-export JAEGER_NAME=$2
-export OUTPUT_FILE=$3
+export NAMESPACE="$1"
+export JAEGER_NAME="$2"
+export OUTPUT_FILE="$3"
 
 set -e
+timeout="1m"
 
-export ROOT_DIR=$(realpath $(dirname ${BASH_SOURCE[0]})/../../)
-source $ROOT_DIR/hack/common.sh
+export ROOT_DIR
+ROOT_DIR=$(realpath $(dirname ${BASH_SOURCE[0]})/../../)
+source "$ROOT_DIR/hack/common.sh"
 
 # Ensure the tools are installed
-$ROOT_DIR/hack/install/install-gomplate.sh > /dev/null
-$ROOT_DIR/hack/install/install-yq.sh > /dev/null
+"$ROOT_DIR/hack/install/install-gomplate.sh" > /dev/null
+"$ROOT_DIR/hack/install/install-yq.sh" > /dev/null
 
 
 if [ -z "$SERVICE_ACCOUNT_NAME" ]; then
     export SERVICE_ACCOUNT_NAME="automation-sa"
 fi
 
-$GOMPLATE -f $TEMPLATES_DIR/openshift/configure-jaeger-sa.yaml.template -o /tmp/jaeger-sa.yaml
-kubectl apply -f /tmp/jaeger-sa.yaml -n $NAMESPACE > /dev/null
+$GOMPLATE -f "$TEMPLATES_DIR/openshift/configure-jaeger-sa.yaml.template" -o /tmp/jaeger-sa.yaml
+kubectl apply -f /tmp/jaeger-sa.yaml -n "$NAMESPACE" > /dev/null
 
 # This takes some time
 sleep 5
 
-SECRET_NAME=$(kubectl get sa $SERVICE_ACCOUNT_NAME -o yaml -n $NAMESPACE | $YQ eval '.secrets[] | select( .name == "*-token-*")'.name)
-SECRET=$(kubectl get secret $SECRET_NAME -n $NAMESPACE -o jsonpath='{.data.token}' |  base64 -d)
+SECRET_NAME=$(kubectl get sa $SERVICE_ACCOUNT_NAME -o yaml -n "$NAMESPACE" | $YQ eval '.secrets[] | select( .name == "*-token-*")'.name)
+SECRET=$(kubectl get secret "$SECRET_NAME" -n "$NAMESPACE" -o jsonpath='{.data.token}' |  base64 -d)
 
-if [ ! -z $OUTPUT_FILE ]; then
-    echo -n $SECRET > $OUTPUT_FILE
+if [ -n "$OUTPUT_FILE" ]; then
+    echo -n "$SECRET" > "$OUTPUT_FILE"
 else
-    echo $SECRET
+    echo "$SECRET"
+fi
+
+
+deployment_mode=$(kubectl get jaeger "$JAEGER_NAME" -n "$NAMESPACE" -o yaml | $YQ e '.spec.strategy')
+if [ "$deployment_mode" = "production" ] || [ "$deployment_mode" = "streaming" ]; then
+    kubectl wait --timeout=$timeout --for=condition=available deployment "$JAEGER_NAME"-query -n "$NAMESPACE"  /dev/null
+else
+    kubectl wait --timeout=$timeout --for=condition=available deployment "$JAEGER_NAME" -n "$NAMESPACE" > /dev/null
 fi

--- a/tests/e2e/ui/render.sh
+++ b/tests/e2e/ui/render.sh
@@ -48,7 +48,7 @@ if [ $IS_OPENSHIFT = true ]; then
     INSECURE="true" EXPECTED_CODE="403" $GOMPLATE -f $TEMPLATES_DIR/assert-http-code.yaml.template -o ./02-check-forbbiden-access.yaml
 fi
 
-# Check we can access the deployment. In OpenShif, a token will be generated
+# Check we can access the deployment. In OpenShift, a token will be generated
 # to access the query endpoint properly
 EXPECTED_CODE="200" $GOMPLATE -f $TEMPLATES_DIR/assert-http-code.yaml.template -o ./03-curl.yaml
 


### PR DESCRIPTION
Signed-off-by: Israel Blancas <iblancasa@gmail.com>

## Which problem is this PR solving?
Avoid race conditions when `get-token.sh` is called, waiting for the deployments to be done again.

If a Jaeger instance is modified and the pods are not started again fast enough, the smoke tests can fail. With this change, we wait until everything is there again before creating the smoke test jobs.