### PR TITLE
add support to run the tests on multi architecture 

### DIFF
--- a/tests/e2e/Makefile
+++ b/tests/e2e/Makefile
@@ -11,6 +11,7 @@ export MULTI_ARCH_ASSERT_IMG ?= false
 USE_KIND_CLUSTER ?= true
 # Skip E2E tests where ES external instance is used
 SKIP_ES_EXTERNAL ?= false
+export SKIP_KAFKA ?= false
 export E2E_TESTS_TIMEOUT ?= 330
 
 

--- a/tests/e2e/Makefile
+++ b/tests/e2e/Makefile
@@ -11,7 +11,7 @@ export MULTI_ARCH_ASSERT_IMG ?= false
 USE_KIND_CLUSTER ?= true
 # Skip E2E tests where ES external instance is used
 SKIP_ES_EXTERNAL ?= false
-# Skip E2e tests where kafka/streaming deployment strategy is used
+# Skip E2E tests where kafka/streaming deployment strategy is used
 export SKIP_KAFKA ?= false
 export E2E_TESTS_TIMEOUT ?= 330
 

--- a/tests/e2e/Makefile
+++ b/tests/e2e/Makefile
@@ -11,6 +11,7 @@ export MULTI_ARCH_ASSERT_IMG ?= false
 USE_KIND_CLUSTER ?= true
 # Skip E2E tests where ES external instance is used
 SKIP_ES_EXTERNAL ?= false
+# Skip E2e tests where kafka/streaming deployment strategy is used
 export SKIP_KAFKA ?= false
 export E2E_TESTS_TIMEOUT ?= 330
 

--- a/tests/e2e/elasticsearch/Makefile
+++ b/tests/e2e/elasticsearch/Makefile
@@ -1,5 +1,8 @@
 render-e2e-tests-elasticsearch: load-assert-job load-elasticsarch-image
-	$(VECHO)SKIP_ES_EXTERNAL=$(SKIP_ES_EXTERNAL) KAFKA_VERSION=$(KAFKA_VERSION) ./tests/e2e/elasticsearch/render.sh
+	$(VECHO) SKIP_ES_EXTERNAL=$(SKIP_ES_EXTERNAL) \
+		KAFKA_VERSION=$(KAFKA_VERSION) \
+		SKIP_KAFKA=$(SKIP_KAFKA) \
+		./tests/e2e/elasticsearch/render.sh
 
 run-e2e-tests-elasticsearch:
 	$(VECHO)KAFKA_OLM=$(KAFKA_OLM) ./hack/run-e2e-test-suite.sh elasticsearch $(USE_KIND_CLUSTER) $(JAEGER_OLM)

--- a/tests/e2e/examples/Makefile
+++ b/tests/e2e/examples/Makefile
@@ -1,5 +1,8 @@
 render-e2e-tests-examples: load-assert-job load-elasticsarch-image load-elasticsarch-image
-	$(VECHO)KAFKA_VERSION=$(KAFKA_VERSION) ./tests/e2e/examples/render.sh
+	$(VECHO) KAFKA_VERSION=$(KAFKA_VERSION) \
+		SKIP_KAFKA=$(SKIP_KAFKA) \
+		VERTX_IMG=$(VERTX_IMG) \
+		./tests/e2e/examples/render.sh
 
 run-e2e-tests-examples:
 	$(VECHO)KAFKA_OLM=$(KAFKA_OLM) ./hack/run-e2e-test-suite.sh examples $(USE_KIND_CLUSTER) $(JAEGER_OLM)

--- a/tests/e2e/examples/render.sh
+++ b/tests/e2e/examples/render.sh
@@ -2,6 +2,9 @@
 
 source $(dirname "$0")/../render-utils.sh
 
+###############################################################################
+# TEST NAME: examples-agent-as-daemonset
+###############################################################################
 start_test "examples-agent-as-daemonset"
 example_name="agent-as-daemonset"
 
