### PR TITLE
Fix: svc port doesnt match istio convention

### DIFF
--- a/pkg/service/collector_test.go
+++ b/pkg/service/collector_test.go
@@ -66,13 +66,13 @@ func TestCollectorGRPCPortName(t *testing.T) {
 		{
 			"nil",
 			nil,
-			"grpc-http",
+			"grpc-jaeger",
 			false, // in openshift?
 		},
 		{
 			"no-tls",
 			&v1.Jaeger{},
-			"grpc-http",
+			"grpc-jaeger",
 			false, // in openshift?
 		},
 		{
@@ -84,7 +84,7 @@ func TestCollectorGRPCPortName(t *testing.T) {
 					},
 				},
 			},
-			"grpc-http",
+			"grpc-jaeger",
 			false, // in openshift?
 		},
 		{
@@ -96,7 +96,7 @@ func TestCollectorGRPCPortName(t *testing.T) {
 					},
 				},
 			},
-			"grpc-http",
+			"grpc-jaeger",
 			false, // in openshift?
 		},
 		{
@@ -108,13 +108,13 @@ func TestCollectorGRPCPortName(t *testing.T) {
 					},
 				},
 			},
-			"grpc-https",
+			"tls-grpc-jaeger",
 			false, // in openshift?
 		},
 		{
 			"in-openshift",
 			&v1.Jaeger{},
-			"grpc-https",
+			"tls-grpc-jaeger",
 			true, // in openshift?
 		},
 	} {

--- a/tests/e2e/miscellaneous/istio/03-assert.yaml
+++ b/tests/e2e/miscellaneous/istio/03-assert.yaml
@@ -7,3 +7,65 @@ spec:
     - name: myapp
     - name: jaeger-agent
     - name: istio-proxy
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: simplest-collector-headless
+spec:
+  ports:
+  - name: http-zipkin
+    port: 9411
+    protocol: TCP
+    targetPort: 9411
+  - name: grpc-jaeger
+    port: 14250
+    protocol: TCP
+    targetPort: 14250
+  - name: http-c-tchan-trft
+    port: 14267
+    protocol: TCP
+    targetPort: 14267
+  - name: http-c-binary-trft
+    port: 14268
+    protocol: TCP
+    targetPort: 14268
+  - name: grpc-otlp
+    port: 4317
+    protocol: TCP
+    targetPort: 4317
+  - name: http-otlp
+    port: 4318
+    protocol: TCP
+    targetPort: 4318
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: simplest-collector
+spec:
+  ports:
+  - name: http-zipkin
+    port: 9411
+    protocol: TCP
+    targetPort: 9411
+  - name: grpc-jaeger
+    port: 14250
+    protocol: TCP
+    targetPort: 14250
+  - name: http-c-tchan-trft
+    port: 14267
+    protocol: TCP
+    targetPort: 14267
+  - name: http-c-binary-trft
+    port: 14268
+    protocol: TCP
+    targetPort: 14268
+  - name: grpc-otlp
+    port: 4317
+    protocol: TCP
+    targetPort: 4317
+  - name: http-otlp
+    port: 4318
+    protocol: TCP
+    targetPort: 4318


### PR DESCRIPTION
This pr changes the service port naming to avoid TLS termination issues when using istio. Istio recognizes which application protocol is used by the port name. Our last name change of the service port name from `https-grpc` to `grcp-https` has resulted in TLS traffic being treated like unencrypted traffic.
Resulting in a handshake error: `authentication handshake failed: tls: first record does not look like a TLS handshake`.

In the analysis, the port names confused me several times. Since I didn't want to just switch grpc and https again, I tried to make the names a bit more descriptive. Note the application protocol is determined by the port name prefix: `<protocol>[-<suffix>]`.
- `grpc-https` (invalid) -> `https-grpc` (valid) -> `https-model-proto` (valid) -> `tls-grpc-jaeger` (valid)
- `grpc-http` (valid) -> `grpc-http`(valid) ->`grpc-model-proto` (valid) -> `grpc-jaeger` (valid)

Jaeger doc:
![image](https://user-images.githubusercontent.com/10403402/197057310-ebf1d78e-1cec-4d19-9769-45c149a8f0b7.png)



In the past, port names have been changed quite frequently to match the [istio naming conventions](https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/#explicit-protocol-selection). To create some overview, here is a list of all interesting changes:
- https://github.com/jaegertracing/jaeger-operator/pull/911
- https://github.com/jaegertracing/jaeger-operator/pull/1122
- https://github.com/jaegertracing/jaeger-operator/pull/1368
- https://github.com/jaegertracing/jaeger-operator/pull/1862

Istio prefers protocols specified in the [appProtocol](https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol) field over the assigned names. Maybe we should think about using this feature in the future. It is supported since kubernetes 1.18. The oldest version we currently support is 1.19.

closes https://github.com/jaegertracing/jaeger-operator/issues/1360

---

cc ) @Stevmann @lautou