### PR TITLE
Bump golangci-lint version from 1.48.0 to 1.49.0

### DIFF
--- a/hack/install/install-golangci-lint.sh
+++ b/hack/install/install-golangci-lint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-VERSION="1.48.0"
+VERSION="1.49.0"
 
 echo "Installing golangci-lint"
 


### PR DESCRIPTION
Signed-off-by: Israel Blancas <iblancasa@gmail.com>

## Which problem is this PR solving?
- Bump `golangci-lint` version from `1.48.0` to `1.49.0`