@@ -10,6 +13,9 @@ render_install_example "$example_name" "01"
 render_smoke_test_example "$example_name" "02"
 
 
+###############################################################################
+# TEST NAME: examples-agent-with-priority-class
+###############################################################################
 start_test "examples-agent-with-priority-class"
 example_name="agent-with-priority-class"
 prepare_daemonset "00"
@@ -17,32 +23,49 @@ render_install_example "$example_name" "01"
 render_smoke_test_example "$example_name" "02"
 
 
-if [ $IS_OPENSHIFT = true ]; then
-    skip_test "examples-all-in-one-with-options" "This test is not supported in OpenShift"
+###############################################################################
+# TEST NAME: examples-all-in-one-with-options
+###############################################################################
+start_test "examples-all-in-one-with-options"
+example_name="all-in-one-with-options"
+render_install_example "$example_name" "00"
+$YQ e -i '.metadata.name="my-jaeger"' ./00-install.yaml
+$YQ e -i 'del(.spec.allInOne.image)' ./00-install.yaml
+render_smoke_test_example "$example_name" "01"
+sed -i "s~my-jaeger-query~my-jaeger-query/jaeger~gi" ./01-smoke-test.yaml
+
+
+###############################################################################
+# TEST NAME: examples-auto-provision-kafka
+###############################################################################
+if [ $SKIP_KAFKA = true ]; then
+    skip_test "examples-auto-provision-kafka" "SKIP_KAFKA is true"
 else
-    start_test "examples-all-in-one-with-options"
-    example_name="all-in-one-with-options"
-    render_install_example "$example_name" "00"
-    render_smoke_test_example "$example_name" "01"
-    sed -i "s~16686~16686/jaeger~gi" ./01-smoke-test.yaml
+    start_test "examples-auto-provision-kafka"
+    example_name="auto-provision-kafka"
+    render_install_kafka_operator "01"
+    render_install_example "$example_name" "02"
+    if [[ $IS_OPENSHIFT = true && $SKIP_ES_EXTERNAL = true ]]; then
+        $YQ e -i '.spec.storage.options={}' ./02-install.yaml
+        $YQ e -i '.spec.storage.elasticsearch={"nodeCount":1,"resources":{"limits":{"memory":"2Gi"}}}' ./02-install.yaml
+    else
+        render_install_elasticsearch "upstream" "00"
+    fi
+    # The Kafka cluster will be started before the Jaeger components. So, we do the
+    # Jaeger assertion later and the Kafka cluster assertion now
+    mv ./02-assert.yaml ./05-assert.yaml
+    render_assert_kafka "true" "$example_name" "02"
+    render_smoke_test_example "$example_name" "06"
 fi
 
 
-start_test "examples-auto-provision-kafka"
-example_name="auto-provision-kafka"
-render_install_elasticsearch "upstream" "00"
-render_install_kafka_operator "01"
-render_install_example "$example_name" "02"
-# The Kafka cluster will be started before the Jaeger components. So, we do the
-# Jaeger assertion later and the Kafka cluster assertion now
-mv ./02-assert.yaml ./05-assert.yaml
-render_assert_kafka "true" "$example_name" "02"
-render_smoke_test_example "$example_name" "06"
-
-
+###############################################################################
+# TEST NAME: examples-business-application-injected-sidecar
+###############################################################################
 start_test "examples-business-application-injected-sidecar"
 example_name="simplest"
 cp $EXAMPLES_DIR/business-application-injected-sidecar.yaml ./00-install.yaml
+$YQ e -i '.spec.template.spec.containers[0].image=strenv(VERTX_IMG)' ./00-install.yaml
 $YQ e -i '.spec.template.spec.containers[0].livenessProbe.httpGet.path="/"' ./00-install.yaml
 $YQ e -i '.spec.template.spec.containers[0].livenessProbe.httpGet.port=8080' ./00-install.yaml
 $YQ e -i '.spec.template.spec.containers[0].livenessProbe.initialDelaySeconds=1' ./00-install.yaml
