### PR TITLE
Refactor the autodetect module to reduce the number of writes/reads in viper configuration

### DIFF
--- a/pkg/autodetect/main_test.go
+++ b/pkg/autodetect/main_test.go
@@ -453,7 +453,6 @@ func TestAutoDetectCronJobsVersion(t *testing.T) {
 
 		// verify
 		assert.Equal(t, apiGroup, viper.GetString(v1.FlagCronJobsVersion))
-		fmt.Printf("Test finished on [%s]\n", apiGroup)
 	}
 }
 


### PR DESCRIPTION
## Which problem is this PR solving?
- Mitigates to #1983

## Short description of the changes
- Reduce the number of read/writes to viper in the different functions
- The version of the autoscaling and cronjob APIs is checked just in the start


Note this is the first PR to fix the #1983 issue.