### PR TITLE
Fix pkg/inventory/deployment.go:ForDeployments(): don't modify the de…

### DIFF
--- a/pkg/inventory/deployment.go
+++ b/pkg/inventory/deployment.go
@@ -37,6 +37,11 @@ func ForDeployments(existing []appsv1.Deployment, desired []appsv1.Deployment) D
 			// we can't blindly DeepCopyInto, so, we select what we bring from the new to the old object
 			tp.Spec = v.Spec
 			tp.Spec = inject.PropagateOAuthCookieSecret(t.Spec, v.Spec)
+
+			// Deployment.Spec.Selector is an immutable field: we can't update
+			// this field with a new value, we MUST keep the original field value
+			tp.Spec.Selector = t.Spec.Selector
+
 			tp.ObjectMeta.OwnerReferences = v.ObjectMeta.OwnerReferences
 
 			for k, v := range v.ObjectMeta.Annotations {


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #2370

## Description of the changes
- Fix the `pkg/inventory/deployment.go:ForDeployments()` function: don't modify the `deployment.spec.selector` immutable field on update

## How was this change tested?
- Added the following unit tests in the `pkg/inventory/deployment_test.go` file:
  - `TestDeploymentKeepSelectorOnUpdate()`
  - `TestDeploymentSetSelectorOnCreate()`

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
