### PR TITLE
Fix Kafka tests for old Kafka operator version

### DIFF
--- a/tests/e2e/elasticsearch/Makefile
+++ b/tests/e2e/elasticsearch/Makefile
@@ -1,5 +1,5 @@
 render-e2e-tests-elasticsearch: load-assert-job load-elasticsarch-image
-	$(VECHO)SKIP_ES_EXTERNAL=$(SKIP_ES_EXTERNAL) ./tests/e2e/elasticsearch/render.sh
+	$(VECHO)SKIP_ES_EXTERNAL=$(SKIP_ES_EXTERNAL) KAFKA_VERSION=$(KAFKA_VERSION) ./tests/e2e/elasticsearch/render.sh
 
 run-e2e-tests-elasticsearch:
 	$(VECHO)KAFKA_OLM=$(KAFKA_OLM) ./hack/run-e2e-test-suite.sh elasticsearch $(USE_KIND_CLUSTER) $(JAEGER_OLM)

--- a/tests/e2e/examples/Makefile
+++ b/tests/e2e/examples/Makefile
@@ -1,5 +1,5 @@
 render-e2e-tests-examples: load-assert-job load-elasticsarch-image load-elasticsarch-image
-	$(VECHO)./tests/e2e/examples/render.sh
+	$(VECHO)KAFKA_VERSION=$(KAFKA_VERSION) ./tests/e2e/examples/render.sh
 
 run-e2e-tests-examples:
 	$(VECHO)KAFKA_OLM=$(KAFKA_OLM) ./hack/run-e2e-test-suite.sh examples $(USE_KIND_CLUSTER) $(JAEGER_OLM)

--- a/tests/e2e/render-utils.sh
+++ b/tests/e2e/render-utils.sh
@@ -866,6 +866,17 @@ if [ ! -z "$output" ]; then
     IS_OPENSHIFT=true
 fi
 
+export KAFKA_USE_CUSTOM_PODSET
+if [ -z "$KAFKA_VERSION" ]; then
+    KAFKA_USE_CUSTOM_PODSET=false
+else
+    if version_gt $KAFKA_VERSION "0.25.0"; then
+        KAFKA_USE_CUSTOM_PODSET=true
+    else
+        KAFKA_USE_CUSTOM_PODSET=false
+    fi
+fi
+
 export IS_OPENSHIFT
 
 # Important folders

--- a/tests/e2e/render-utils.sh
+++ b/tests/e2e/render-utils.sh
@@ -867,14 +867,10 @@ if [ ! -z "$output" ]; then
 fi
 
 export KAFKA_USE_CUSTOM_PODSET
-if [ -z "$KAFKA_VERSION" ]; then
+if [ -z "$KAFKA_VERSION" ] || version_le $KAFKA_VERSION "0.25.0" ; then
     KAFKA_USE_CUSTOM_PODSET=false
 else
-    if version_gt $KAFKA_VERSION "0.25.0"; then
-        KAFKA_USE_CUSTOM_PODSET=true
-    else
-        KAFKA_USE_CUSTOM_PODSET=false
-    fi
+    KAFKA_USE_CUSTOM_PODSET=true
 fi
 
 export IS_OPENSHIFT

--- a/tests/e2e/streaming/Makefile
+++ b/tests/e2e/streaming/Makefile
@@ -1,5 +1,5 @@
 render-e2e-tests-streaming: load-assert-job load-elasticsarch-image
-	$(VECHO)./tests/e2e/streaming/render.sh
+	$(VECHO)KAFKA_VERSION=$(KAFKA_VERSION) ./tests/e2e/streaming/render.sh
 
 run-e2e-tests-streaming:
 	$(VECHO)KAFKA_OLM=$(KAFKA_OLM) ./hack/run-e2e-test-suite.sh streaming $(USE_KIND_CLUSTER) $(JAEGER_OLM)

--- a/tests/templates/assert-kafka-cluster.yaml.template
+++ b/tests/templates/assert-kafka-cluster.yaml.template
@@ -1,7 +1,16 @@
 # Assert the Kafka StrimziPodSet is up and running
+{{if eq .Env.KAFKA_USE_CUSTOM_PODSET "true" }}
 apiVersion: core.strimzi.io/v1beta2
 kind: StrimziPodSet
+{{else}}
+apiVersion: apps/v1
+kind: StatefulSet
+{{end}}
 metadata:
   name: {{ .Env.CLUSTER_NAME }}-kafka
 status:
+{{if eq .Env.KAFKA_USE_CUSTOM_PODSET "true" }}
   readyPods: {{ .Env.REPLICAS }}
+{{else}}
+  availableReplicas: 1
+{{end}}

--- a/tests/templates/assert-zookeeper-cluster.yaml.template
+++ b/tests/templates/assert-zookeeper-cluster.yaml.template
@@ -1,7 +1,16 @@
 # Assert the Zookeeper StrimziPodSet is up and running
+{{if eq .Env.KAFKA_USE_CUSTOM_PODSET "true" }}
 apiVersion: core.strimzi.io/v1beta2
 kind: StrimziPodSet
+{{else}}
+apiVersion: apps/v1
+kind: StatefulSet
+{{end}}
 metadata:
   name: {{ .Env.CLUSTER_NAME }}-zookeeper
 status:
+{{if eq .Env.KAFKA_USE_CUSTOM_PODSET "true" }}
   readyPods: {{ .Env.REPLICAS }}
+{{else}}
+  availableReplicas: 1
+{{end}}


### PR DESCRIPTION
Signed-off-by: Israel Blancas <iblancasa@gmail.com>

## Which problem is this PR solving?
- Newer Kafka Operator versions deploy `StrimziPodSet` instead of `StatefulSet`. This can be a problem if we want to do something with an older version of the Kafka Operator