### PR TITLE
Fix Liveness Probe for Ingester and Query

### DIFF
--- a/pkg/deployment/ingester.go
+++ b/pkg/deployment/ingester.go
@@ -115,8 +115,8 @@ func (i *Ingester) Get() *appsv1.Deployment {
 		FailureThreshold:    5,
 	}
 
-	if i.jaeger.Spec.Collector.LivenessProbe != nil {
-		livenessProbe = i.jaeger.Spec.Collector.LivenessProbe
+	if i.jaeger.Spec.Ingester.LivenessProbe != nil {
+		livenessProbe = i.jaeger.Spec.Ingester.LivenessProbe
 	}
 
 	return &appsv1.Deployment{

--- a/pkg/deployment/ingester_test.go
+++ b/pkg/deployment/ingester_test.go
@@ -527,7 +527,7 @@ func TestIngesterLivenessProbe(t *testing.T) {
 		FailureThreshold:    60,
 	}
 	jaeger := newIngesterJaeger("my-instance")
-	jaeger.Spec.Collector.LivenessProbe = livenessProbe
+	jaeger.Spec.Ingester.LivenessProbe = livenessProbe
 	i := NewIngester(jaeger)
 	dep := i.Get()
 	assert.Equal(t, livenessProbe, dep.Spec.Template.Spec.Containers[0].LivenessProbe)

--- a/pkg/deployment/query.go
+++ b/pkg/deployment/query.go
@@ -111,8 +111,8 @@ func (q *Query) Get() *appsv1.Deployment {
 		FailureThreshold:    5,
 	}
 
-	if q.jaeger.Spec.Collector.LivenessProbe != nil {
-		livenessProbe = q.jaeger.Spec.Collector.LivenessProbe
+	if q.jaeger.Spec.Query.LivenessProbe != nil {
+		livenessProbe = q.jaeger.Spec.Query.LivenessProbe
 	}
 
 	return &appsv1.Deployment{

--- a/pkg/deployment/query_test.go
+++ b/pkg/deployment/query_test.go
@@ -404,7 +404,7 @@ func TestQueryLivenessProbe(t *testing.T) {
 		FailureThreshold:    60,
 	}
 	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
-	jaeger.Spec.Collector.LivenessProbe = livenessProbe
+	jaeger.Spec.Query.LivenessProbe = livenessProbe
 	q := NewQuery(jaeger)
 	dep := q.Get()
 	assert.Equal(t, livenessProbe, dep.Spec.Template.Spec.Containers[0].LivenessProbe)


### PR DESCRIPTION
## Which problem is this PR solving?

The liveness probes added in https://github.com/jaegertracing/jaeger-operator/pull/1605 are not working for the ingester and query, because of a copy / paste mistake (sorry for that 😞).

## Short description of the changes

This PR fixes the liveness probe configuration for the ingester and query.