### PR TITLE
Fix query ingress when using streaming strategy

### DIFF
--- a/pkg/ingress/query.go
+++ b/pkg/ingress/query.go
@@ -81,10 +81,10 @@ func (i *QueryIngress) Get() *networkingv1.Ingress {
 func (i *QueryIngress) addRulesSpec(spec *networkingv1.IngressSpec, backend *networkingv1.IngressBackend) {
 	path := ""
 
-	if allInOneQueryBasePath, ok := i.jaeger.Spec.AllInOne.Options.StringMap()["query.base-path"]; ok && i.jaeger.Spec.Strategy == v1.DeploymentStrategyAllInOne {
-		path = allInOneQueryBasePath
-	} else if queryBasePath, ok := i.jaeger.Spec.Query.Options.StringMap()["query.base-path"]; ok && i.jaeger.Spec.Strategy == v1.DeploymentStrategyProduction {
-		path = queryBasePath
+	if i.jaeger.Spec.Strategy == v1.DeploymentStrategyAllInOne {
+		path = i.jaeger.Spec.AllInOne.Options.StringMap()["query.base-path"]
+	} else if i.jaeger.Spec.Strategy == v1.DeploymentStrategyProduction || i.jaeger.Spec.Strategy == v1.DeploymentStrategyStreaming {
+		path = i.jaeger.Spec.Query.Options.StringMap()["query.base-path"]
 	}
 
 	pathType := networkingv1.PathTypeImplementationSpecific

--- a/pkg/ingress/query.go
+++ b/pkg/ingress/query.go
@@ -81,10 +81,12 @@ func (i *QueryIngress) Get() *networkingv1.Ingress {
 func (i *QueryIngress) addRulesSpec(spec *networkingv1.IngressSpec, backend *networkingv1.IngressBackend) {
 	path := ""
 
-	if i.jaeger.Spec.Strategy == v1.DeploymentStrategyAllInOne {
-		path = i.jaeger.Spec.AllInOne.Options.StringMap()["query.base-path"]
-	} else if i.jaeger.Spec.Strategy == v1.DeploymentStrategyProduction || i.jaeger.Spec.Strategy == v1.DeploymentStrategyStreaming {
-		path = i.jaeger.Spec.Query.Options.StringMap()["query.base-path"]
+	jaegerSpec := i.jaeger.Spec
+	strategy := jaegerSpec.Strategy
+	if allInOneQueryBasePath, ok := jaegerSpec.AllInOne.Options.StringMap()["query.base-path"]; ok && strategy == v1.DeploymentStrategyAllInOne {
+		path = allInOneQueryBasePath
+	} else if queryBasePath, ok := jaegerSpec.Query.Options.StringMap()["query.base-path"]; ok && strategy == v1.DeploymentStrategyProduction || strategy == v1.DeploymentStrategyStreaming {
+		path = queryBasePath
 	}
 
 	pathType := networkingv1.PathTypeImplementationSpecific

--- a/pkg/ingress/query_test.go
+++ b/pkg/ingress/query_test.go
@@ -85,27 +85,6 @@ func TestIngressWithPath(t *testing.T) {
 	}
 }
 
-func TestQueryIngressQueryBasePathWithStreaming(t *testing.T) {
-	enabled := true
-	name := "TestQueryIngressQueryBasePath"
-	jaeger := v1.NewJaeger(types.NamespacedName{Name: name})
-	jaeger.Spec.Ingress.Enabled = &enabled
-	jaeger.Spec.Strategy = v1.DeploymentStrategyStreaming
-	jaeger.Spec.Query.Options = v1.NewOptions(map[string]interface{}{"query.base-path": "/jaeger-streaming"})
-	ingress := NewQueryIngress(jaeger)
-
-	dep := ingress.Get()
-
-	assert.NotNil(t, dep)
-	assert.Nil(t, dep.Spec.DefaultBackend)
-	assert.Len(t, dep.Spec.Rules, 1)
-
-	assert.Len(t, dep.Spec.Rules[0].HTTP.Paths, 1)
-	assert.Equal(t, "/jaeger-streaming", dep.Spec.Rules[0].HTTP.Paths[0].Path)
-	assert.Empty(t, dep.Spec.Rules[0].Host)
-	assert.NotNil(t, dep.Spec.Rules[0].HTTP.Paths[0].Backend)
-}
-
 func TestQueryIngressAnnotations(t *testing.T) {
 	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestQueryIngressAnnotations"})
 	jaeger.Spec.Annotations = map[string]string{


### PR DESCRIPTION
Signed-off-by: Kevin Earls <kearls@redhat.com>

This resolves #2088 If a base path is set in the CR and the streaming strategy is being used, we were not creating the ingress correctly.


