### PR TITLE
Pass proxy env vars to operands

### DIFF
--- a/pkg/cronjob/es_index_cleaner.go
+++ b/pkg/cronjob/es_index_cleaner.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/operator-framework/operator-lib/proxy"
 	"github.com/spf13/viper"
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
@@ -30,6 +31,7 @@ func CreateEsIndexCleaner(jaeger *v1.Jaeger) runtime.Object {
 
 	envFromSource := util.CreateEnvsFromSecret(jaeger.Spec.Storage.SecretName)
 	envs := EsScriptEnvVars(jaeger.Spec.Storage.Options)
+	envs = append(envs, proxy.ReadProxyVarsFromEnv()...)
 	if val, ok := jaeger.Spec.Storage.Options.StringMap()["es.use-aliases"]; ok && strings.EqualFold(val, "true") {
 		envs = append(envs, corev1.EnvVar{Name: "ROLLOVER", Value: "true"})
 	}

--- a/pkg/cronjob/es_rollover.go
+++ b/pkg/cronjob/es_rollover.go
@@ -5,13 +5,13 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/operator-framework/operator-lib/proxy"
 	"github.com/spf13/viper"
-	"k8s.io/apimachinery/pkg/runtime"
-
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	v1 "github.com/jaegertracing/jaeger-operator/apis/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/account"
@@ -97,6 +97,7 @@ func rollover(jaeger *v1.Jaeger) runtime.Object {
 
 func createTemplate(name, action string, jaeger *v1.Jaeger, envs []corev1.EnvVar) *corev1.PodTemplateSpec {
 	envFromSource := util.CreateEnvsFromSecret(jaeger.Spec.Storage.SecretName)
+	envs = append(envs, proxy.ReadProxyVarsFromEnv()...)
 	baseCommonSpec := v1.JaegerCommonSpec{
 		Annotations: map[string]string{
 			"prometheus.io/scrape":    "false",

--- a/pkg/cronjob/spark_dependencies.go
+++ b/pkg/cronjob/spark_dependencies.go
@@ -4,14 +4,13 @@ import (
 	"strconv"
 	"strings"
 
-	"k8s.io/apimachinery/pkg/runtime"
-
+	"github.com/operator-framework/operator-lib/proxy"
+	"github.com/spf13/viper"
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/spf13/viper"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	v1 "github.com/jaegertracing/jaeger-operator/apis/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/account"
@@ -35,6 +34,7 @@ func CreateSparkDependencies(jaeger *v1.Jaeger) runtime.Object {
 		{Name: "JAVA_OPTS", Value: jaeger.Spec.Storage.Dependencies.JavaOpts},
 	}
 	envVars = append(envVars, getStorageEnvs(jaeger.Spec.Storage)...)
+	envVars = append(envVars, proxy.ReadProxyVarsFromEnv()...)
 
 	envFromSource := util.CreateEnvsFromSecret(jaeger.Spec.Storage.SecretName)
 

--- a/pkg/deployment/agent.go
+++ b/pkg/deployment/agent.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/operator-framework/operator-lib/proxy"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -148,6 +149,7 @@ func (a *Agent) Get() *appsv1.DaemonSet {
 						Image: util.ImageName(a.jaeger.Spec.Agent.Image, "jaeger-agent-image"),
 						Name:  "jaeger-agent-daemonset",
 						Args:  args,
+						Env:   proxy.ReadProxyVarsFromEnv(),
 						Ports: []corev1.ContainerPort{
 							{
 								ContainerPort: zkCompactTrft,

--- a/pkg/deployment/all_in_one.go
+++ b/pkg/deployment/all_in_one.go
@@ -5,9 +5,7 @@ import (
 	"sort"
 	"strconv"
 
-	"github.com/jaegertracing/jaeger-operator/pkg/autodetect"
-	"github.com/jaegertracing/jaeger-operator/pkg/storage"
-
+	"github.com/operator-framework/operator-lib/proxy"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -15,11 +13,13 @@ import (
 
 	v1 "github.com/jaegertracing/jaeger-operator/apis/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/account"
+	"github.com/jaegertracing/jaeger-operator/pkg/autodetect"
 	"github.com/jaegertracing/jaeger-operator/pkg/config/ca"
 	"github.com/jaegertracing/jaeger-operator/pkg/config/sampling"
 	"github.com/jaegertracing/jaeger-operator/pkg/config/tls"
 	configmap "github.com/jaegertracing/jaeger-operator/pkg/config/ui"
 	"github.com/jaegertracing/jaeger-operator/pkg/service"
+	"github.com/jaegertracing/jaeger-operator/pkg/storage"
 	"github.com/jaegertracing/jaeger-operator/pkg/util"
 )
 
@@ -152,6 +152,7 @@ func (a *AllInOne) Get() *appsv1.Deployment {
 			Value: strconv.FormatBool(jaegerDisabled),
 		},
 	}
+	envVars = append(envVars, proxy.ReadProxyVarsFromEnv()...)
 
 	ports := []corev1.ContainerPort{
 		{

--- a/pkg/deployment/collector.go
+++ b/pkg/deployment/collector.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strconv"
 
+	"github.com/operator-framework/operator-lib/proxy"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -137,6 +138,7 @@ func (c *Collector) Get() *appsv1.Deployment {
 			Value: ":9411",
 		},
 	}
+	envVars = append(envVars, proxy.ReadProxyVarsFromEnv()...)
 
 	ports := []corev1.ContainerPort{
 		{

--- a/pkg/inject/oauth_proxy.go
+++ b/pkg/inject/oauth_proxy.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/operator-framework/operator-lib/proxy"
 	"github.com/spf13/viper"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -111,6 +112,7 @@ func getOAuthProxyContainer(jaeger *v1.Jaeger) corev1.Container {
 			},
 		},
 		Resources: commonSpec.Resources,
+		Env:       proxy.ReadProxyVarsFromEnv(),
 	}
 }
 

--- a/pkg/inject/sidecar.go
+++ b/pkg/inject/sidecar.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/operator-framework/operator-lib/proxy"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -209,6 +210,25 @@ func getJaeger(name string, jaegers *v1.JaegerList) *v1.Jaeger {
 
 func container(jaeger *v1.Jaeger, dep *appsv1.Deployment, agentIdx int) corev1.Container {
 	args := jaeger.Spec.Agent.Options.ToArgs()
+	envs := []corev1.EnvVar{
+		{
+			Name: envVarPodName,
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "metadata.name",
+				},
+			},
+		},
+		{
+			Name: envVarHostIP,
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "status.hostIP",
+				},
+			},
+		},
+	}
+	envs = append(envs, proxy.ReadProxyVarsFromEnv()...)
 
 	// we only add the grpc host if we are adding the reporter type and there's no explicit value yet
 	if len(util.FindItem("--reporter.grpc.host-port=", args)) == 0 {
@@ -275,24 +295,7 @@ func container(jaeger *v1.Jaeger, dep *appsv1.Deployment, agentIdx int) corev1.C
 		Image: util.ImageName(jaeger.Spec.Agent.Image, "jaeger-agent-image"),
 		Name:  "jaeger-agent",
 		Args:  args,
-		Env: []corev1.EnvVar{
-			{
-				Name: envVarPodName,
-				ValueFrom: &corev1.EnvVarSource{
-					FieldRef: &corev1.ObjectFieldSelector{
-						FieldPath: "metadata.name",
-					},
-				},
-			},
-			{
-				Name: envVarHostIP,
-				ValueFrom: &corev1.EnvVarSource{
-					FieldRef: &corev1.ObjectFieldSelector{
-						FieldPath: "status.hostIP",
-					},
-				},
-			},
-		},
+		Env:   envs,
 		Ports: []corev1.ContainerPort{
 			{
 				ContainerPort: zkCompactTrft,

--- a/pkg/storage/elasticsearch.go
+++ b/pkg/storage/elasticsearch.go
@@ -75,7 +75,7 @@ func (ed *ElasticsearchDeployment) injectArguments(container *corev1.Container) 
 			calculateReplicaShards(ed.Jaeger.Spec.Storage.Elasticsearch.RedundancyPolicy, int(ed.Jaeger.Spec.Storage.Elasticsearch.NodeCount))))
 	}
 	if strings.EqualFold(util.FindItem("--es-archive.enabled", container.Args), "--es-archive.enabled=true") {
-		container.Args = append(container.Args, fmt.Sprintf("--es-archive.server-urls=https://%s:9200", ed.Jaeger.Spec.Storage.Elasticsearch.Name))
+		container.Args = append(container.Args, fmt.Sprintf("--es-archive.server-urls=https://%s.%s.svc.cluster.local:9200", ed.Jaeger.Spec.Storage.Elasticsearch.Name, ed.Jaeger.Namespace))
 		if util.FindItem("--es-archive.tls=", container.Args) == "" && util.FindItem("--es-archive.tls.enabled=", container.Args) == "" {
 			container.Args = append(container.Args, "--es-archive.tls.enabled=true")
 		}

--- a/pkg/storage/elasticsearch.go
+++ b/pkg/storage/elasticsearch.go
@@ -53,7 +53,7 @@ type ElasticsearchDeployment struct {
 }
 
 func (ed *ElasticsearchDeployment) injectArguments(container *corev1.Container) {
-	container.Args = append(container.Args, fmt.Sprintf("--es.server-urls=https://%s:9200", ed.Jaeger.Spec.Storage.Elasticsearch.Name))
+	container.Args = append(container.Args, fmt.Sprintf("--es.server-urls=https://%s.%s.svc.cluster.local:9200", ed.Jaeger.Spec.Storage.Elasticsearch.Name, ed.Jaeger.Namespace))
 	if util.FindItem("--es.tls=", container.Args) == "" && util.FindItem("--es.tls.enabled=", container.Args) == "" {
 		container.Args = append(container.Args, "--es.tls.enabled=true")
 	}
@@ -134,7 +134,7 @@ func (ed *ElasticsearchDeployment) InjectSecretsConfiguration(p *corev1.PodSpec)
 	// we assume jaeger containers are first
 	if len(p.Containers) > 0 {
 		// the size of arguments array should be always 2
-		p.Containers[0].Args[1] = fmt.Sprintf("https://%s:9200", ed.Jaeger.Spec.Storage.Elasticsearch.Name)
+		p.Containers[0].Args[1] = fmt.Sprintf("https://%s.%s.svc.cluster.local:9200", ed.Jaeger.Spec.Storage.Elasticsearch.Name, ed.Jaeger.Namespace)
 		p.Containers[0].Env = append(p.Containers[0].Env,
 			corev1.EnvVar{Name: "ES_TLS_ENABLED", Value: "true"},
 			corev1.EnvVar{Name: "ES_TLS_CA", Value: ed.getCertCaPath()},

--- a/pkg/storage/elasticsearch_test.go
+++ b/pkg/storage/elasticsearch_test.go
@@ -295,7 +295,7 @@ func TestInject(t *testing.T) {
 				Containers: []corev1.Container{{
 					Args: []string{
 						"foo",
-						"--es.server-urls=https://elasticsearch:9200",
+						"--es.server-urls=https://elasticsearch.project.svc.cluster.local:9200",
 						"--es.tls.enabled=true",
 						"--es.tls.ca=" + caPath,
 						"--es.tls.cert=" + certPath,
@@ -333,7 +333,7 @@ func TestInject(t *testing.T) {
 				Containers: []corev1.Container{{
 					Args: []string{
 						"foo",
-						"--es.server-urls=https://elasticsearch:9200",
+						"--es.server-urls=https://elasticsearch.project.svc.cluster.local:9200",
 						"--es.tls.enabled=true",
 						"--es.tls.ca=" + caPathESCerManagement,
 						"--es.tls.cert=" + certPathESCertManagement,
@@ -369,7 +369,7 @@ func TestInject(t *testing.T) {
 						"--es.num-shards=15",
 						"--es.num-replicas=55",
 						"--es.timeout=99s",
-						"--es.server-urls=https://elasticsearch:9200",
+						"--es.server-urls=https://elasticsearch.project.svc.cluster.local:9200",
 						"--es.tls.enabled=true",
 						"--es.tls.ca=" + caPath,
 						"--es.tls.cert=" + certPath,
@@ -398,7 +398,7 @@ func TestInject(t *testing.T) {
 			expected: &corev1.PodSpec{
 				Containers: []corev1.Container{{
 					Args: []string{
-						"--es.server-urls=https://my-es:9200",
+						"--es.server-urls=https://my-es.project.svc.cluster.local:9200",
 						"--es.tls.enabled=true",
 						"--es.tls.ca=" + caPath,
 						"--es.tls.cert=" + certPath,
@@ -437,7 +437,7 @@ func TestInject(t *testing.T) {
 				Containers: []corev1.Container{{
 					Args: []string{
 						"--es-archive.enabled=true",
-						"--es.server-urls=https://es-tenant2:9200",
+						"--es.server-urls=https://es-tenant2.project.svc.cluster.local:9200",
 						"--es.tls.enabled=true",
 						"--es.tls.ca=" + caPath,
 						"--es.tls.cert=" + certPath,
@@ -445,7 +445,7 @@ func TestInject(t *testing.T) {
 						"--es.timeout=15s",
 						"--es.num-shards=15",
 						"--es.num-replicas=14",
-						"--es-archive.server-urls=https://es-tenant2:9200",
+						"--es-archive.server-urls=https://es-tenant2.project.svc.cluster.local:9200",
 						"--es-archive.tls.enabled=true",
 						"--es-archive.tls.ca=" + caPath,
 						"--es-archive.tls.cert=" + certPath,
@@ -471,7 +471,7 @@ func TestInject(t *testing.T) {
 
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			es := &ElasticsearchDeployment{Jaeger: v1.NewJaeger(types.NamespacedName{Name: "jtest"})}
+			es := &ElasticsearchDeployment{Jaeger: v1.NewJaeger(types.NamespacedName{Name: "jtest", Namespace: "project"})}
 			es.Jaeger.Spec.Storage.Elasticsearch = test.es
 			es.InjectStorageConfiguration(test.pod)
 			assert.Equal(t, test.expected, test.pod)
@@ -501,7 +501,7 @@ func TestInjectJobs(t *testing.T) {
 			},
 			expected: &corev1.PodSpec{
 				Containers: []corev1.Container{{
-					Args: []string{"init", "https://elasticsearch:9200"},
+					Args: []string{"init", "https://elasticsearch.project.svc.cluster.local:9200"},
 					Env: []corev1.EnvVar{
 						{
 							Name:  "ES_TLS_ENABLED",
@@ -557,7 +557,7 @@ func TestInjectJobs(t *testing.T) {
 			},
 			expected: &corev1.PodSpec{
 				Containers: []corev1.Container{{
-					Args: []string{"init", "https://elasticsearch:9200"},
+					Args: []string{"init", "https://elasticsearch.project.svc.cluster.local:9200"},
 					Env: []corev1.EnvVar{
 						{
 							Name:  "ES_TLS_ENABLED",
@@ -602,7 +602,7 @@ func TestInjectJobs(t *testing.T) {
 
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
-			es := &ElasticsearchDeployment{Jaeger: v1.NewJaeger(types.NamespacedName{Name: "jtest"})}
+			es := &ElasticsearchDeployment{Jaeger: v1.NewJaeger(types.NamespacedName{Name: "jtest", Namespace: "project"})}
 			es.Jaeger.Spec.Storage.Elasticsearch = test.es
 			es.InjectSecretsConfiguration(test.pod)
 			assert.Equal(t, test.expected, test.pod)


### PR DESCRIPTION
Docs:

- https://docs.openshift.com/container-platform/4.13/operators/operator_sdk/golang/osdk-golang-tutorial.html#osdk-run-proxy_osdk-golang-tutorial 
- https://sdk.operatorframework.io/docs/building-operators/golang/references/proxy-vars/
- https://docs.openshift.com/container-platform/4.13/networking/enable-cluster-wide-proxy.html#enable-cluster-wide-proxy


docker image: `pavolloffay/jaeger-opeator:PR2330-6`
(IMG=pavolloffay/jaeger-opeator:PR2330-4 make docker)

CRs for testing:
```
kubectl apply  -f - <<EOF
apiVersion: jaegertracing.io/v1
kind: Jaeger
metadata:
  name: simplest
spec:
   allInOne:
     image: pavolloffay/all-in-one:proxy-6
EOF

kubectl apply  -f - <<EOF
apiVersion: jaegertracing.io/v1
kind: Jaeger
metadata:
  name: simple-prod
spec:
  query:
    image: pavolloffay/jaeger-query:proxy-6
  collector:
    image: pavolloffay/jaeger-collector:proxy-6
  strategy: production
  storage:
    type: elasticsearch
    elasticsearch:
      nodeCount: 1
      resources:
        requests:
          cpu: 200m
          memory: 1Gi
        limits:
          memory: 1Gi
EOF
```