### PR TITLE
Add liveness and readiness probes to injected sidecar

### DIFF
--- a/pkg/inject/sidecar_test.go
+++ b/pkg/inject/sidecar_test.go
@@ -284,6 +284,23 @@ func TestSidecarDefaultPorts(t *testing.T) {
 	assert.Contains(t, dep.Spec.Template.Spec.Containers[1].Ports, corev1.ContainerPort{ContainerPort: 14271, Name: "admin-http"})
 }
 
+func TestSidecarProbes(t *testing.T) {
+	// prepare
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
+	dep := dep(map[string]string{}, map[string]string{"app": "testapp"})
+
+	// test
+	dep = Sidecar(jaeger, dep)
+
+	// verify
+	assert.Len(t, dep.Spec.Template.Spec.Containers, 2)
+	assert.Contains(t, dep.Spec.Template.Spec.Containers[1].Image, "jaeger-agent")
+
+	assert.Len(t, dep.Spec.Template.Spec.Containers[1].Ports, 5)
+	assert.NotNil(t, dep.Spec.Template.Spec.Containers[1].LivenessProbe)
+	assert.NotNil(t, dep.Spec.Template.Spec.Containers[1].ReadinessProbe)
+}
+
 func TestSkipInjectSidecar(t *testing.T) {
 	// prepare
 	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})


### PR DESCRIPTION
Signed-off-by: Jacob Colvin <jacobcolvin1@gmail.com>

Fixes #1202

This PR is mainly just taking code from #1230 which was unfortunately abandoned.

I believe I've fixed all of the issues with #1230, which involved:
- Changing `Handler` to `ProbeHandler`.
- Skipping checks for conflicting ports on the agent container. (Without this, it seems that probes could not be added if a deployment was restarted/upgraded, because the port was already used on the deployment from the last injection.)
