### PR TITLE
update operator-sdk to 1.27.0

### DIFF
--- a/.github/workflows/base-checks.yaml
+++ b/.github/workflows/base-checks.yaml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18
+        go-version: 1.19
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18
+        go-version: 1.19
 
     - uses: actions/checkout@v3
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,12 +1,12 @@
 run:
-  go: '1.18'
+  go: '1.19'
   timeout: 10m
 
 linters-settings:
   goimports:
     local-prefixes: github.com/jaegertracing/jaeger-operator
   gosimple:
-    go: "1.18"
+    go: "1.19"
 
 linters:
   enable:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.18 as builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.19 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/Dockerfile.asserts
+++ b/Dockerfile.asserts
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.18 as builder
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.19 as builder
 
 WORKDIR /workspace
 

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ CERTMANAGER_VERSION ?= 1.6.1
 CMCTL ?= $(LOCALBIN)/cmctl
 # Operator SDK
 OPERATOR_SDK ?= $(LOCALBIN)/operator-sdk
-OPERATOR_SDK_VERSION ?= 1.23.0
+OPERATOR_SDK_VERSION ?= 1.27.0
 # Use a KIND cluster for the E2E tests
 USE_KIND_CLUSTER ?= true
  # Is Jaeger Operator installed via OLM?
@@ -167,7 +167,7 @@ endif
 .PHONY: unit-tests
 unit-tests: envtest
 	@echo Running unit tests...
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test -p 1 ${GOTEST_OPTS} ./... -cover -coverprofile=cover.out -ldflags $(LD_FLAGS)
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -p 1 ${GOTEST_OPTS} ./... -cover -coverprofile=cover.out -ldflags $(LD_FLAGS)
 
 .PHONY: set-node-os-linux
 set-node-os-linux:
@@ -353,6 +353,7 @@ bundle: manifests kustomize operator-sdk ## Generate bundle manifests and metada
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle -q --overwrite --manifests --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 	$(OPERATOR_SDK) bundle validate ./bundle
+	./hack/ignore-createdAt-bundle.sh
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.

--- a/bundle/manifests/jaeger-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/jaeger-operator.clusterserviceversion.yaml
@@ -23,7 +23,7 @@ metadata:
     description: Provides tracing, monitoring and troubleshooting for microservices-based
       distributed systems
     operators.openshift.io/infrastructure-features: '["disconnected"]'
-    operators.operatorframework.io/builder: operator-sdk-v1.23.0
+    operators.operatorframework.io/builder: operator-sdk-v1.27.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/jaegertracing/jaeger-operator
     support: Jaeger Community

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jaegertracing/jaeger-operator
 
