### PR TITLE
Add PriorityClass for AllInOne strategy

### DIFF
--- a/apis/v1/jaeger_types.go
+++ b/apis/v1/jaeger_types.go
@@ -404,6 +404,9 @@ type JaegerAllInOneSpec struct {
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Strategy"
 	Strategy *appsv1.DeploymentStrategy `json:"strategy,omitempty"`
+
+	// +optional
+	PriorityClassName string `json:"priorityClassName,omitempty"`
 }
 
 // AutoScaleSpec defines the common elements used for create HPAs

--- a/bundle/manifests/jaegertracing.io_jaegers.yaml
+++ b/bundle/manifests/jaegertracing.io_jaegers.yaml
@@ -2423,6 +2423,8 @@ spec:
                   options:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
+                  priorityClassName:
+                    type: string
                   resources:
                     nullable: true
                     properties:

--- a/config/crd/bases/jaegertracing.io_jaegers.yaml
+++ b/config/crd/bases/jaegertracing.io_jaegers.yaml
@@ -2421,6 +2421,8 @@ spec:
                   options:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
+                  priorityClassName:
+                    type: string
                   resources:
                     nullable: true
                     properties:

--- a/docs/api.md
+++ b/docs/api.md
@@ -7313,6 +7313,13 @@ Resource Types:
         </td>
         <td>false</td>
       </tr><tr>
+        <td><b>priorityClassName</b></td>
+        <td>string</td>
+        <td>
+          <br/>
+        </td>
+        <td>false</td>
+      </tr><tr>
         <td><b><a href="#jaegerspecallinoneresources">resources</a></b></td>
         <td>object</td>
         <td>

--- a/examples/all-in-one-with-priority-class.yaml
+++ b/examples/all-in-one-with-priority-class.yaml
@@ -1,0 +1,17 @@
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: high-priority # priorityClassName here
+value: 1000000
+globalDefault: false
+description: "This priority class should be used for XYZ service pods only."
+---
+apiVersion: jaegertracing.io/v1
+kind: "Jaeger"
+metadata:
+  name: "my-jaeger"
+spec:
+  strategy: allInOne
+  allInOne:
+    image: jaegertracing/all-in-one:1.30.0
+    priorityClassName: high-priority # priorityClassName here

--- a/pkg/deployment/all_in_one.go
+++ b/pkg/deployment/all_in_one.go
@@ -113,6 +113,11 @@ func (a *AllInOne) Get() *appsv1.Deployment {
 		strategy = *a.jaeger.Spec.AllInOne.Strategy
 	}
 
+	priorityClassName := ""
+	if a.jaeger.Spec.Collector.PriorityClassName != "" {
+		priorityClassName = a.jaeger.Spec.Collector.PriorityClassName
+	}
+
 	livenessProbe := &corev1.Probe{
 		ProbeHandler: corev1.ProbeHandler{
 			HTTPGet: &corev1.HTTPGetAction{
@@ -246,6 +251,7 @@ func (a *AllInOne) Get() *appsv1.Deployment {
 						ImagePullPolicy: commonSpec.ImagePullPolicy,
 						SecurityContext: commonSpec.ContainerSecurityContext,
 					}},
+					PriorityClassName:  priorityClassName,
 					Volumes:            commonSpec.Volumes,
 					ServiceAccountName: account.JaegerServiceAccountFor(a.jaeger, account.AllInOneComponent),
 					Affinity:           commonSpec.Affinity,

--- a/pkg/deployment/all_in_one.go
+++ b/pkg/deployment/all_in_one.go
@@ -114,8 +114,8 @@ func (a *AllInOne) Get() *appsv1.Deployment {
 	}
 
 	priorityClassName := ""
-	if a.jaeger.Spec.Collector.PriorityClassName != "" {
-		priorityClassName = a.jaeger.Spec.Collector.PriorityClassName
+	if a.jaeger.Spec.AllInOne.PriorityClassName != "" {
+		priorityClassName = a.jaeger.Spec.AllInOne.PriorityClassName
 	}
 
 	livenessProbe := &corev1.Probe{

--- a/pkg/deployment/all_in_one_test.go
+++ b/pkg/deployment/all_in_one_test.go
@@ -598,6 +598,15 @@ func TestAllInOneContainerSecurityContextOverride(t *testing.T) {
 	assert.Equal(t, overrideSecurityContextVar, *dep.Spec.Template.Spec.Containers[0].SecurityContext)
 }
 
+func TestAllInOnePriorityClassName(t *testing.T) {
+	priorityClassName := "test-class"
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
+	jaeger.Spec.AllInOne.PriorityClassName = "priorityClassName"
+	a := NewAllInOne(jaeger)
+	dep := a.Get()
+	assert.Equal(t, priorityClassName, dep.Spec.Template.Spec.PriorityClassName)
+}
+
 func getEnvVarByName(vars []corev1.EnvVar, name string) corev1.EnvVar {
 	envVar := corev1.EnvVar{}
 	for _, v := range vars {

--- a/pkg/deployment/all_in_one_test.go
+++ b/pkg/deployment/all_in_one_test.go
@@ -601,7 +601,7 @@ func TestAllInOneContainerSecurityContextOverride(t *testing.T) {
 func TestAllInOnePriorityClassName(t *testing.T) {
 	priorityClassName := "test-class"
 	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
-	jaeger.Spec.AllInOne.PriorityClassName = "priorityClassName"
+	jaeger.Spec.AllInOne.PriorityClassName = priorityClassName
 	a := NewAllInOne(jaeger)
 	dep := a.Get()
 	assert.Equal(t, priorityClassName, dep.Spec.Template.Spec.PriorityClassName)


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #1601

## Short description of the changes
- Add PriorityClass capability for allinone strategy; includes unit test & example
- Please note that the make generate api path was changed to './apis/v1' in order to run the command.
