### PR TITLE
Add v1.48.x and v1.49.x to the support map

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -3,6 +3,8 @@ The following table shows the compatibility of jaeger operator with different co
 
 | Jaeger Operator | Kubernetes      | Strimzi Operator   | Cert-Manager |
 |-----------------|-----------------|--------------------|--------------|
+| v1.49.x         | v1.19 to v1.28  | v0.32              | v1.6.1       |
+| v1.48.x         | v1.19 to v1.27  | v0.32              | v1.6.1       |
 | v1.47.x         | v1.19 to v1.27  | v0.32              | v1.6.1       |
 | v1.46.x         | v1.19 to v1.26  | v0.32              | v1.6.1       |
 | v1.45.x         | v1.19 to v1.26  | v0.32              | v1.6.1       |


### PR DESCRIPTION
## Which problem is this PR solving?
Resolves: https://github.com/jaegertracing/jaeger-operator/issues/2331

## Description of the changes
Adds the latest 2 releases of jaeger-operator to the COMPATIBILITY.md file

## How was this change tested?
The information is taken by first checking out to the tags and then for each tag:
- **Kubernetes**: Kind .yamls present in the root dir indicating the tested K8s versions
- **Strimzi Operator**: Strimzi Operator version being pulled in the Makefile
    <img width="717" alt="Screenshot 2023-09-26 at 2 35 41 PM" src="https://github.com/jaegertracing/jaeger-operator/assets/57728496/9d0d668c-f927-4c6a-a81c-a7c8144db218">
- **Cert-Manager**: From the `CERTMANAGER_VERSION` variable defined in the Makefile
    <img width="277" alt="Screenshot 2023-09-26 at 2 36 25 PM" src="https://github.com/jaegertracing/jaeger-operator/assets/57728496/9c7c2142-945f-479e-8fe6-91809a1dad56">

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
