### PR TITLE
Expose admin ports for agent, collector, and query Deployments via the equivalent Service

### DIFF
--- a/pkg/service/agent.go
+++ b/pkg/service/agent.go
@@ -13,6 +13,10 @@ func NewAgentService(jaeger *v1.Jaeger, selector map[string]string) *corev1.Serv
 	trueVar := true
 	name := util.DNSName(util.Truncate("%s-agent", 63, jaeger.Name))
 
+	args := jaeger.Spec.Agent.Options.ToArgs()
+
+	adminPort := util.GetAdminPort(args, 14271)
+
 	return &corev1.Service{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Service",
@@ -54,6 +58,10 @@ func NewAgentService(jaeger *v1.Jaeger, selector map[string]string) *corev1.Serv
 					Name:     "jg-binary-trft",
 					Port:     6832,
 					Protocol: corev1.ProtocolUDP,
+				},
+				{
+					Name: "admin-http",
+					Port: adminPort,
 				},
 			},
 		},

--- a/pkg/service/agent_test.go
+++ b/pkg/service/agent_test.go
@@ -19,10 +19,11 @@ func TestAgentServiceNameAndPorts(t *testing.T) {
 	assert.Equal(t, "testagentservicenameandports-agent", svc.ObjectMeta.Name)
 
 	ports := map[int32]bool{
-		5775: false,
-		5778: false,
-		6831: false,
-		6832: false,
+		5775:  false,
+		5778:  false,
+		6831:  false,
+		6832:  false,
+		14271: false,
 	}
 
 	for _, port := range svc.Spec.Ports {

--- a/pkg/service/collector.go
+++ b/pkg/service/collector.go
@@ -39,6 +39,10 @@ func clusteripCollectorService(jaeger *v1.Jaeger, selector map[string]string) *c
 
 func collectorService(jaeger *v1.Jaeger, selector map[string]string) *corev1.Service {
 	trueVar := true
+
+	args := jaeger.Spec.Collector.Options.ToArgs()
+	adminPort := util.GetAdminPort(args, 14269)
+
 	ports := []corev1.ServicePort{
 		{
 			Name: "http-zipkin",
@@ -55,6 +59,10 @@ func collectorService(jaeger *v1.Jaeger, selector map[string]string) *corev1.Ser
 		{
 			Name: "http-c-binary-trft",
 			Port: 14268,
+		},
+		{
+			Name: "admin-http",
+			Port: adminPort,
 		},
 	}
 

--- a/pkg/service/collector_test.go
+++ b/pkg/service/collector_test.go
@@ -26,6 +26,7 @@ func TestCollectorServiceNameAndPorts(t *testing.T) {
 		14250: false,
 		14267: false,
 		14268: false,
+		14269: false,
 	}
 
 	svc := svcs[0]

--- a/pkg/service/query.go
+++ b/pkg/service/query.go
@@ -21,6 +21,10 @@ func NewQueryService(jaeger *v1.Jaeger, selector map[string]string) *corev1.Serv
 		annotations["service.alpha.openshift.io/serving-cert-secret-name"] = GetTLSSecretNameForQueryService(jaeger)
 	}
 
+	args := jaeger.Spec.Query.Options.ToArgs()
+
+	adminPort := util.GetAdminPort(args, 16687)
+
 	ports := []corev1.ServicePort{
 		{
 			Name:       GetPortNameForQueryService(jaeger),
@@ -31,6 +35,11 @@ func NewQueryService(jaeger *v1.Jaeger, selector map[string]string) *corev1.Serv
 			Name:       "grpc-query",
 			Port:       int32(16685),
 			TargetPort: intstr.FromInt(16685),
+		},
+		{
+			Name:       "admin-http",
+			Port:       int32(adminPort),
+			TargetPort: intstr.FromInt(int(adminPort)),
 		},
 	}
 	if jaeger.Spec.Query.ServiceType == corev1.ServiceTypeNodePort {

--- a/pkg/service/query_test.go
+++ b/pkg/service/query_test.go
@@ -125,7 +125,7 @@ func TestQueryServiceSpecifiedNodePortWithIngress(t *testing.T) {
 	assert.Equal(t, "admin-http", svc.Spec.Ports[2].Name)
 	assert.Equal(t, int32(32767), svc.Spec.Ports[0].NodePort) // make sure we get the same NodePort as set above
 	assert.Equal(t, intstr.FromInt(16686), svc.Spec.Ports[0].TargetPort)
-	assert.Equal(t, intstr.FromInt(16687), svc.Spec.Ports[1].TargetPort)
+	assert.Equal(t, intstr.FromInt(16685), svc.Spec.Ports[1].TargetPort)
 	assert.Equal(t, intstr.FromInt(16687), svc.Spec.Ports[2].TargetPort)
 	assert.Equal(t, svc.Spec.Type, corev1.ServiceTypeNodePort)
 }

--- a/pkg/service/query_test.go
+++ b/pkg/service/query_test.go
@@ -20,9 +20,10 @@ func TestQueryServiceNameAndPorts(t *testing.T) {
 	svc := NewQueryService(jaeger, selector)
 
 	assert.Equal(t, "testqueryservicenameandports-query", svc.ObjectMeta.Name)
-	assert.Len(t, svc.Spec.Ports, 2)
+	assert.Len(t, svc.Spec.Ports, 3)
 	assert.Equal(t, int32(16686), svc.Spec.Ports[0].Port)
 	assert.Equal(t, int32(16685), svc.Spec.Ports[1].Port)
+	assert.Equal(t, int32(16687), svc.Spec.Ports[2].Port)
 	assert.Equal(t, "http-query", svc.Spec.Ports[0].Name)
 	assert.Equal(t, "grpc-query", svc.Spec.Ports[1].Name)
 	assert.Equal(t, intstr.FromInt(16686), svc.Spec.Ports[0].TargetPort)
@@ -50,7 +51,7 @@ func TestQueryServiceNameAndPortsWithOAuthProxy(t *testing.T) {
 	svc := NewQueryService(jaeger, selector)
 
 	assert.Equal(t, "testqueryservicenameandportswithoauthproxy-query", svc.ObjectMeta.Name)
-	assert.Len(t, svc.Spec.Ports, 2)
+	assert.Len(t, svc.Spec.Ports, 3)
 	assert.Equal(t, int32(443), svc.Spec.Ports[0].Port)
 	assert.Equal(t, int32(16685), svc.Spec.Ports[1].Port)
 	assert.Equal(t, "https-query", svc.Spec.Ports[0].Name)
@@ -66,9 +67,10 @@ func TestQueryServiceNodePortWithIngress(t *testing.T) {
 	svc := NewQueryService(jaeger, selector)
 
 	assert.Equal(t, "testqueryservicenodeportwithingress-query", svc.ObjectMeta.Name)
-	assert.Len(t, svc.Spec.Ports, 2)
+	assert.Len(t, svc.Spec.Ports, 3)
 	assert.Equal(t, int32(16686), svc.Spec.Ports[0].Port)
 	assert.Equal(t, int32(16685), svc.Spec.Ports[1].Port)
+	assert.Equal(t, int32(16687), svc.Spec.Ports[2].Port)
 	assert.Equal(t, "http-query", svc.Spec.Ports[0].Name)
 	assert.Equal(t, int32(0), svc.Spec.Ports[0].NodePort)
 	assert.Equal(t, int32(0), svc.Spec.Ports[1].NodePort)
@@ -85,9 +87,10 @@ func TestQueryServiceLoadBalancerWithIngress(t *testing.T) {
 	svc := NewQueryService(jaeger, selector)
 
 	assert.Equal(t, "testqueryservicenodeportwithingress-query", svc.ObjectMeta.Name)
-	assert.Len(t, svc.Spec.Ports, 2)
+	assert.Len(t, svc.Spec.Ports, 3)
 	assert.Equal(t, int32(16686), svc.Spec.Ports[0].Port)
 	assert.Equal(t, int32(16685), svc.Spec.Ports[1].Port)
+	assert.Equal(t, int32(16687), svc.Spec.Ports[2].Port)
 	assert.Equal(t, "http-query", svc.Spec.Ports[0].Name)
 	assert.Equal(t, "grpc-query", svc.Spec.Ports[1].Name)
 	assert.Equal(t, intstr.FromInt(16686), svc.Spec.Ports[0].TargetPort)
@@ -105,9 +108,10 @@ func TestQueryServiceSpecifiedNodePortWithIngress(t *testing.T) {
 	svc := NewQueryService(jaeger, selector)
 
 	assert.Equal(t, "testqueryservicespecifiednodeportwithingress-query", svc.ObjectMeta.Name)
-	assert.Len(t, svc.Spec.Ports, 2)
+	assert.Len(t, svc.Spec.Ports, 3)
 	assert.Equal(t, int32(16686), svc.Spec.Ports[0].Port)
 	assert.Equal(t, int32(16685), svc.Spec.Ports[1].Port)
+	assert.Equal(t, int32(16687), svc.Spec.Ports[2].Port)
 	assert.Equal(t, "http-query", svc.Spec.Ports[0].Name)
 	assert.Equal(t, int32(32767), svc.Spec.Ports[0].NodePort) // make sure we get the same NodePort as set above
 	assert.Equal(t, intstr.FromInt(16686), svc.Spec.Ports[0].TargetPort)
@@ -123,9 +127,10 @@ func TestQueryServiceSpecAnnotations(t *testing.T) {
 	svc := NewQueryService(jaeger, selector)
 
 	assert.Equal(t, "testqueryservicespecannotations-query", svc.ObjectMeta.Name)
-	assert.Len(t, svc.Spec.Ports, 2)
+	assert.Len(t, svc.Spec.Ports, 3)
 	assert.Equal(t, int32(16686), svc.Spec.Ports[0].Port)
 	assert.Equal(t, int32(16685), svc.Spec.Ports[1].Port)
+	assert.Equal(t, int32(16687), svc.Spec.Ports[2].Port)
 	assert.Equal(t, "http-query", svc.Spec.Ports[0].Name)
 	assert.Equal(t, intstr.FromInt(16686), svc.Spec.Ports[0].TargetPort)
 	assert.Equal(t, map[string]string{"component": "jaeger"}, svc.Annotations)

--- a/pkg/service/query_test.go
+++ b/pkg/service/query_test.go
@@ -79,6 +79,8 @@ func TestQueryServiceNodePortWithIngress(t *testing.T) {
 	assert.Equal(t, int32(0), svc.Spec.Ports[0].NodePort)
 	assert.Equal(t, int32(0), svc.Spec.Ports[1].NodePort)
 	assert.Equal(t, intstr.FromInt(16686), svc.Spec.Ports[0].TargetPort)
+	assert.Equal(t, intstr.FromInt(16685), svc.Spec.Ports[1].TargetPort)
+	assert.Equal(t, intstr.FromInt(16687), svc.Spec.Ports[2].TargetPort)
 	assert.Equal(t, svc.Spec.Type, corev1.ServiceTypeNodePort) // make sure we get a NodePort service
 }
 
@@ -100,6 +102,7 @@ func TestQueryServiceLoadBalancerWithIngress(t *testing.T) {
 	assert.Equal(t, "admin-http", svc.Spec.Ports[2].Name)
 	assert.Equal(t, intstr.FromInt(16686), svc.Spec.Ports[0].TargetPort)
 	assert.Equal(t, intstr.FromInt(16685), svc.Spec.Ports[1].TargetPort)
+	assert.Equal(t, intstr.FromInt(16687), svc.Spec.Ports[2].TargetPort)
 	assert.Equal(t, svc.Spec.Type, corev1.ServiceTypeLoadBalancer) // make sure we get a LoadBalancer service
 }
 
@@ -122,6 +125,8 @@ func TestQueryServiceSpecifiedNodePortWithIngress(t *testing.T) {
 	assert.Equal(t, "admin-http", svc.Spec.Ports[2].Name)
 	assert.Equal(t, int32(32767), svc.Spec.Ports[0].NodePort) // make sure we get the same NodePort as set above
 	assert.Equal(t, intstr.FromInt(16686), svc.Spec.Ports[0].TargetPort)
+	assert.Equal(t, intstr.FromInt(16687), svc.Spec.Ports[1].TargetPort)
+	assert.Equal(t, intstr.FromInt(16687), svc.Spec.Ports[2].TargetPort)
 	assert.Equal(t, svc.Spec.Type, corev1.ServiceTypeNodePort)
 }
 
@@ -142,5 +147,7 @@ func TestQueryServiceSpecAnnotations(t *testing.T) {
 	assert.Equal(t, "grpc-query", svc.Spec.Ports[1].Name)
 	assert.Equal(t, "admin-http", svc.Spec.Ports[2].Name)
 	assert.Equal(t, intstr.FromInt(16686), svc.Spec.Ports[0].TargetPort)
+	assert.Equal(t, intstr.FromInt(16685), svc.Spec.Ports[1].TargetPort)
+	assert.Equal(t, intstr.FromInt(16687), svc.Spec.Ports[2].TargetPort)
 	assert.Equal(t, map[string]string{"component": "jaeger"}, svc.Annotations)
 }

--- a/pkg/service/query_test.go
+++ b/pkg/service/query_test.go
@@ -26,8 +26,10 @@ func TestQueryServiceNameAndPorts(t *testing.T) {
 	assert.Equal(t, int32(16687), svc.Spec.Ports[2].Port)
 	assert.Equal(t, "http-query", svc.Spec.Ports[0].Name)
 	assert.Equal(t, "grpc-query", svc.Spec.Ports[1].Name)
+	assert.Equal(t, "admin-http", svc.Spec.Ports[2].Name)
 	assert.Equal(t, intstr.FromInt(16686), svc.Spec.Ports[0].TargetPort)
 	assert.Equal(t, intstr.FromInt(16685), svc.Spec.Ports[1].TargetPort)
+	assert.Equal(t, intstr.FromInt(16687), svc.Spec.Ports[2].TargetPort)
 	assert.Len(t, svc.Spec.ClusterIP, 0)                        // make sure we get a cluster IP
 	assert.Equal(t, svc.Spec.Type, corev1.ServiceTypeClusterIP) // make sure we get a ClusterIP service
 }
@@ -72,6 +74,8 @@ func TestQueryServiceNodePortWithIngress(t *testing.T) {
 	assert.Equal(t, int32(16685), svc.Spec.Ports[1].Port)
 	assert.Equal(t, int32(16687), svc.Spec.Ports[2].Port)
 	assert.Equal(t, "http-query", svc.Spec.Ports[0].Name)
+	assert.Equal(t, "grpc-query", svc.Spec.Ports[1].Name)
+	assert.Equal(t, "admin-http", svc.Spec.Ports[2].Name)
 	assert.Equal(t, int32(0), svc.Spec.Ports[0].NodePort)
 	assert.Equal(t, int32(0), svc.Spec.Ports[1].NodePort)
 	assert.Equal(t, intstr.FromInt(16686), svc.Spec.Ports[0].TargetPort)
@@ -93,6 +97,7 @@ func TestQueryServiceLoadBalancerWithIngress(t *testing.T) {
 	assert.Equal(t, int32(16687), svc.Spec.Ports[2].Port)
 	assert.Equal(t, "http-query", svc.Spec.Ports[0].Name)
 	assert.Equal(t, "grpc-query", svc.Spec.Ports[1].Name)
+	assert.Equal(t, "admin-http", svc.Spec.Ports[2].Name)
 	assert.Equal(t, intstr.FromInt(16686), svc.Spec.Ports[0].TargetPort)
 	assert.Equal(t, intstr.FromInt(16685), svc.Spec.Ports[1].TargetPort)
 	assert.Equal(t, svc.Spec.Type, corev1.ServiceTypeLoadBalancer) // make sure we get a LoadBalancer service
@@ -113,6 +118,8 @@ func TestQueryServiceSpecifiedNodePortWithIngress(t *testing.T) {
 	assert.Equal(t, int32(16685), svc.Spec.Ports[1].Port)
 	assert.Equal(t, int32(16687), svc.Spec.Ports[2].Port)
 	assert.Equal(t, "http-query", svc.Spec.Ports[0].Name)
+	assert.Equal(t, "grpc-query", svc.Spec.Ports[1].Name)
+	assert.Equal(t, "admin-http", svc.Spec.Ports[2].Name)
 	assert.Equal(t, int32(32767), svc.Spec.Ports[0].NodePort) // make sure we get the same NodePort as set above
 	assert.Equal(t, intstr.FromInt(16686), svc.Spec.Ports[0].TargetPort)
 	assert.Equal(t, svc.Spec.Type, corev1.ServiceTypeNodePort)
@@ -132,6 +139,8 @@ func TestQueryServiceSpecAnnotations(t *testing.T) {
 	assert.Equal(t, int32(16685), svc.Spec.Ports[1].Port)
 	assert.Equal(t, int32(16687), svc.Spec.Ports[2].Port)
 	assert.Equal(t, "http-query", svc.Spec.Ports[0].Name)
+	assert.Equal(t, "grpc-query", svc.Spec.Ports[1].Name)
+	assert.Equal(t, "admin-http", svc.Spec.Ports[2].Name)
 	assert.Equal(t, intstr.FromInt(16686), svc.Spec.Ports[0].TargetPort)
 	assert.Equal(t, map[string]string{"component": "jaeger"}, svc.Annotations)
 }

--- a/tests/e2e/miscellaneous/istio/03-assert.yaml
+++ b/tests/e2e/miscellaneous/istio/03-assert.yaml
@@ -30,6 +30,10 @@ spec:
     port: 14268
     protocol: TCP
     targetPort: 14268
+  - name: admin-http
+    port: 14269
+    protocol: TCP
+    targetPort: 14269
   - name: grpc-otlp
     port: 4317
     protocol: TCP
@@ -61,6 +65,10 @@ spec:
     port: 14268
     protocol: TCP
     targetPort: 14268
+  - name: admin-http
+    port: 14269
+    protocol: TCP
+    targetPort: 14269
   - name: grpc-otlp
     port: 4317
     protocol: TCP


### PR DESCRIPTION
This PR was originally created by @thomaspaulin. After doing a tiny modification 754db2b4b5970cd4a3d9ea2ae228052059d71d29 and pushing it to the original branch, the pr got automatically closed :no_good: 

For more details see:
- https://github.com/jaegertracing/jaeger-operator/pull/2204

Closes https://github.com/jaegertracing/jaeger-operator/issues/2203