### PR TITLE
Document that the openshift CI can fail on release PR

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -183,9 +183,8 @@ difference are:
 * You need to log in your Kubernetes cluster before running the E2E tests
 * You need to provide the `USE_KIND_CLUSTER=false` parameter when calling `make`
 
-For instance, to run the `examples` E2E test suite in OpenShift, the command is:
 ```sh
-$ make run-e2e-tests-examples USE_KIND_CLUSTER=false
+$ make run-e2e-tests USE_KIND_CLUSTER=false
 ```
 
 ### Developing new E2E tests

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -27,6 +27,7 @@ Steps to release a new version of the Jaeger Operator:
    ```sh
    git commit -sm "Preparing release v1.30.0"
    ```
+    Note that the OpenShift CI test job fails. This is expected and the release PR can be merged.
 
 5. Once the changes above are merged and available in `main` tag it with the desired version, prefixed with `v`, eg. `v1.30.0`
 


### PR DESCRIPTION
The OpenShift CI fials for release PRs e.g. https://github.com/jaegertracing/jaeger-operator/pull/2365. We should either make it pass or document this. 