@@ -54,58 +77,100 @@ render_install_example "$example_name" "01"
 render_smoke_test_example "$example_name" "02"
 
 
+###############################################################################
+# TEST NAME: examples-collector-with-priority-class
+###############################################################################
 start_test "examples-collector-with-priority-class"
 example_name="collector-with-priority-class"
 render_install_example "$example_name" "00"
 render_smoke_test_example "$example_name" "01"
 
 
+###############################################################################
+# TEST NAME: examples-service-types
+###############################################################################
 start_test "examples-service-types"
 example_name="service-types"
 render_install_example "$example_name" "00"
 render_smoke_test_example "$example_name" "01"
 
 
+###############################################################################
+# TEST NAME: examples-simple-prod
+###############################################################################
 start_test "examples-simple-prod"
 example_name="simple-prod"
-render_install_elasticsearch "upstream" "00"
 render_install_example "$example_name" "01"
+if [[ $IS_OPENSHIFT = true && $SKIP_ES_EXTERNAL = true ]]; then
+    $YQ e -i '.spec.storage.options={}' ./01-install.yaml
+    $YQ e -i '.spec.storage.elasticsearch={"nodeCount":1,"resources":{"limits":{"memory":"2Gi"}}}' ./01-install.yaml
+else
+    render_install_elasticsearch "upstream" "00"
+fi
 render_smoke_test_example "$example_name" "02"
 
 
+###############################################################################
+# TEST NAME: examples-simple-prod-with-volumes
+###############################################################################
 start_test "examples-simple-prod-with-volumes"
 example_name="simple-prod-with-volumes"
-render_install_elasticsearch "upstream" "00"
 render_install_example "$example_name" "01"
+if [[ $IS_OPENSHIFT = true && $SKIP_ES_EXTERNAL = true ]]; then
+    $YQ e -i '.spec.storage.options={}' ./01-install.yaml
+    $YQ e -i '.spec.storage.elasticsearch={"nodeCount":1,"resources":{"limits":{"memory":"2Gi"}}}' ./01-install.yaml
+else
+    render_install_elasticsearch "upstream" "00"
+fi
 render_smoke_test_example "$example_name" "02"
 $GOMPLATE -f ./03-check-volume.yaml.template -o 03-check-volume.yaml
 
 
+###############################################################################
+# TEST NAME: examples-simplest
+###############################################################################
 start_test "examples-simplest"
 example_name="simplest"
 render_install_example "$example_name" "00"
 render_smoke_test_example "$example_name" "01"
 
 
+###############################################################################
+# TEST NAME: examples-with-badger
+###############################################################################
 start_test "examples-with-badger"
 example_name="with-badger"
 render_install_example "$example_name" "00"
 render_smoke_test_example "$example_name" "01"
 
 
+###############################################################################
+# TEST NAME: examples-with-badger-and-volume
+###############################################################################
 start_test "examples-with-badger-and-volume"
 example_name="with-badger-and-volume"
 render_install_example "$example_name" "00"
 render_smoke_test_example "$example_name" "01"
 
 
+###############################################################################
+# TEST NAME: examples-with-cassandra
+###############################################################################
 start_test "examples-with-cassandra"
 example_name="with-cassandra"
 render_install_cassandra "00"
 render_install_example "$example_name" "01"
+# jaeger-cassandra-schema multi arch image is not available
+# created a PR: https://github.com/jaegertracing/jaeger/pull/4122 and https://github.com/jaegertracing/jaeger/pull/4123
+# until we get new release image, this is a workaround image
+# $YQ e -i '.spec.storage.cassandraCreateSchema.image = "quay.io/redhat-distributed-tracing-qe/jaeger-cassandra-schema:1.40.0"' ./01-install.yaml
+
 render_smoke_test_example "$example_name" "02"
 
 
