### PR TITLE
Fix injection: prefer jaeger in the same namespace

### DIFF
--- a/pkg/inject/sidecar_test.go
+++ b/pkg/inject/sidecar_test.go
@@ -1113,3 +1113,60 @@ func TestGetConfigMapsMatchedEnvFromInDeploymentWithEnvFromConfigAndSecret(t *te
 	assert.Len(t, matchedConfigMaps, 1)
 	assert.Equal(t, matchedConfigMaps[0].Name, "test-config")
 }
+
+func TestGetJaeger(t *testing.T) {
+	jaegers := v1.JaegerList{
+		Items: []v1.Jaeger{
+			*v1.NewJaeger(types.NamespacedName{
+				Namespace: "project1",
+				Name:      "jaeger",
+			}),
+			*v1.NewJaeger(types.NamespacedName{
+				Namespace: "project1",
+				Name:      "jaeger2",
+			}),
+			*v1.NewJaeger(types.NamespacedName{
+				Namespace: "project2",
+				Name:      "jaeger",
+			}),
+		},
+	}
+
+	tests := []struct {
+		testName     string
+		deploymentNs string
+		jaegerName   string
+		jaeger       *v1.Jaeger
+	}{
+		{
+			testName:     "deployment matches jaeger namespace",
+			deploymentNs: "project1",
+			jaegerName:   "jaeger",
+			jaeger: v1.NewJaeger(types.NamespacedName{
+				Namespace: "project1",
+				Name:      "jaeger",
+			}),
+		},
+		{
+			testName:     "deployment in other namespace",
+			deploymentNs: "app",
+			jaegerName:   "jaeger",
+			jaeger: v1.NewJaeger(types.NamespacedName{
+				Namespace: "project1",
+				Name:      "jaeger",
+			}),
+		},
+		{
+			testName:     "jaeger name does not match",
+			deploymentNs: "app",
+			jaegerName:   "does-not-exist",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			selectedJaeger := getJaeger(tt.deploymentNs, tt.jaegerName, &jaegers)
+			assert.Equal(t, tt.jaeger, selectedJaeger)
+		})
+	}
+}


### PR DESCRIPTION
Resolves https://issues.redhat.com/browse/TRACING-3722 

<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- <!-- Example: Resolves #123 -->

With this patch the agent injection code prefers Jaeger in the same namespace. 

Before if jaeger production (with a separate jaeger-query pod that injects agent) was created in multiple namespaces the jaeger-agent injected into the query pod was overridden to the Jaeger that was return as first from the API server. 


docker image: `docker.io/pavolloffay/jaeger-operator:agent-issue-PR2383-1`

## Description of the changes
See the comment in the code

## How was this change tested?
- 

## Checklist
- [ ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
