### PR TITLE
Add http- prefix to port names to resolve similar issue to PR-1862

### DIFF
--- a/pkg/deployment/otlp.go
+++ b/pkg/deployment/otlp.go
@@ -25,11 +25,11 @@ func getOTLPContainePorts(options []string) []corev1.ContainerPort {
 		return []corev1.ContainerPort{
 			{
 				ContainerPort: 4317,
-				Name:          "otlp-grpc",
+				Name:          "grpc-otlp",
 			},
 			{
 				ContainerPort: 4318,
-				Name:          "otlp-http",
+				Name:          "http-otlp",
 			},
 		}
 	}

--- a/pkg/service/collector.go
+++ b/pkg/service/collector.go
@@ -143,11 +143,11 @@ func getOTLPServicePorts(jaeger *v1.Jaeger) []corev1.ServicePort {
 	if util.IsOTLPEnable(options) {
 		return []corev1.ServicePort{
 			{
-				Name: "otlp-grpc",
+				Name: "grpc-otlp",
 				Port: 4317,
 			},
 			{
-				Name: "otlp-http",
+				Name: "http-otlp",
 				Port: 4318,
 			},
 		}


### PR DESCRIPTION
## Which problem is this PR solving?
https://github.com/jaegertracing/helm-charts/issues/344#issuecomment-1100166786 (partially)

## Short description of the changes
Adding a prefix to service port names, resolves issues with istioctl
```
istioctl analyze
Info [IST0118] (Service istio-system/jaeger-operator-webhook-service) Port name  (port: 443, targetPort: 9443) doesn't follow the naming convention of Istio port.
Info [IST0118] (Service istio-system/streaming-jaeger-collector-headless) Port name otlp-grpc (port: 4317, targetPort: 4317) doesn't follow the naming convention of Istio port.
Info [IST0118] (Service istio-system/streaming-jaeger-collector-headless) Port name otlp-http (port: 4318, targetPort: 4318) doesn't follow the naming convention of Istio port.
Info [IST0118] (Service istio-system/streaming-jaeger-collector) Port name otlp-grpc (port: 4317, targetPort: 4317) doesn't follow the naming convention of Istio port.
Info [IST0118] (Service istio-system/streaming-jaeger-collector) Port name otlp-http (port: 4318, targetPort: 4318) doesn't follow the naming convention of Istio port.
```