### PR TITLE
Revert "Bump docker/setup-buildx-action from 2.9.1 to 2.10.0"

### DIFF
--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: docker/setup-qemu-action@v2.2.0
-    - uses: docker/setup-buildx-action@v2.10.0
+    - uses: docker/setup-buildx-action@v2.9.1
     - name: "publishes the images"
       env:
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ jobs:
       run: ./hack/install/install-kustomize.sh
 
     - uses: docker/setup-qemu-action@v2.2.0
-    - uses: docker/setup-buildx-action@v2.10.0
+    - uses: docker/setup-buildx-action@v2.9.1
 
     - name: "generate release resources"
       run: make release-artifacts USER=jaegertracing


### PR DESCRIPTION
Reverts jaegertracing/jaeger-operator#2300

Let's revert maybe it will fix publishing the images 