-go 1.18
+go 1.19
 
 require (
 	github.com/Masterminds/semver v1.5.0

--- a/hack/actions/e2e/action.yaml
+++ b/hack/actions/e2e/action.yaml
@@ -23,7 +23,7 @@ runs:
     - name: "Set up Go"
       uses: actions/setup-go@v2.1.4
       with:
-        go-version: 1.18
+        go-version: 1.19
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
       with:

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -9,3 +9,4 @@ export EXAMPLES_DIR=$ROOT_DIR/examples
 export GOMPLATE=$ROOT_DIR/bin/gomplate
 export YQ=$ROOT_DIR/bin/yq
 export KUTTL=$ROOT_DIR/bin/kubectl-kuttl
+export KUSTOMIZE=$ROOT_DIR/bin/kustomize

--- a/hack/ignore-createdAt-bundle.sh
+++ b/hack/ignore-createdAt-bundle.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Since operator-sdk 1.26.0, `make bundle` changes the `createdAt` field from the bundle
+# even if it is patched:
+#   https://github.com/operator-framework/operator-sdk/pull/6136
+# This code checks if only the createdAt field. If is the only change, it is ignored.
+# Else, it will do nothing.
+# https://github.com/operator-framework/operator-sdk/issues/6285#issuecomment-1415350333
+git diff --quiet -I'^    createdAt: ' bundle
+if ((! $?)) ; then
+    git checkout bundle
+fi

--- a/hack/install/install-kustomize.sh
+++ b/hack/install/install-kustomize.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-VERSION="4.2.0"
+VERSION="4.5.7"
 
 echo "Installing kustomize"
 

--- a/tests/e2e/miscellaneous/non-cluster-wide/00-errors.yaml
+++ b/tests/e2e/miscellaneous/non-cluster-wide/00-errors.yaml
@@ -1,0 +1,7 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jaeger-operator
+  namespace: observability
+status:
+  readyReplicas: 1

--- a/tests/e2e/miscellaneous/non-cluster-wide/00-undeploy.yaml.template
+++ b/tests/e2e/miscellaneous/non-cluster-wide/00-undeploy.yaml.template
@@ -1,0 +1,12 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  # Before executing the KUTTL tests, the Jaeger Operator is deployed in the
+  # observability namespace. To run this test, we modify that
+  # deployment to watch only in certain namespaces
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  # Before executing the KUTTL tests, the Jaeger Operator is deployed in the
+  # observability namespace. We remove it to deploy it later
+  - script: "cd {{ .Env.ROOT_DIR }} && make undeploy ignore-not-found=true"

--- a/tests/e2e/miscellaneous/non-cluster-wide/01-install.yaml.template
+++ b/tests/e2e/miscellaneous/non-cluster-wide/01-install.yaml.template
@@ -7,11 +7,6 @@ commands:
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  # Before executing the KUTTL tests, the Jaeger Operator is deployed in the
-  # observability namespace. To run this test, we modify that
-  # deployment to watch only in certain namespaces
-  - script: "cd {{ .Env.ROOT_DIR }} && make undeploy"
+  # To run this test, we modify the operator to only run and look in this namespace
   - script: "cd {{ .Env.ROOT_DIR }}/config/default && {{ .Env.KUSTOMIZE }} edit set namespace $NAMESPACE"
-  - script: "cd {{ .Env.ROOT_DIR }} && {{ .Env.KUSTOMIZE }} build config/namespaced > {{ .Env.ROOT_DIR }}/new_config.yaml"
-  - script: "cat {{ .Env.ROOT_DIR }}/new_config.yaml"
-  - script: "kubectl apply -f {{ .Env.ROOT_DIR }}/new_config.yaml"
+  - script: "cd {{ .Env.ROOT_DIR }} && {{ .Env.KUSTOMIZE }} build config/namespaced | kubectl apply -f - -n $NAMESPACE"

--- a/tests/e2e/miscellaneous/non-cluster-wide/01-install.yaml.template
+++ b/tests/e2e/miscellaneous/non-cluster-wide/01-install.yaml.template
@@ -11,7 +11,7 @@ commands:
   # observability namespace. To run this test, we modify that
   # deployment to watch only in certain namespaces
   - script: "cd {{ .Env.ROOT_DIR }} && make undeploy"
-  - script: "cd {{ .Env.ROOT_DIR }}/config/default && kustomize edit set namespace $NAMESPACE"
-  - script: "cd {{ .Env.ROOT_DIR }} && kustomize build config/namespaced > {{ .Env.ROOT_DIR }}/new_config.yaml"
+  - script: "cd {{ .Env.ROOT_DIR }}/config/default && {{ .Env.KUSTOMIZE }} edit set namespace $NAMESPACE"
+  - script: "cd {{ .Env.ROOT_DIR }} && {{ .Env.KUSTOMIZE }} build config/namespaced > {{ .Env.ROOT_DIR }}/new_config.yaml"
   - script: "cat {{ .Env.ROOT_DIR }}/new_config.yaml"
   - script: "kubectl apply -f {{ .Env.ROOT_DIR }}/new_config.yaml"

--- a/tests/e2e/miscellaneous/non-cluster-wide/01-install.yaml.template
+++ b/tests/e2e/miscellaneous/non-cluster-wide/01-install.yaml.template
@@ -4,4 +4,14 @@ commands:
   # Before executing the KUTTL tests, the Jaeger Operator is deployed in the
   # observability namespace. To run this test, we modify that
   # deployment to watch only in certain namespaces
-  - script: "cd {{ .Env.ROOT_DIR }} && make undeploy && cd config/default && kustomize edit set namespace $NAMESPACE && cd ../.. && kustomize build config/namespaced | kubectl apply -f - -n $NAMESPACE"
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  # Before executing the KUTTL tests, the Jaeger Operator is deployed in the
+  # observability namespace. To run this test, we modify that
+  # deployment to watch only in certain namespaces
+  - script: "cd {{ .Env.ROOT_DIR }} && make undeploy"
+  - script: "cd {{ .Env.ROOT_DIR }}/config/default && kustomize edit set namespace $NAMESPACE"
+  - script: "cd {{ .Env.ROOT_DIR }} && kustomize build config/namespaced > {{ .Env.ROOT_DIR }}/new_config.yaml"
+  - script: "cat {{ .Env.ROOT_DIR }}/new_config.yaml"
+  - script: "kubectl apply -f {{ .Env.ROOT_DIR }}/new_config.yaml"

--- a/tests/e2e/miscellaneous/non-cluster-wide/03-assert.yaml
+++ b/tests/e2e/miscellaneous/non-cluster-wide/03-assert.yaml
@@ -1,0 +1,7 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jaeger-operator
+  namespace: observability
+status:
+  readyReplicas: 1

--- a/tests/e2e/miscellaneous/non-cluster-wide/03-install.yaml.template
+++ b/tests/e2e/miscellaneous/non-cluster-wide/03-install.yaml.template
@@ -2,4 +2,6 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
   # Restore operator
-  - script: "cd {{ .Env.ROOT_DIR }} && kustomize build config/namespaced | kubectl delete -f - -n $NAMESPACE && cd config/default && kustomize edit set namespace observability && cd ../.. && make deploy"
+  - script: "cd {{ .Env.ROOT_DIR }} && {{ .Env.KUSTOMIZE }}  build config/namespaced | kubectl delete -f - -n $NAMESPACE"
+  - script: "cd {{ .Env.ROOT_DIR }}/config/default && {{ .Env.KUSTOMIZE }} edit set namespace observability"
+  - script: "cd {{ .Env.ROOT_DIR }} && make deploy"

--- a/tests/e2e/miscellaneous/render.sh
+++ b/tests/e2e/miscellaneous/render.sh
@@ -152,6 +152,7 @@ if [ $IS_OPENSHIFT = true ]; then
     skip_test "non-cluster-wide" "Test not supported in OpenShift"
 else
     start_test "non-cluster-wide"
+    $GOMPLATE -f ./00-undeploy.yaml.template -o 00-undeploy.yaml
     $GOMPLATE -f ./01-install.yaml.template -o 01-install.yaml
     jaeger_name="my-jaeger"
     render_install_jaeger "$jaeger_name" "allInOne" "02"

--- a/tests/e2e/render-utils.sh
+++ b/tests/e2e/render-utils.sh
@@ -888,6 +888,7 @@ export SUITE_DIR=$(dirname "$0")
 # Check the dependencies are there
 $ROOT_DIR/hack/install/install-gomplate.sh
 $ROOT_DIR/hack/install/install-yq.sh
+$ROOT_DIR/hack/install/install-kustomize.sh
 
 
 # Elasticsearch settings


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #2177

## Short description of the changes
- Bump the `operator-sdk` version to `1.27.0`
- Add all the required changes to make the version work


> **Note**
> Some other changes are requested in #2177. These will be addressed in another PR