+###############################################################################
+# TEST NAME: examples-with-sampling
+###############################################################################
 start_test "examples-with-sampling"
 export example_name="with-sampling"
 render_install_cassandra "00"

--- a/tests/e2e/examples/render.sh
+++ b/tests/e2e/examples/render.sh
@@ -32,7 +32,11 @@ render_install_example "$example_name" "00"
 $YQ e -i '.metadata.name="my-jaeger"' ./00-install.yaml
 $YQ e -i 'del(.spec.allInOne.image)' ./00-install.yaml
 render_smoke_test_example "$example_name" "01"
-sed -i "s~my-jaeger-query~my-jaeger-query/jaeger~gi" ./01-smoke-test.yaml
+if [ $IS_OPENSHIFT = true ]; then
+    sed -i "s~my-jaeger-query:443~my-jaeger-query:443/jaeger~gi" ./01-smoke-test.yaml
+else
+    sed -i "s~my-jaeger-query:16686~my-jaeger-query:16686/jaeger~gi" ./01-smoke-test.yaml
+fi
 
 
 ###############################################################################

--- a/tests/e2e/examples/render.sh
+++ b/tests/e2e/examples/render.sh
@@ -160,11 +160,6 @@ start_test "examples-with-cassandra"
 example_name="with-cassandra"
 render_install_cassandra "00"
 render_install_example "$example_name" "01"
-# jaeger-cassandra-schema multi arch image is not available
-# created a PR: https://github.com/jaegertracing/jaeger/pull/4122 and https://github.com/jaegertracing/jaeger/pull/4123
-# until we get new release image, this is a workaround image
-# $YQ e -i '.spec.storage.cassandraCreateSchema.image = "quay.io/redhat-distributed-tracing-qe/jaeger-cassandra-schema:1.40.0"' ./01-install.yaml
-
 render_smoke_test_example "$example_name" "02"
 
 

--- a/tests/e2e/generate/render.sh
+++ b/tests/e2e/generate/render.sh
@@ -2,14 +2,18 @@
 
 source $(dirname "$0")/../render-utils.sh
 
+is_secured="false"
 if [ $IS_OPENSHIFT = true ]; then
-    skip_test "generate" "This test was skipped until https://github.com/jaegertracing/jaeger-operator/issues/1278 is fixed"
-else
-    start_test "generate"
-    # JAEGER_VERSION environment variable is set before this script is called
-    jaeger_name="my-jaeger"
-
-    $GOMPLATE -f ./jaeger-template.yaml.template -o ./jaeger-deployment.yaml
-
-    render_smoke_test "$jaeger_name" "false" "01"
+    is_secured="true"
 fi
+
+###############################################################################
+# TEST NAME: generate
+###############################################################################
+start_test "generate"
+# JAEGER_VERSION environment variable is set before this script is called
+jaeger_name="my-jaeger"
+
+$GOMPLATE -f ./jaeger-template.yaml.template -o ./jaeger-deployment.yaml
+
+render_smoke_test "$jaeger_name" is_secured "01"

--- a/tests/e2e/generate/render.sh
+++ b/tests/e2e/generate/render.sh
@@ -16,4 +16,4 @@ jaeger_name="my-jaeger"
 
 $GOMPLATE -f ./jaeger-template.yaml.template -o ./jaeger-deployment.yaml
 
-render_smoke_test "$jaeger_name" is_secured "01"
+render_smoke_test "$jaeger_name" "$is_secured" "01"

