### PR TITLE
Check if envFrom has ConfigMapRef set

### DIFF
--- a/pkg/inject/sidecar.go
+++ b/pkg/inject/sidecar.go
@@ -527,6 +527,9 @@ func GetConfigMapsMatchedEnvFromInDeployment(dep appsv1.Deployment, configMaps [
 	matchedConfigMaps := []corev1.ConfigMap{}
 	for _, container := range dep.Spec.Template.Spec.Containers {
 		for _, envConfigMap := range container.EnvFrom {
+			if envConfigMap.ConfigMapRef == nil {
+				continue
+			}
 			if matchedCM, ok := configMapSearchMap[envConfigMap.ConfigMapRef.Name]; ok {
 				matchedConfigMaps = append(matchedConfigMaps, matchedCM)
 			}


### PR DESCRIPTION
EnvFrom can also be used for SecretRefs in which case the existing logic would result in a nil pointer dereference.

## Which problem is this PR solving?
Resolves #2341

## Description of the changes
- Add a nil check for ConfigMapRef when retrieving matched config maps for deployment

## How was this change tested?
- Added appropriate unit testing for the func
- Tested on local kind minikube cluster with test deployment configs from #2341 

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
