### PR TITLE
Fix e2e secret for newer OCP versions

### DIFF
--- a/tests/cmd-utils/get-token.sh
+++ b/tests/cmd-utils/get-token.sh
@@ -31,7 +31,9 @@ kubectl apply -f /tmp/jaeger-sa.yaml -n "$NAMESPACE" > /dev/null
 # This takes some time
 sleep 5
 
-SECRET_NAME=$(kubectl get sa $SERVICE_ACCOUNT_NAME -o yaml -n "$NAMESPACE" | $YQ eval '.secrets[] | select( .name == "*-token-*")'.name)
+SECRET_NAME=$SERVICE_ACCOUNT_NAME
+$GOMPLATE -f "$TEMPLATES_DIR/openshift/sa-secret.yaml.template" -o /tmp/sa-secret.yaml
+kubectl create -f /tmp/sa-secret.yaml -n "$NAMESPACE" > /dev/null
 SECRET=$(kubectl get secret "$SECRET_NAME" -n "$NAMESPACE" -o jsonpath='{.data.token}' |  base64 -d)
 
 if [ -n "$OUTPUT_FILE" ]; then

--- a/tests/templates/openshift/find-service.yaml.template
+++ b/tests/templates/openshift/find-service.yaml.template
@@ -5,5 +5,5 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - script: "SERVICE_ACCOUNT_NAME={{ .Env.SERVICE_ACCOUNT_NAME }} {{ .Env.GET_TOKEN_PROGRAM }} $NAMESPACE {{ .Env.JAEGER_NAME }} /dev/null"
-  - script: "SERVICE_NAME={{ .Env.SERVICE_NAME }} ASSERT_IMG={{ .Env.ASSERT_IMG }} {{if getenv "JOB_NUMBER"}}JOB_NUMBER={{ .Env.JOB_NUMBER }}{{end}} JAEGER_QUERY_ENDPOINT={{ .Env.JAEGER_QUERY_ENDPOINT }} MOUNT_SECRET=$(kubectl get sa {{ .Env.SERVICE_ACCOUNT_NAME }} -n $NAMESPACE -o json | jq -r '.secrets[] |  select( .name | test(\"{{ .Env.SERVICE_ACCOUNT_NAME }}-token-\")).name') {{ .Env.GOMPLATE }} -f {{ .Env.TEMPLATES_DIR }}/find-service.yaml.template -o find-service{{if getenv "JOB_NUMBER"}}-{{ .Env.JOB_NUMBER }}{{end}}-job.yaml"
+  - script: "SERVICE_NAME={{ .Env.SERVICE_NAME }} ASSERT_IMG={{ .Env.ASSERT_IMG }} {{if getenv "JOB_NUMBER"}}JOB_NUMBER={{ .Env.JOB_NUMBER }}{{end}} JAEGER_QUERY_ENDPOINT={{ .Env.JAEGER_QUERY_ENDPOINT }} MOUNT_SECRET={{ .Env.SERVICE_ACCOUNT_NAME }} {{ .Env.GOMPLATE }} -f {{ .Env.TEMPLATES_DIR }}/find-service.yaml.template -o find-service{{if getenv "JOB_NUMBER"}}-{{ .Env.JOB_NUMBER }}{{end}}-job.yaml"
   - script: "kubectl create -f find-service{{if getenv "JOB_NUMBER"}}-{{ .Env.JOB_NUMBER }}{{end}}-job.yaml -n $NAMESPACE"

--- a/tests/templates/openshift/otlp-smoke-test.yaml.template
+++ b/tests/templates/openshift/otlp-smoke-test.yaml.template
@@ -5,5 +5,5 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - script: "SERVICE_ACCOUNT_NAME={{ .Env.SERVICE_ACCOUNT_NAME }} {{ .Env.GET_TOKEN_PROGRAM }} $NAMESPACE {{ .Env.JAEGER_NAME }} /dev/null"
-  - script: "REPORTING_PROTOCOL={{ .Env.REPORTING_PROTOCOL }} ASSERT_IMG={{ .Env.ASSERT_IMG }} OTEL_EXPORTER_OTLP_ENDPOINT={{ .Env.OTEL_EXPORTER_OTLP_ENDPOINT }} JAEGER_QUERY_ENDPOINT={{ .Env.JAEGER_QUERY_ENDPOINT }} MOUNT_SECRET=$(kubectl get sa {{ .Env.SERVICE_ACCOUNT_NAME }} -o yaml -n $NAMESPACE | {{ .Env.YQ }} eval '.secrets[] | select( .name == \"{{ .Env.SERVICE_ACCOUNT_NAME }}-token-*\")'.name) {{ .Env.GOMPLATE }} -f {{ .Env.TEMPLATES_DIR }}/otlp-smoke-test.yaml.template -o otlp-smoke-test-job.yaml"
+  - script: "REPORTING_PROTOCOL={{ .Env.REPORTING_PROTOCOL }} ASSERT_IMG={{ .Env.ASSERT_IMG }} OTEL_EXPORTER_OTLP_ENDPOINT={{ .Env.OTEL_EXPORTER_OTLP_ENDPOINT }} JAEGER_QUERY_ENDPOINT={{ .Env.JAEGER_QUERY_ENDPOINT }} MOUNT_SECRET={{ .Env.SERVICE_ACCOUNT_NAME }} {{ .Env.GOMPLATE }} -f {{ .Env.TEMPLATES_DIR }}/otlp-smoke-test.yaml.template -o otlp-smoke-test-job.yaml"
   - script: "kubectl create -f otlp-smoke-test-job.yaml -n $NAMESPACE"