--- a/tests/e2e/render-utils.sh
+++ b/tests/e2e/render-utils.sh
@@ -35,7 +35,7 @@ function render_smoke_test() {
 
     if [ $is_secured = true ]; then
         protocol="https://"
-        query_port=""
+        query_port=":443"
         template="$TEMPLATES_DIR/openshift/smoke-test.yaml.template"
     elif [ $is_secured = false ]; then
         protocol="http://"

--- a/tests/e2e/render-utils.sh
+++ b/tests/e2e/render-utils.sh
@@ -82,7 +82,7 @@ function render_otlp_smoke_test() {
 
     if [ $is_secured = true ]; then
         protocol="https://"
-        query_port=""
+        query_port=":443"
         template="$TEMPLATES_DIR/openshift/otlp-smoke-test.yaml.template"
     else
         protocol="http://"
@@ -97,7 +97,7 @@ function render_otlp_smoke_test() {
     fi
 
     export JAEGER_QUERY_ENDPOINT="$protocol$jaeger-query$query_port"
-    export OTEL_EXPORTER_OTLP_ENDPOINT="$protocol$jaeger-collector-headless$reporting_port"
+    export OTEL_EXPORTER_OTLP_ENDPOINT="http://$jaeger-collector-headless$reporting_port"
     export JAEGER_NAME=$jaeger
 
     REPORTING_PROTOCOL=$reporting_protocol $GOMPLATE -f $template -o ./$test_step-smoke-test.yaml

--- a/tests/e2e/sidecar/render.sh
+++ b/tests/e2e/sidecar/render.sh
@@ -5,6 +5,9 @@ source $(dirname "$0")/../render-utils.sh
 # This Jaeger service name is the one used by vertx
 jaeger_service_name="order"
 
+###############################################################################
+# TEST NAME: sidecar-deployment
+###############################################################################
 start_test "sidecar-deployment"
 render_install_vertx "01"
 # Check Jaeger is receiving spans
@@ -14,6 +17,9 @@ render_find_service "agent-as-sidecar" "allInOne" "$jaeger_service_name" "00" "0
 render_find_service "agent-as-sidecar2" "allInOne" "$jaeger_service_name" "01" "06"
 
 
+###############################################################################
+# TEST NAME: sidecar-namespace
+###############################################################################
 start_test "sidecar-namespace"
 render_install_vertx "01"
 # After removing the first Jaeger instance, we should be able to continue
@@ -23,5 +29,8 @@ render_find_service "agent-as-sidecar" "allInOne" "$jaeger_service_name" "00" "0
 render_find_service "agent-as-sidecar2" "allInOne" "$jaeger_service_name" "01" "06"
 
 
+###############################################################################
+# TEST NAME: sidecar-skip-webhook
+###############################################################################
 start_test "sidecar-skip-webhook"
 render_install_vertx "01"

--- a/tests/e2e/streaming/Makefile
+++ b/tests/e2e/streaming/Makefile
@@ -1,5 +1,8 @@
 render-e2e-tests-streaming: load-assert-job load-elasticsarch-image
-	$(VECHO)KAFKA_VERSION=$(KAFKA_VERSION) ./tests/e2e/streaming/render.sh
+	$(VECHO) KAFKA_VERSION=$(KAFKA_VERSION) \
+		SKIP_KAFKA=$(SKIP_KAFKA) \
+		SKIP_ES_EXTERNAL=$(SKIP_ES_EXTERNAL) \
+		./tests/e2e/streaming/render.sh
 
 run-e2e-tests-streaming:
 	$(VECHO)KAFKA_OLM=$(KAFKA_OLM) ./hack/run-e2e-test-suite.sh streaming $(USE_KIND_CLUSTER) $(JAEGER_OLM)

--- a/tests/e2e/streaming/render.sh
+++ b/tests/e2e/streaming/render.sh
@@ -8,40 +8,61 @@ if [ $IS_OPENSHIFT = true ]; then
 fi
 
 
-start_test "streaming-simple"
-render_install_kafka "my-cluster" "00"
-render_install_elasticsearch "upstream" "01"
-JAEGER_NAME="simple-streaming" $GOMPLATE -f $TEMPLATES_DIR/streaming-jaeger-assert.yaml.template -o ./04-assert.yaml
-render_smoke_test "simple-streaming" "$is_secured" "05"
-
-
-start_test "streaming-with-tls"
-render_install_kafka "my-cluster" "00"
-render_install_elasticsearch "upstream" "03"
-render_smoke_test "tls-streaming" "$is_secured" "05"
-
-
-start_test "streaming-with-autoprovisioning-autoscale"
-if [ $IS_OPENSHIFT = true ]; then
-    # Remove the installation of the operator
-    rm ./00-install.yaml ./00-assert.yaml
+###############################################################################
+# TEST NAME: streaming-simple
+###############################################################################
+if [ $SKIP_KAFKA = true ]; then
+    skip_test "streaming-simple" "SKIP_KAFKA is true"
+else
+    start_test "streaming-simple"
+    render_install_kafka "my-cluster" "00"
+    render_install_elasticsearch "upstream" "01"
+    JAEGER_NAME="simple-streaming" $GOMPLATE -f $TEMPLATES_DIR/streaming-jaeger-assert.yaml.template -o ./04-assert.yaml
+    render_smoke_test "simple-streaming" "$is_secured" "05"
 fi
 
-render_install_elasticsearch "upstream" "01"
 
-jaeger_name="auto-provisioned"
-# Change the resource limits for the autoprovisioned deployment
-$YQ e -i '.spec.ingester.resources.requests.memory="20Mi"' ./02-install.yaml
-$YQ e -i '.spec.ingester.resources.requests.memory="500m"' ./02-install.yaml
+###############################################################################
+# TEST NAME: streaming-with-tls
+###############################################################################
+if [ $SKIP_KAFKA = true ]; then
+    skip_test "streaming-with-tls" "SKIP_KAFKA is true"
+else
+    start_test "streaming-with-tls"
+    render_install_kafka "my-cluster" "00"
+    render_install_elasticsearch "upstream" "03"
+    render_smoke_test "tls-streaming" "$is_secured" "05"
+fi
 
-# Enable autoscale
-$YQ e -i '.spec.ingester.autoscale=true' ./02-install.yaml
-$YQ e -i '.spec.ingester.minReplicas=1' ./02-install.yaml
-$YQ e -i '.spec.ingester.maxReplicas=2' ./02-install.yaml
 
-# Assert the autoprovisioned Kafka deployment
-render_assert_kafka "true" "$jaeger_name" "03"
+###############################################################################
+# TEST NAME: streaming-with-autoprovisioning-autoscale
+###############################################################################
+if [ $SKIP_KAFKA = true ]; then
+    skip_test "streaming-with-autoprovisioning-autoscale" "SKIP_KAFKA is true"
+else
+    start_test "streaming-with-autoprovisioning-autoscale"
+    if [ $IS_OPENSHIFT = true ]; then
+        # Remove the installation of the operator
+        rm ./00-install.yaml ./00-assert.yaml
+    fi
 
-# Create the tracegen deployment
-# Deploy Tracegen instance to generate load in the Jaeger collector
-render_install_tracegen "$jaeger_name" "06"
+    render_install_elasticsearch "upstream" "01"
+
+    jaeger_name="auto-provisioned"
+    # Change the resource limits for the autoprovisioned deployment
+    $YQ e -i '.spec.ingester.resources.requests.memory="20Mi"' ./02-install.yaml
+    $YQ e -i '.spec.ingester.resources.requests.memory="500m"' ./02-install.yaml
+
+    # Enable autoscale
+    $YQ e -i '.spec.ingester.autoscale=true' ./02-install.yaml
+    $YQ e -i '.spec.ingester.minReplicas=1' ./02-install.yaml
+    $YQ e -i '.spec.ingester.maxReplicas=2' ./02-install.yaml
+
+    # Assert the autoprovisioned Kafka deployment
+    render_assert_kafka "true" "$jaeger_name" "03"
+
+    # Create the tracegen deployment
+    # Deploy Tracegen instance to generate load in the Jaeger collector
+    render_install_tracegen "$jaeger_name" "06"
+fi

--- a/tests/e2e/ui/render.sh
+++ b/tests/e2e/ui/render.sh
@@ -2,7 +2,9 @@
 
 source $(dirname "$0")/../render-utils.sh
 
-
+###############################################################################
+# TEST NAME: allinone
+###############################################################################
 start_test "allinone"
 export GET_URL_COMMAND
 export URL
@@ -31,12 +33,19 @@ EXPECTED_CODE="200" $GOMPLATE -f $TEMPLATES_DIR/assert-http-code.yaml.template -
 ASSERT_PRESENT="true" TRACKING_ID="MyTrackingId" $GOMPLATE -f $TEMPLATES_DIR/test-ui-config.yaml.template -o ./04-test-ui-config.yaml
 
 
-
+###############################################################################
+# TEST NAME: production
+###############################################################################
 start_test "production"
 export JAEGER_NAME="production-ui"
 
-render_install_elasticsearch "upstream" "00"
-render_install_jaeger $JAEGER_NAME "production" "01"
+if [[ $IS_OPENSHIFT = true && $SKIP_ES_EXTERNAL = true ]]; then
+    render_install_jaeger $JAEGER_NAME "production_autoprovisioned" "01"
+else
+    render_install_elasticsearch "upstream" "00"
+    render_install_jaeger $JAEGER_NAME "production" "01"
+fi
+
 
 # Sometimes, the Ingress/OpenShift route is there but not 100% ready so, when
 # kubectl tries to get the hostname, it returns an empty string

--- a/tests/e2e/upgrade/render.sh
+++ b/tests/e2e/upgrade/render.sh
@@ -28,7 +28,7 @@ else
     $GOMPLATE -f ./remove-jaeger-operator.yaml.template -o ./00-remove-operator.yaml
 
     # Download the latest Jaeger Operator released manifest and install it
-    LATEST_VERSION=$(curl -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/jaegertracing/jaeger-operator/releases/latest | $YQ -P ".tag_name"| grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')
+    LATEST_VERSION=$(curl --max-time 5 --retry 5 -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/jaegertracing/jaeger-operator/releases/latest | $YQ -P ".tag_name" | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+')
     wget -q https://github.com/jaegertracing/jaeger-operator/releases/download/v$LATEST_VERSION/jaeger-operator.yaml
 
     if version_gt $LATEST_VERSION "1.35.0"; then

--- a/tests/templates/vertex-install.yaml.template
+++ b/tests/templates/vertex-install.yaml.template
@@ -14,18 +14,18 @@ spec:
     spec:
       containers:
         - name: vertx-create-span-sidecar
-          image: "jaegertracing/vertx-create-span:operator-e2e-tests"
+          image: "{{ .Env.VERTX_IMG }}"
           ports:
             - containerPort: 8080
           readinessProbe:
             httpGet:
               path: "/"
               port: 8080
-            initialDelaySeconds: 1
+            initialDelaySeconds: 7
             periodSeconds: 1
           livenessProbe:
             httpGet:
               path: "/"
               port: 8080
-            initialDelaySeconds: 1
+            initialDelaySeconds: 7
             periodSeconds: 1


### PR DESCRIPTION
## Which problem is this PR solving?
- Currently e2e tests are not supported to run on non `x86_64` environment. due to lack of other dependent operator/images support
- Needs environment variables to filter required tests to run on a target platform. able to skip some of the tests which we can not run on the target platform at this time.

## Short description of the changes
- Introduced `SKIP_KAFKA` environment variable to skip kafka/streaming related tests. default: enabled
- Updated the code to react for `SKIP_ES_EXTERNAL` variable. In Openshift if `SKIP_ES_EXTERNAL` enabled, uses self provision Elasticsearch node.
- Updated to react for custom `VERTX_IMG` variable
