### PR TITLE
Disable generate E2E test in OCP

### DIFF
--- a/tests/e2e/generate/render.sh
+++ b/tests/e2e/generate/render.sh
@@ -2,18 +2,17 @@
 
 source $(dirname "$0")/../render-utils.sh
 
-is_secured="false"
-if [ $IS_OPENSHIFT = true ]; then
-    is_secured="true"
-fi
-
 ###############################################################################
 # TEST NAME: generate
 ###############################################################################
-start_test "generate"
-# JAEGER_VERSION environment variable is set before this script is called
-jaeger_name="my-jaeger"
+if [ $IS_OPENSHIFT = true ]; then
+    skip_test "generate" "This test was skipped until https://github.com/jaegertracing/jaeger-operator/issues/2145 is fixed"
+else
+    start_test "generate"
+    # JAEGER_VERSION environment variable is set before this script is called
+    jaeger_name="my-jaeger"
 
-$GOMPLATE -f ./jaeger-template.yaml.template -o ./jaeger-deployment.yaml
+    $GOMPLATE -f ./jaeger-template.yaml.template -o ./jaeger-deployment.yaml
 
-render_smoke_test "$jaeger_name" "$is_secured" "01"
+    render_smoke_test "$jaeger_name" "false" "01"
+fi


### PR DESCRIPTION
Signed-off-by: Israel Blancas <iblancasa@gmail.com>

Disable `generate` E2E test due to #2145.