--- a/tests/templates/openshift/report-spans.yaml.template
+++ b/tests/templates/openshift/report-spans.yaml.template
@@ -5,5 +5,5 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - script: "SERVICE_ACCOUNT_NAME={{ .Env.SERVICE_ACCOUNT_NAME }} {{ .Env.GET_TOKEN_PROGRAM }} $NAMESPACE {{ .Env.JAEGER_NAME }} /dev/null"
-  - script: "DAYS={{ .Env.DAYS }} ASSERT_IMG={{ .Env.ASSERT_IMG }} {{if getenv "JOB_NUMBER"}}JOB_NUMBER={{ .Env.JOB_NUMBER }}{{end}} JAEGER_COLLECTOR_ENDPOINT={{ .Env.JAEGER_COLLECTOR_ENDPOINT }} {{if getenv "JAEGER_QUERY_ENDPOINT"}}JAEGER_QUERY_ENDPOINT={{ .Env.JAEGER_QUERY_ENDPOINT }} MOUNT_SECRET=$(kubectl get sa {{ .Env.SERVICE_ACCOUNT_NAME }} -n $NAMESPACE -o json | jq -r '.secrets[] |  select( .name | test(\"{{ .Env.SERVICE_ACCOUNT_NAME }}-token-\")).name'){{end}} {{ .Env.GOMPLATE }} -f {{ .Env.TEMPLATES_DIR }}/report-spans.yaml.template -o report-span-{{ .Env.JOB_NUMBER }}-job.yaml"
+  - script: "DAYS={{ .Env.DAYS }} ASSERT_IMG={{ .Env.ASSERT_IMG }} {{if getenv "JOB_NUMBER"}}JOB_NUMBER={{ .Env.JOB_NUMBER }}{{end}} JAEGER_COLLECTOR_ENDPOINT={{ .Env.JAEGER_COLLECTOR_ENDPOINT }} {{if getenv "JAEGER_QUERY_ENDPOINT"}}JAEGER_QUERY_ENDPOINT={{ .Env.JAEGER_QUERY_ENDPOINT }} MOUNT_SECRET={{ .Env.SERVICE_ACCOUNT_NAME }} {{ .Env.GOMPLATE }} -f {{ .Env.TEMPLATES_DIR }}/report-spans.yaml.template -o report-span-{{ .Env.JOB_NUMBER }}-job.yaml"
   - script: "kubectl apply -f report-span{{if getenv "JOB_NUMBER"}}-{{ .Env.JOB_NUMBER }}{{end}}-job.yaml -n $NAMESPACE"

--- a/tests/templates/openshift/sa-secret.yaml.template
+++ b/tests/templates/openshift/sa-secret.yaml.template
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/service-account-token
+metadata:
+  name: {{ .Env.SERVICE_ACCOUNT_NAME }}
+  annotations:
+    kubernetes.io/service-account.name: "{{ .Env.SERVICE_ACCOUNT_NAME }}"

--- a/tests/templates/openshift/smoke-test.yaml.template
+++ b/tests/templates/openshift/smoke-test.yaml.template
@@ -5,5 +5,5 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   - script: "SERVICE_ACCOUNT_NAME={{ .Env.SERVICE_ACCOUNT_NAME }} {{ .Env.GET_TOKEN_PROGRAM }} $NAMESPACE {{ .Env.JAEGER_NAME }} /dev/null"
-  - script: "ASSERT_IMG={{ .Env.ASSERT_IMG }} JAEGER_COLLECTOR_ENDPOINT={{ .Env.JAEGER_COLLECTOR_ENDPOINT }} JAEGER_QUERY_ENDPOINT={{ .Env.JAEGER_QUERY_ENDPOINT }} MOUNT_SECRET=$(kubectl get sa {{ .Env.SERVICE_ACCOUNT_NAME }} -o yaml -n $NAMESPACE | {{ .Env.YQ }} eval '.secrets[] | select( .name == \"{{ .Env.SERVICE_ACCOUNT_NAME }}-token-*\")'.name) {{ .Env.GOMPLATE }} -f {{ .Env.TEMPLATES_DIR }}/smoke-test.yaml.template -o smoke-test-job.yaml"
+  - script: "ASSERT_IMG={{ .Env.ASSERT_IMG }} JAEGER_COLLECTOR_ENDPOINT={{ .Env.JAEGER_COLLECTOR_ENDPOINT }} JAEGER_QUERY_ENDPOINT={{ .Env.JAEGER_QUERY_ENDPOINT }} MOUNT_SECRET={{ .Env.SERVICE_ACCOUNT_NAME }} {{ .Env.GOMPLATE }} -f {{ .Env.TEMPLATES_DIR }}/smoke-test.yaml.template -o smoke-test-job.yaml"
   - script: "kubectl apply -f smoke-test-job.yaml -n $NAMESPACE"


### PR DESCRIPTION
## Which problem is this PR solving?
- Fix E2E smoke tests for OCP 4.11

## Short description of the changes
Starting on Kubernetes 1.24, when creating a Service Account, no tokens are created associated to it. You need to create one and associate to the desired Service Account.
https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md

This PR follows that process in order to allow the smoke tests to get the info from the Jaeger REST API.
Note this change is backward compatible with older OCP versions.