### PR TITLE
Fix custom labels for the deployable components in production strategy 

### DIFF
--- a/pkg/deployment/agent.go
+++ b/pkg/deployment/agent.go
@@ -135,7 +135,7 @@ func (a *Agent) Get() *appsv1.DaemonSet {
 		},
 		Spec: appsv1.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{
-				MatchLabels: labels,
+				MatchLabels: commonSpec.Labels,
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/deployment/agent_test.go
+++ b/pkg/deployment/agent_test.go
@@ -114,6 +114,9 @@ func TestDaemonSetAgentLabels(t *testing.T) {
 	assert.Equal(t, "operator", dep.Spec.Template.Labels["name"])
 	assert.Equal(t, "world", dep.Spec.Template.Labels["hello"])
 	assert.Equal(t, "false", dep.Spec.Template.Labels["another"])
+	assert.Equal(t, "operator", dep.Spec.Selector.MatchLabels["name"])
+	assert.Equal(t, "world", dep.Spec.Selector.MatchLabels["hello"])
+	assert.Equal(t, "false", dep.Spec.Selector.MatchLabels["another"])
 }
 
 func TestDaemonSetAgentResources(t *testing.T) {

--- a/pkg/deployment/collector.go
+++ b/pkg/deployment/collector.go
@@ -187,7 +187,7 @@ func (c *Collector) Get() *appsv1.Deployment {
 		Spec: appsv1.DeploymentSpec{
 			Replicas: c.jaeger.Spec.Collector.Replicas,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: labels,
+				MatchLabels: commonSpec.Labels,
 			},
 			Strategy: strategy,
 			Template: corev1.PodTemplateSpec{

--- a/pkg/deployment/collector_test.go
+++ b/pkg/deployment/collector_test.go
@@ -134,6 +134,9 @@ func TestCollectorLabels(t *testing.T) {
 	assert.Equal(t, "operator", dep.Spec.Template.Labels["name"])
 	assert.Equal(t, "world", dep.Spec.Template.Labels["hello"])
 	assert.Equal(t, "false", dep.Spec.Template.Labels["another"])
+	assert.Equal(t, "operator", dep.Spec.Selector.MatchLabels["name"])
+	assert.Equal(t, "world", dep.Spec.Selector.MatchLabels["hello"])
+	assert.Equal(t, "false", dep.Spec.Selector.MatchLabels["another"])
 }
 
 func TestCollectorSecrets(t *testing.T) {

--- a/pkg/deployment/ingester.go
+++ b/pkg/deployment/ingester.go
@@ -144,7 +144,7 @@ func (i *Ingester) Get() *appsv1.Deployment {
 		Spec: appsv1.DeploymentSpec{
 			Replicas: i.jaeger.Spec.Ingester.Replicas,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: labels,
+				MatchLabels: commonSpec.Labels,
 			},
 			Strategy: strategy,
 			Template: corev1.PodTemplateSpec{

--- a/pkg/deployment/ingester_test.go
+++ b/pkg/deployment/ingester_test.go
@@ -126,6 +126,9 @@ func TestIngesterLabels(t *testing.T) {
 	assert.Equal(t, "operator", dep.Spec.Template.Labels["name"])
 	assert.Equal(t, "world", dep.Spec.Template.Labels["hello"])
 	assert.Equal(t, "false", dep.Spec.Template.Labels["another"])
+	assert.Equal(t, "operator", dep.Spec.Selector.MatchLabels["name"])
+	assert.Equal(t, "world", dep.Spec.Selector.MatchLabels["hello"])
+	assert.Equal(t, "false", dep.Spec.Selector.MatchLabels["another"])
 }
 
 func TestIngesterSecrets(t *testing.T) {

--- a/pkg/deployment/query.go
+++ b/pkg/deployment/query.go
@@ -141,7 +141,7 @@ func (q *Query) Get() *appsv1.Deployment {
 		Spec: appsv1.DeploymentSpec{
 			Replicas: q.jaeger.Spec.Query.Replicas,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: labels,
+				MatchLabels: commonSpec.Labels,
 			},
 			Strategy: strategy,
 			Template: corev1.PodTemplateSpec{

--- a/pkg/deployment/query_test.go
+++ b/pkg/deployment/query_test.go
@@ -102,6 +102,9 @@ func TestQueryLabels(t *testing.T) {
 	assert.Equal(t, "operator", dep.Spec.Template.Labels["name"])
 	assert.Equal(t, "world", dep.Spec.Template.Labels["hello"])
 	assert.Equal(t, "false", dep.Spec.Template.Labels["another"])
+	assert.Equal(t, "operator", dep.Spec.Selector.MatchLabels["name"])
+	assert.Equal(t, "world", dep.Spec.Selector.MatchLabels["hello"])
+	assert.Equal(t, "false", dep.Spec.Selector.MatchLabels["another"])
 }
 
 func TestQuerySecrets(t *testing.T) {


### PR DESCRIPTION
<!--
Please delete this comment before posting.

We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
-  Resolves #1531 

## Short description of the changes
- We are facing this error because labels generated in the selector fields are different from the labels in the template.metadata.labels. With this PR we are generating the same labels under both sections.
