### PR TITLE
fix for min tls version to v1.2

### DIFF
--- a/pkg/cmd/start/main.go
+++ b/pkg/cmd/start/main.go
@@ -37,6 +37,7 @@ func AddFlags(cmd *cobra.Command) {
 	cmd.Flags().String("secure-listen-address", "", "")
 	cmd.Flags().String("health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	cmd.Flags().Int("webhook-bind-port", 9443, "The address webhooks expose.")
+	cmd.Flags().String("tls-min-version", "VersionTLS12", "Minimum TLS version supported. Value must match version names from https://golang.org/pkg/crypto/tls/#pkg-constants.")
 	cmd.Flags().Bool("leader-elect", false, "Enable leader election for controller manager. "+
 		"Enabling this will ensure there is only one active controller manager.")
 

--- a/pkg/cmd/start/main.go
+++ b/pkg/cmd/start/main.go
@@ -38,6 +38,7 @@ func AddFlags(cmd *cobra.Command) {
 	cmd.Flags().String("health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	cmd.Flags().Int("webhook-bind-port", 9443, "The address webhooks expose.")
 	cmd.Flags().String("tls-min-version", "VersionTLS12", "Minimum TLS version supported. Value must match version names from https://golang.org/pkg/crypto/tls/#pkg-constants.")
+	cmd.Flags().StringSlice("tls-cipher-suites", nil, "Comma-separated list of cipher suites for the server. Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants). If omitted, the default Go cipher suites will be used")
 	cmd.Flags().Bool("leader-elect", false, "Enable leader election for controller manager. "+
 		"Enabling this will ensure there is only one active controller manager.")
 


### PR DESCRIPTION
<!--
Please delete this comment before posting.

We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
Fix #2118

## Short description of the changes
Adding min tls version for webhook server during bootstraping