### PR TITLE
enable errorlint and testifylint linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,10 @@
-run:
-  go: '1.21'
-  timeout: 10m
+issues:
+  # Excluding configuration per-path, per-linter, per-text and per-source
+  exclude-rules:
+    # Exclude some linters from running on tests files.
+    - path: _test\.go
+      linters:
+        - gosec
 
 linters-settings:
   goimports:
@@ -10,20 +14,17 @@ linters-settings:
 
 linters:
   enable:
-    - gofmt
+    - bidichk
+    - errorlint
     - gofumpt
     - goimports
     - gosec
     - govet
     - misspell
-    - bidichk
+    - testifylint
   disable:
     - errcheck
 
-issues:
-  # Excluding configuration per-path, per-linter, per-text and per-source
-  exclude-rules:
-    # Exclude some linters from running on tests files.
-    - path: _test\.go
-      linters:
-        - gosec
+run:
+  go: '1.20'
+  timeout: 10m

--- a/apis/v1/deployment_strategy_test.go
+++ b/apis/v1/deployment_strategy_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestUnmarshalJSON(t *testing.T) {
@@ -28,7 +29,7 @@ func TestUnmarshalJSON(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ds := DeploymentStrategy("")
 			err := json.Unmarshal([]byte(tc.json), &ds)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tc.expected, ds)
 		})
 	}
@@ -48,7 +49,7 @@ func TestMarshalJSON(t *testing.T) {
 	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {
 			data, err := json.Marshal(tc.strategy)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tc.expected, string(data))
 		})
 	}

--- a/apis/v1/freeform_test.go
+++ b/apis/v1/freeform_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFreeForm(t *testing.T) {
@@ -16,7 +17,7 @@ func TestFreeForm(t *testing.T) {
 		},
 	})
 	json, err := o.MarshalJSON()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, json)
 	assert.Equal(t, uiconfig, string(*o.json))
 }
@@ -26,7 +27,7 @@ func TestFreeFormUnmarhalMarshal(t *testing.T) {
 	o := NewFreeForm(nil)
 	o.UnmarshalJSON([]byte(uiconfig))
 	json, err := o.MarshalJSON()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, json)
 	assert.Equal(t, uiconfig, string(*o.json))
 }
@@ -66,9 +67,9 @@ func TestToMap(t *testing.T) {
 		f := NewFreeForm(test.m)
 		got, err := f.GetMap()
 		if test.err != "" {
-			assert.EqualError(t, err, test.err)
+			require.EqualError(t, err, test.err)
 		} else {
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, test.expected, got)
 		}
 	}

--- a/apis/v1/jaeger_webhook.go
+++ b/apis/v1/jaeger_webhook.go
@@ -104,7 +104,7 @@ func (j *Jaeger) ValidateUpdate(_ runtime.Object) (admission.Warnings, error) {
 			Name:      j.Spec.Storage.Elasticsearch.Name,
 		}, es)
 		if errors.IsNotFound(err) {
-			return nil, fmt.Errorf("elasticsearch instance not found: %v", err)
+			return nil, fmt.Errorf("elasticsearch instance not found: %w", err)
 		}
 	}
 

--- a/apis/v1/jaeger_webhook_test.go
+++ b/apis/v1/jaeger_webhook_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDefault(t *testing.T) {
@@ -179,7 +180,7 @@ func TestDefault(t *testing.T) {
 func TestValidateDelete(t *testing.T) {
 	warnings, err := new(Jaeger).ValidateDelete()
 	assert.Nil(t, warnings)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestValidate(t *testing.T) {
@@ -279,10 +280,10 @@ func TestValidate(t *testing.T) {
 
 			warnings, err := test.current.ValidateCreate()
 			if test.err != "" {
-				assert.NotNil(t, err)
+				require.Error(t, err)
 				assert.Equal(t, test.err, err.Error())
 			} else {
-				assert.Nil(t, err)
+				require.NoError(t, err)
 			}
 			assert.Nil(t, warnings)
 		})

--- a/apis/v1/options_test.go
+++ b/apis/v1/options_test.go
@@ -18,7 +18,7 @@ func TestSimpleOption(t *testing.T) {
 
 func TestNoOptions(t *testing.T) {
 	o := Options{}
-	assert.Len(t, o.ToArgs(), 0)
+	assert.Empty(t, o.ToArgs())
 }
 
 func TestNestedOption(t *testing.T) {
@@ -40,7 +40,7 @@ func TestMarshalling(t *testing.T) {
 	})
 
 	b, err := json.Marshal(o)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	s := string(b)
 	assert.Contains(t, s, `"es.password":"changeme"`)
 	assert.Contains(t, s, `"es.server-urls":"http://elasticsearch.default.svc:9200"`)
@@ -85,9 +85,9 @@ func TestUnmarshalToArgs(t *testing.T) {
 		opts := Options{}
 		err := opts.UnmarshalJSON([]byte(test.in))
 		if test.err != "" {
-			assert.EqualError(t, err, test.err)
+			require.EqualError(t, err, test.err)
 		} else {
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			args := opts.ToArgs()
 			sort.SliceStable(args, func(i, j int) bool {
 				return args[i] < args[j]
@@ -129,7 +129,7 @@ func TestMarshallRaw(t *testing.T) {
 	o := NewOptions(nil)
 	o.json = &json
 	bytes, err := o.MarshalJSON()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, bytes, json)
 }
 
@@ -137,7 +137,7 @@ func TestMarshallEmpty(t *testing.T) {
 	o := NewOptions(nil)
 	json := []byte(`{}`)
 	bytes, err := o.MarshalJSON()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, bytes, json)
 }
 
@@ -151,7 +151,7 @@ func TestUpdate(t *testing.T) {
 	o.Map()["key"] = "new"
 
 	// verify
-	assert.Equal(t, o.opts["key"], "new")
+	assert.Equal(t, "new", o.opts["key"])
 }
 
 func TestStringMap(t *testing.T) {
@@ -170,7 +170,7 @@ func TestDeepCopy(t *testing.T) {
 	require.NoError(t, err)
 	copy := o1.opts.DeepCopy()
 
-	assert.Equal(t, copy, &(o1.opts))
+	assert.Equal(t, &(o1.opts), copy)
 }
 
 func TestRepetitiveArguments(t *testing.T) {

--- a/controllers/appsv1/namespace_controller_test.go
+++ b/controllers/appsv1/namespace_controller_test.go
@@ -3,7 +3,6 @@ package appsv1_test
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	k8sconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -27,5 +26,5 @@ func TestNamespaceControllerRegisterWithManager(t *testing.T) {
 	err = reconciler.SetupWithManager(mgr)
 
 	// verify
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }

--- a/controllers/jaegertracing/jaeger_controller_test.go
+++ b/controllers/jaegertracing/jaeger_controller_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
 	k8sconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -52,5 +51,5 @@ func TestRegisterWithManager(t *testing.T) {
 	err = reconciler.SetupWithManager(mgr)
 
 	// verify
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }

--- a/hack/install/install-golangci-lint.sh
+++ b/hack/install/install-golangci-lint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-VERSION="1.53.2"
+VERSION="1.55.2"
 
 echo "Installing golangci-lint"
 

--- a/pkg/autoclean/main_test.go
+++ b/pkg/autoclean/main_test.go
@@ -92,7 +92,7 @@ func TestCleanDeployments(t *testing.T) {
 			dep = inject.Sidecar(jaeger, dep)
 
 			// sanity check
-			require.Equal(t, 2, len(dep.Spec.Template.Spec.Containers))
+			require.Len(t, dep.Spec.Template.Spec.Containers, 2)
 
 			// prepare the list of existing objects
 			objs := []runtime.Object{dep}
@@ -121,10 +121,10 @@ func TestCleanDeployments(t *testing.T) {
 
 			// should the sidecar have been deleted?
 			if tt.deleted {
-				assert.Equal(t, 1, len(persisted.Spec.Template.Spec.Containers))
+				assert.Len(t, persisted.Spec.Template.Spec.Containers, 1)
 				assert.NotContains(t, persisted.Labels, inject.Label)
 			} else {
-				assert.Equal(t, 2, len(persisted.Spec.Template.Spec.Containers))
+				assert.Len(t, persisted.Spec.Template.Spec.Containers, 2)
 				assert.Contains(t, persisted.Labels, inject.Label)
 			}
 		})

--- a/pkg/autodetect/main.go
+++ b/pkg/autodetect/main.go
@@ -183,7 +183,7 @@ func AvailableAPIs(discovery discovery.DiscoveryInterface, groups map[string]boo
 			if err == nil {
 				apiLists = append(apiLists, groupAPIList)
 			} else {
-				errors = fmt.Errorf("%v; Error getting resources for server group %s: %v", errors, sg.Name, err)
+				errors = fmt.Errorf("%w; Error getting resources for server group %s: %w", errors, sg.Name, err)
 			}
 		}
 	}

--- a/pkg/clusterrolebinding/main_test.go
+++ b/pkg/clusterrolebinding/main_test.go
@@ -36,7 +36,7 @@ func TestGetClusterRoleBinding(t *testing.T) {
 	assert.Len(t, crbs[0].Subjects, 1)
 	assert.Equal(t, account.OAuthProxyAccountNameFor(jaeger), crbs[0].Subjects[0].Name)
 	assert.Equal(t, "ServiceAccount", crbs[0].Subjects[0].Kind)
-	assert.Len(t, crbs[0].Subjects[0].Namespace, 0) // cluster roles aren't namespaced
+	assert.Empty(t, crbs[0].Subjects[0].Namespace) // cluster roles aren't namespaced
 }
 
 func TestIngressDisabled(t *testing.T) {
@@ -53,7 +53,7 @@ func TestIngressDisabled(t *testing.T) {
 	crbs := Get(jaeger)
 
 	// verify
-	assert.Len(t, crbs, 0)
+	assert.Empty(t, crbs)
 }
 
 func TestNotOAuthProxy(t *testing.T) {
@@ -70,7 +70,7 @@ func TestNotOAuthProxy(t *testing.T) {
 	crbs := Get(jaeger)
 
 	// verify
-	assert.Len(t, crbs, 0)
+	assert.Empty(t, crbs)
 }
 
 func TestAuthDelegatorNotAvailable(t *testing.T) {
@@ -90,5 +90,5 @@ func TestAuthDelegatorNotAvailable(t *testing.T) {
 	crbs := Get(jaeger)
 
 	// verify
-	assert.Len(t, crbs, 0)
+	assert.Empty(t, crbs)
 }

--- a/pkg/cmd/generate/main.go
+++ b/pkg/cmd/generate/main.go
@@ -2,6 +2,7 @@ package generate
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -55,7 +56,7 @@ func createSpecFromYAML(filename string) (*v1.Jaeger, error) {
 
 	var spec v1.Jaeger
 	decoder := yaml.NewYAMLOrJSONDecoder(f, 8192)
-	if err := decoder.Decode(&spec); err != nil && err != io.EOF {
+	if err := decoder.Decode(&spec); err != nil && !errors.Is(err, io.EOF) {
 		return nil, err
 	}
 

--- a/pkg/config/ca/ca_test.go
+++ b/pkg/config/ca/ca_test.go
@@ -108,8 +108,8 @@ func TestUpdateWithoutCAs(t *testing.T) {
 	AddServiceCA(jaeger, &commonSpec)
 
 	// verify
-	assert.Len(t, commonSpec.Volumes, 0)
-	assert.Len(t, commonSpec.VolumeMounts, 0)
+	assert.Empty(t, commonSpec.Volumes)
+	assert.Empty(t, commonSpec.VolumeMounts)
 }
 
 func TestUpdateWithTrustedCA(t *testing.T) {
@@ -152,6 +152,6 @@ func TestUpdateWithExistingTrustedCA(t *testing.T) {
 	AddServiceCA(jaeger, &commonSpec)
 
 	// verify
-	assert.Len(t, commonSpec.Volumes, 0)
-	assert.Len(t, commonSpec.VolumeMounts, 0)
+	assert.Empty(t, commonSpec.Volumes)
+	assert.Empty(t, commonSpec.VolumeMounts)
 }

--- a/pkg/config/sampling/sampling_test.go
+++ b/pkg/config/sampling/sampling_test.go
@@ -91,9 +91,9 @@ func TestUpdateWithSamplingConfigFileOption(t *testing.T) {
 	commonSpec := v1.JaegerCommonSpec{}
 
 	Update(jaeger, &commonSpec, &options)
-	assert.Len(t, commonSpec.Volumes, 0)
-	assert.Len(t, commonSpec.VolumeMounts, 0)
-	assert.Len(t, options, 0)
+	assert.Empty(t, commonSpec.Volumes)
+	assert.Empty(t, commonSpec.VolumeMounts)
+	assert.Empty(t, options)
 }
 
 func TestGetWithSamplingConfigFileOption(t *testing.T) {

--- a/pkg/config/tls/tls_test.go
+++ b/pkg/config/tls/tls_test.go
@@ -35,8 +35,8 @@ func TestIgnoreDefaultTLSSecretWhenGrpcHostPortIsSet(t *testing.T) {
 	options = append(options, "--reporter.grpc.host-port=my.host-port.com")
 
 	Update(jaeger, &commonSpec, &options)
-	assert.Len(t, commonSpec.Volumes, 0)
-	assert.Len(t, commonSpec.VolumeMounts, 0)
+	assert.Empty(t, commonSpec.Volumes)
+	assert.Empty(t, commonSpec.VolumeMounts)
 	assert.Len(t, options, 1)
 	assert.Equal(t, "--reporter.grpc.host-port=my.host-port.com", options[0])
 }

--- a/pkg/config/ui/ui_test.go
+++ b/pkg/config/ui/ui_test.go
@@ -49,9 +49,9 @@ func TestUpdateNoUIConfig(t *testing.T) {
 	options := []string{}
 
 	Update(jaeger, &commonSpec, &options)
-	assert.Len(t, commonSpec.Volumes, 0)
-	assert.Len(t, commonSpec.VolumeMounts, 0)
-	assert.Len(t, options, 0)
+	assert.Empty(t, commonSpec.Volumes)
+	assert.Empty(t, commonSpec.VolumeMounts)
+	assert.Empty(t, options)
 }
 
 func TestUpdateWithUIConfig(t *testing.T) {

--- a/pkg/consolelink/main_test.go
+++ b/pkg/consolelink/main_test.go
@@ -51,7 +51,7 @@ func TestUpdateHref(t *testing.T) {
 	}
 
 	link := Get(jaeger, &route)
-	assert.Equal(t, link.Spec.Href, "")
+	assert.Equal(t, "", link.Spec.Href)
 	route.Spec.Host = "namespace.somehostname"
 	newLinks := UpdateHref([]corev1.Route{route}, []consolev1.ConsoleLink{*link})
 	assert.Equal(t, fmt.Sprintf("https://%s", route.Spec.Host), newLinks[0].Spec.Href)

--- a/pkg/controller/jaeger/account_test.go
+++ b/pkg/controller/jaeger/account_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -41,7 +42,7 @@ func TestServiceAccountCreate(t *testing.T) {
 	res, err := r.Reconcile(req)
 
 	// verify
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, res.Requeue, "We don't requeue for now")
 
 	persisted := &corev1.ServiceAccount{}
@@ -51,7 +52,7 @@ func TestServiceAccountCreate(t *testing.T) {
 	}
 	err = cl.Get(context.Background(), persistedName, persisted)
 	assert.Equal(t, persistedName.Name, persisted.Name)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestServiceAccountUpdate(t *testing.T) {
@@ -83,7 +84,7 @@ func TestServiceAccountUpdate(t *testing.T) {
 
 	// test
 	_, err := r.Reconcile(reconcile.Request{NamespacedName: nsn})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// verify
 	persisted := &corev1.ServiceAccount{}
@@ -93,7 +94,7 @@ func TestServiceAccountUpdate(t *testing.T) {
 	}
 	err = cl.Get(context.Background(), persistedName, persisted)
 	assert.Equal(t, "new-value", persisted.Annotations["key"])
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestServiceAccountDelete(t *testing.T) {
@@ -119,7 +120,7 @@ func TestServiceAccountDelete(t *testing.T) {
 
 	// test
 	_, err := r.Reconcile(reconcile.Request{NamespacedName: nsn})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// verify
 	persisted := &corev1.ServiceAccount{}
@@ -129,7 +130,7 @@ func TestServiceAccountDelete(t *testing.T) {
 	}
 	err = cl.Get(context.Background(), persistedName, persisted)
 	assert.Empty(t, persisted.Name)
-	assert.Error(t, err) // not found
+	require.Error(t, err) // not found
 }
 
 func TestAccountCreateExistingNameInAnotherNamespace(t *testing.T) {
@@ -173,18 +174,18 @@ func TestAccountCreateExistingNameInAnotherNamespace(t *testing.T) {
 	res, err := r.Reconcile(req)
 
 	// verify
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, res.Requeue, "We don't requeue for now")
 
 	persisted := &corev1.ServiceAccount{}
 	err = cl.Get(context.Background(), nsn, persisted)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, nsn.Name, persisted.Name)
 	assert.Equal(t, nsn.Namespace, persisted.Namespace)
 
 	persistedExisting := &corev1.ServiceAccount{}
 	err = cl.Get(context.Background(), nsnExisting, persistedExisting)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, nsnExisting.Name, persistedExisting.Name)
 	assert.Equal(t, nsnExisting.Namespace, persistedExisting.Namespace)
 }

--- a/pkg/controller/jaeger/clusterrolebinding_test.go
+++ b/pkg/controller/jaeger/clusterrolebinding_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	rbac "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -48,7 +49,7 @@ func TestClusterRoleBindingsCreate(t *testing.T) {
 	res, err := r.Reconcile(req)
 
 	// verify
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, res.Requeue, "We don't requeue for now")
 
 	persisted := &rbac.ClusterRoleBinding{}
@@ -58,7 +59,7 @@ func TestClusterRoleBindingsCreate(t *testing.T) {
 	}
 	err = cl.Get(context.Background(), persistedName, persisted)
 	assert.Equal(t, persistedName.Name, persisted.Name)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestClusterRoleBindingsSkipped(t *testing.T) {
@@ -92,7 +93,7 @@ func TestClusterRoleBindingsSkipped(t *testing.T) {
 	res, err := r.Reconcile(req)
 
 	// verify
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, res.Requeue, "We don't requeue for now")
 
 	persisted := &rbac.ClusterRoleBinding{}
@@ -138,7 +139,7 @@ func TestClusterRoleBindingsUpdate(t *testing.T) {
 
 	// test
 	_, err := r.Reconcile(reconcile.Request{NamespacedName: nsn})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// verify
 	persisted := &rbac.ClusterRoleBinding{}
@@ -148,7 +149,7 @@ func TestClusterRoleBindingsUpdate(t *testing.T) {
 	}
 	err = cl.Get(context.Background(), persistedName, persisted)
 	assert.Equal(t, "new-value", persisted.Annotations["key"])
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestClusterRoleBindingsDelete(t *testing.T) {
@@ -179,7 +180,7 @@ func TestClusterRoleBindingsDelete(t *testing.T) {
 
 	// test
 	_, err := r.Reconcile(reconcile.Request{NamespacedName: nsn})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// verify
 	persisted := &rbac.ClusterRoleBinding{}
@@ -189,5 +190,5 @@ func TestClusterRoleBindingsDelete(t *testing.T) {
 	}
 	err = cl.Get(context.Background(), persistedName, persisted)
 	assert.Empty(t, persisted.Name)
-	assert.Error(t, err) // not found
+	require.Error(t, err) // not found
 }

--- a/pkg/controller/jaeger/configmap_test.go
+++ b/pkg/controller/jaeger/configmap_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -44,7 +45,7 @@ func TestConfigMapsCreate(t *testing.T) {
 	res, err := r.Reconcile(req)
 
 	// verify
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, res.Requeue, "We don't requeue for now")
 
 	persisted := &corev1.ConfigMap{}
@@ -54,7 +55,7 @@ func TestConfigMapsCreate(t *testing.T) {
 	}
 	err = cl.Get(context.Background(), persistedName, persisted)
 	assert.Equal(t, persistedName.Name, persisted.Name)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestConfigMapsUpdate(t *testing.T) {
@@ -88,7 +89,7 @@ func TestConfigMapsUpdate(t *testing.T) {
 
 	// test
 	_, err := r.Reconcile(reconcile.Request{NamespacedName: nsn})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// verify
 	persisted := &corev1.ConfigMap{}
@@ -98,7 +99,7 @@ func TestConfigMapsUpdate(t *testing.T) {
 	}
 	err = cl.Get(context.Background(), persistedName, persisted)
 	assert.Equal(t, "new-value", persisted.Annotations["key"])
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestConfigMapsDelete(t *testing.T) {
@@ -126,7 +127,7 @@ func TestConfigMapsDelete(t *testing.T) {
 
 	// test
 	_, err := r.Reconcile(reconcile.Request{NamespacedName: nsn})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// verify
 	persisted := &corev1.ConfigMap{}
@@ -136,7 +137,7 @@ func TestConfigMapsDelete(t *testing.T) {
 	}
 	err = cl.Get(context.Background(), persistedName, persisted)
 	assert.Empty(t, persisted.Name)
-	assert.Error(t, err) // not found
+	require.Error(t, err) // not found
 }
 
 func TestConfigMapCreateExistingNameInAnotherNamespace(t *testing.T) {
@@ -180,18 +181,18 @@ func TestConfigMapCreateExistingNameInAnotherNamespace(t *testing.T) {
 	res, err := r.Reconcile(req)
 
 	// verify
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, res.Requeue, "We don't requeue for now")
 
 	persisted := &corev1.ConfigMap{}
 	err = cl.Get(context.Background(), nsn, persisted)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, nsn.Name, persisted.Name)
 	assert.Equal(t, nsn.Namespace, persisted.Namespace)
 
 	persistedExisting := &corev1.ConfigMap{}
 	err = cl.Get(context.Background(), nsnExisting, persistedExisting)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, nsnExisting.Name, persistedExisting.Name)
 	assert.Equal(t, nsnExisting.Namespace, persistedExisting.Namespace)
 }
@@ -244,16 +245,16 @@ func TestConfigMapsClean(t *testing.T) {
 	// The three defined ConfigMaps exist
 	configMaps := &corev1.ConfigMapList{}
 	err := cl.List(context.Background(), configMaps)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, configMaps.Items, 3)
 
 	// Reconcile non-exist jaeger
 	_, err = r.Reconcile(reconcile.Request{NamespacedName: nsnNonExist})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Check that configmaps were clean up.
 	err = cl.List(context.Background(), configMaps)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, configMaps.Items, 1)
 	assert.Equal(t, fmt.Sprintf("%s-service-ca", nsnExisting.Name), configMaps.Items[0].Name)
 }

--- a/pkg/controller/jaeger/consolelink_test.go
+++ b/pkg/controller/jaeger/consolelink_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -63,7 +64,7 @@ func TestConsoleLinkCreate(t *testing.T) {
 	res, err := r.Reconcile(req)
 
 	// verify
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, res.Requeue, "We don't requeue for now")
 
 	persisted := &osconsolev1.ConsoleLink{}
@@ -73,9 +74,9 @@ func TestConsoleLinkCreate(t *testing.T) {
 	}
 	err = cl.Get(context.Background(), persistedName, persisted)
 	assert.Equal(t, persistedName.Name, persisted.Name)
-	assert.Equal(t, persisted.Spec.Href, "https://myhost")
+	assert.Equal(t, "https://myhost", persisted.Spec.Href)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestConsoleLinkUpdate(t *testing.T) {
@@ -123,7 +124,7 @@ func TestConsoleLinkUpdate(t *testing.T) {
 
 	// test
 	_, err := r.Reconcile(reconcile.Request{NamespacedName: nsn})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// verify
 	persisted := &osconsolev1.ConsoleLink{}
@@ -133,7 +134,7 @@ func TestConsoleLinkUpdate(t *testing.T) {
 	}
 	err = cl.Get(context.Background(), persistedName, persisted)
 	assert.Equal(t, "new-value", persisted.Annotations["key"])
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestConsoleLinkDelete(t *testing.T) {
@@ -165,7 +166,7 @@ func TestConsoleLinkDelete(t *testing.T) {
 
 	// test
 	_, err := r.Reconcile(reconcile.Request{NamespacedName: nsn})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// verify
 	persisted := &osconsolev1.ConsoleLink{}
@@ -175,7 +176,7 @@ func TestConsoleLinkDelete(t *testing.T) {
 	}
 	err = cl.Get(context.Background(), persistedName, persisted)
 	assert.Empty(t, persisted.Name)
-	assert.Error(t, err) // not found
+	require.Error(t, err) // not found
 }
 
 func TestConsoleLinksCreateExistingNameInAnotherNamespace(t *testing.T) {
@@ -263,12 +264,12 @@ func TestConsoleLinksCreateExistingNameInAnotherNamespace(t *testing.T) {
 	res, err := r.Reconcile(req)
 
 	// verify
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, res.Requeue, "We don't requeue for now")
 
 	persisted := &osconsolev1.ConsoleLink{}
 	err = cl.Get(context.Background(), nsn, persisted)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, nsn.Name, persisted.Name)
 	assert.Equal(t, nsn.Namespace, persisted.Namespace)
 	// New instance should have Href=host2
@@ -276,7 +277,7 @@ func TestConsoleLinksCreateExistingNameInAnotherNamespace(t *testing.T) {
 
 	persistedExisting := &osconsolev1.ConsoleLink{}
 	err = cl.Get(context.Background(), nsnExisting, persistedExisting)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, nsnExisting.Name, persistedExisting.Name)
 	assert.Equal(t, nsnExisting.Namespace, persistedExisting.Namespace)
 	// Existing should have Href=host1, reconciliation should not touch existing instances.
@@ -329,7 +330,7 @@ func TestConsoleLinksSkipped(t *testing.T) {
 	res, err := r.Reconcile(req)
 
 	// verify
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, res.Requeue, "We don't requeue for now")
 
 	persisted := &osconsolev1.ConsoleLink{}

--- a/pkg/controller/jaeger/cronjob_test.go
+++ b/pkg/controller/jaeger/cronjob_test.go
@@ -8,6 +8,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -55,7 +56,7 @@ func TestCronJobsCreate(t *testing.T) {
 	res, err := r.Reconcile(req)
 
 	// verify
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, res.Requeue, "We don't requeue for now")
 
 	persisted := &batchv1.CronJob{}
@@ -65,7 +66,7 @@ func TestCronJobsCreate(t *testing.T) {
 	}
 	err = cl.Get(context.Background(), persistedName, persisted)
 	assert.Equal(t, persistedName.Name, persisted.Name)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestCronJobsUpdate(t *testing.T) {
@@ -102,7 +103,7 @@ func TestCronJobsUpdate(t *testing.T) {
 
 	// test
 	_, err := r.Reconcile(reconcile.Request{NamespacedName: nsn})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// verify
 	persisted := &batchv1.CronJob{}
@@ -112,7 +113,7 @@ func TestCronJobsUpdate(t *testing.T) {
 	}
 	err = cl.Get(context.Background(), persistedName, persisted)
 	assert.Equal(t, "new-value", persisted.Annotations["key"])
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestCronJobsDelete(t *testing.T) {
@@ -140,7 +141,7 @@ func TestCronJobsDelete(t *testing.T) {
 
 	// test
 	_, err := r.Reconcile(reconcile.Request{NamespacedName: nsn})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// verify
 	persisted := &batchv1.CronJob{}
@@ -150,7 +151,7 @@ func TestCronJobsDelete(t *testing.T) {
 	}
 	err = cl.Get(context.Background(), persistedName, persisted)
 	assert.Empty(t, persisted.Name)
-	assert.Error(t, err) // not found
+	require.Error(t, err) // not found
 }
 
 func TestCronJobsCreateExistingNameInAnotherNamespace(t *testing.T) {
@@ -200,18 +201,18 @@ func TestCronJobsCreateExistingNameInAnotherNamespace(t *testing.T) {
 	res, err := r.Reconcile(req)
 
 	// verify
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, res.Requeue, "We don't requeue for now")
 
 	persisted := &batchv1.CronJob{}
 	err = cl.Get(context.Background(), nsn, persisted)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, nsn.Name, persisted.Name)
 	assert.Equal(t, nsn.Namespace, persisted.Namespace)
 
 	persistedExisting := &batchv1.CronJob{}
 	err = cl.Get(context.Background(), nsnExisting, persistedExisting)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, nsnExisting.Name, persistedExisting.Name)
 	assert.Equal(t, nsnExisting.Namespace, persistedExisting.Namespace)
 }

--- a/pkg/controller/jaeger/daemonset_test.go
+++ b/pkg/controller/jaeger/daemonset_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -43,7 +44,7 @@ func TestDaemonSetsCreate(t *testing.T) {
 	res, err := r.Reconcile(req)
 
 	// verify
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, res.Requeue, "We don't requeue for now")
 
 	persisted := &appsv1.DaemonSet{}
@@ -53,7 +54,7 @@ func TestDaemonSetsCreate(t *testing.T) {
 	}
 	err = cl.Get(context.Background(), persistedName, persisted)
 	assert.Equal(t, persistedName.Name, persisted.Name)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestDaemonSetsUpdate(t *testing.T) {
@@ -87,7 +88,7 @@ func TestDaemonSetsUpdate(t *testing.T) {
 
 	// test
 	_, err := r.Reconcile(reconcile.Request{NamespacedName: nsn})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// verify
 	persisted := &appsv1.DaemonSet{}
@@ -97,7 +98,7 @@ func TestDaemonSetsUpdate(t *testing.T) {
 	}
 	err = cl.Get(context.Background(), persistedName, persisted)
 	assert.Equal(t, "new-value", persisted.Annotations["key"])
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestDaemonSetsDelete(t *testing.T) {
@@ -125,7 +126,7 @@ func TestDaemonSetsDelete(t *testing.T) {
 
 	// test
 	_, err := r.Reconcile(reconcile.Request{NamespacedName: nsn})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// verify
 	persisted := &appsv1.DaemonSet{}
@@ -135,7 +136,7 @@ func TestDaemonSetsDelete(t *testing.T) {
 	}
 	err = cl.Get(context.Background(), persistedName, persisted)
 	assert.Empty(t, persisted.Name)
-	assert.Error(t, err) // not found
+	require.Error(t, err) // not found
 }
 
 func TestDaemonSetsCreateExistingNameInAnotherNamespace(t *testing.T) {
@@ -179,18 +180,18 @@ func TestDaemonSetsCreateExistingNameInAnotherNamespace(t *testing.T) {
 	res, err := r.Reconcile(req)
 
 	// verify
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, res.Requeue, "We don't requeue for now")
 
 	persisted := &appsv1.DaemonSet{}
 	err = cl.Get(context.Background(), nsn, persisted)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, nsn.Name, persisted.Name)
 	assert.Equal(t, nsn.Namespace, persisted.Namespace)
 
 	persistedExisting := &appsv1.DaemonSet{}
 	err = cl.Get(context.Background(), nsnExisting, persistedExisting)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, nsnExisting.Name, persistedExisting.Name)
 	assert.Equal(t, nsnExisting.Namespace, persistedExisting.Namespace)
 }

--- a/pkg/controller/jaeger/dependencies_test.go
+++ b/pkg/controller/jaeger/dependencies_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -38,7 +39,7 @@ func TestHandleDependencies(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		_, err := r.Reconcile(reconcile.Request{NamespacedName: nsn})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		wg.Done()
 	}()
 
@@ -46,14 +47,14 @@ func TestHandleDependencies(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	persisted := &batchv1.Job{}
-	assert.NoError(t, cl.Get(context.Background(), nsn, persisted))
+	require.NoError(t, cl.Get(context.Background(), nsn, persisted))
 	persisted.Status.Succeeded = 1
-	assert.NoError(t, cl.Status().Update(context.Background(), persisted))
+	require.NoError(t, cl.Status().Update(context.Background(), persisted))
 
 	wg.Wait()
 
 	// verify
 	persisted = &batchv1.Job{}
-	assert.NoError(t, cl.Get(context.Background(), nsn, persisted))
+	require.NoError(t, cl.Get(context.Background(), nsn, persisted))
 	assert.Equal(t, nsn.Name, persisted.Name)
 }

--- a/pkg/controller/jaeger/elasticsearch_test.go
+++ b/pkg/controller/jaeger/elasticsearch_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -49,7 +50,7 @@ func TestElasticsearchesCreate(t *testing.T) {
 	res, err := r.Reconcile(req)
 
 	// verify
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, res.Requeue, "We don't requeue for now")
 
 	persisted := &esv1.Elasticsearch{}
@@ -59,7 +60,7 @@ func TestElasticsearchesCreate(t *testing.T) {
 	}
 	err = cl.Get(context.Background(), persistedName, persisted)
 	assert.Equal(t, persistedName.Name, persisted.Name)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestElasticsearchesUpdate(t *testing.T) {
@@ -96,7 +97,7 @@ func TestElasticsearchesUpdate(t *testing.T) {
 
 	// test
 	_, err := r.Reconcile(reconcile.Request{NamespacedName: nsn})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// verify
 	persisted := &esv1.Elasticsearch{}
@@ -106,7 +107,7 @@ func TestElasticsearchesUpdate(t *testing.T) {
 	}
 	err = cl.Get(context.Background(), persistedName, persisted)
 	assert.Equal(t, "new-value", persisted.Annotations["key"])
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestElasticsearchesDelete(t *testing.T) {
@@ -137,7 +138,7 @@ func TestElasticsearchesDelete(t *testing.T) {
 
 	// test
 	_, err := r.Reconcile(reconcile.Request{NamespacedName: nsn})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// verify
 	persisted := &esv1.Elasticsearch{}
@@ -147,7 +148,7 @@ func TestElasticsearchesDelete(t *testing.T) {
 	}
 	err = cl.Get(context.Background(), persistedName, persisted)
 	assert.Empty(t, persisted.Name)
-	assert.Error(t, err) // not found
+	require.Error(t, err) // not found
 }
 
 func TestElasticsearchesCreateExistingNameInAnotherNamespace(t *testing.T) {
@@ -194,18 +195,18 @@ func TestElasticsearchesCreateExistingNameInAnotherNamespace(t *testing.T) {
 	res, err := r.Reconcile(req)
 
 	// verify
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, res.Requeue, "We don't requeue for now")
 
 	persisted := &esv1.Elasticsearch{}
 	err = cl.Get(context.Background(), nsn, persisted)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, nsn.Name, persisted.Name)
 	assert.Equal(t, nsn.Namespace, persisted.Namespace)
 
 	persistedExisting := &esv1.Elasticsearch{}
 	err = cl.Get(context.Background(), nsnExisting, persistedExisting)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, nsnExisting.Name, persistedExisting.Name)
 	assert.Equal(t, nsnExisting.Namespace, persistedExisting.Namespace)
 }

--- a/pkg/controller/jaeger/horizontalpodautoscaler_test.go
+++ b/pkg/controller/jaeger/horizontalpodautoscaler_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -51,7 +52,7 @@ func TestHorizontalPodAutoscalerCreateV2(t *testing.T) {
 	res, err := r.Reconcile(req)
 
 	// verify
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, res.Requeue, "We don't requeue for now")
 
 	persisted := &autoscalingv2.HorizontalPodAutoscaler{}
@@ -61,7 +62,7 @@ func TestHorizontalPodAutoscalerCreateV2(t *testing.T) {
 	}
 	err = cl.Get(context.Background(), persistedName, persisted)
 	assert.Equal(t, persistedName.Name, persisted.Name)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestHorizontalPodAutoscalerCreateV2Beta2(t *testing.T) {
@@ -97,7 +98,7 @@ func TestHorizontalPodAutoscalerCreateV2Beta2(t *testing.T) {
 	res, err := r.Reconcile(req)
 
 	// verify
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, res.Requeue, "We don't requeue for now")
 
 	persisted := &autoscalingv2beta2.HorizontalPodAutoscaler{}
@@ -107,7 +108,7 @@ func TestHorizontalPodAutoscalerCreateV2Beta2(t *testing.T) {
 	}
 	err = cl.Get(context.Background(), persistedName, persisted)
 	assert.Equal(t, persistedName.Name, persisted.Name)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestHorizontalPodAutoscalerUpdateV2(t *testing.T) {
@@ -147,7 +148,7 @@ func TestHorizontalPodAutoscalerUpdateV2(t *testing.T) {
 
 	// test
 	_, err := r.Reconcile(reconcile.Request{NamespacedName: nsn})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// verify
 	persisted := &autoscalingv2.HorizontalPodAutoscaler{}
@@ -157,7 +158,7 @@ func TestHorizontalPodAutoscalerUpdateV2(t *testing.T) {
 	}
 	err = cl.Get(context.Background(), persistedName, persisted)
 	assert.Equal(t, "new-value", persisted.Annotations["key"])
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestHorizontalPodAutoscalerUpdateV2Beta2(t *testing.T) {
@@ -197,7 +198,7 @@ func TestHorizontalPodAutoscalerUpdateV2Beta2(t *testing.T) {
 
 	// test
 	_, err := r.Reconcile(reconcile.Request{NamespacedName: nsn})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// verify
 	persisted := &autoscalingv2beta2.HorizontalPodAutoscaler{}
@@ -207,7 +208,7 @@ func TestHorizontalPodAutoscalerUpdateV2Beta2(t *testing.T) {
 	}
 	err = cl.Get(context.Background(), persistedName, persisted)
 	assert.Equal(t, "new-value", persisted.Annotations["key"])
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestHorizontalPodAutoscalerDeleteV2(t *testing.T) {
@@ -236,7 +237,7 @@ func TestHorizontalPodAutoscalerDeleteV2(t *testing.T) {
 
 	// test
 	_, err := r.Reconcile(reconcile.Request{NamespacedName: nsn})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// verify
 	persisted := &autoscalingv2.HorizontalPodAutoscaler{}
@@ -246,7 +247,7 @@ func TestHorizontalPodAutoscalerDeleteV2(t *testing.T) {
 	}
 	err = cl.Get(context.Background(), persistedName, persisted)
 	assert.Empty(t, persisted.Name)
-	assert.Error(t, err) // not found
+	require.Error(t, err) // not found
 }
 
 func TestHorizontalPodAutoscalerDeleteV2Beta2(t *testing.T) {
@@ -275,7 +276,7 @@ func TestHorizontalPodAutoscalerDeleteV2Beta2(t *testing.T) {
 
 	// test
 	_, err := r.Reconcile(reconcile.Request{NamespacedName: nsn})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// verify
 	persisted := &autoscalingv2beta2.HorizontalPodAutoscaler{}
@@ -285,7 +286,7 @@ func TestHorizontalPodAutoscalerDeleteV2Beta2(t *testing.T) {
 	}
 	err = cl.Get(context.Background(), persistedName, persisted)
 	assert.Empty(t, persisted.Name)
-	assert.Error(t, err) // not found
+	require.Error(t, err) // not found
 }
 
 func TestHorizontalPodAutoscalerCreateExistingNameInAnotherNamespaceV2(t *testing.T) {
@@ -331,18 +332,18 @@ func TestHorizontalPodAutoscalerCreateExistingNameInAnotherNamespaceV2(t *testin
 	res, err := r.Reconcile(req)
 
 	// verify
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, res.Requeue, "We don't requeue for now")
 
 	persisted := &autoscalingv2.HorizontalPodAutoscaler{}
 	err = cl.Get(context.Background(), nsn, persisted)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, nsn.Name, persisted.Name)
 	assert.Equal(t, nsn.Namespace, persisted.Namespace)
 
 	persistedExisting := &autoscalingv2.HorizontalPodAutoscaler{}
 	err = cl.Get(context.Background(), nsnExisting, persistedExisting)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, nsnExisting.Name, persistedExisting.Name)
 	assert.Equal(t, nsnExisting.Namespace, persistedExisting.Namespace)
 }
@@ -390,18 +391,18 @@ func TestHorizontalPodAutoscalerCreateExistingNameInAnotherNamespaceV2Beta2(t *t
 	res, err := r.Reconcile(req)
 
 	// verify
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, res.Requeue, "We don't requeue for now")
 
 	persisted := &autoscalingv2beta2.HorizontalPodAutoscaler{}
 	err = cl.Get(context.Background(), nsn, persisted)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, nsn.Name, persisted.Name)
 	assert.Equal(t, nsn.Namespace, persisted.Namespace)
 
 	persistedExisting := &autoscalingv2beta2.HorizontalPodAutoscaler{}
 	err = cl.Get(context.Background(), nsnExisting, persistedExisting)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, nsnExisting.Name, persistedExisting.Name)
 	assert.Equal(t, nsnExisting.Namespace, persistedExisting.Namespace)
 }

--- a/pkg/controller/jaeger/ingress_test.go
+++ b/pkg/controller/jaeger/ingress_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -43,7 +44,7 @@ func TestIngressesCreate(t *testing.T) {
 	res, err := r.Reconcile(req)
 
 	// verify
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, res.Requeue, "We don't requeue for now")
 
 	persisted := &networkingv1.Ingress{}
@@ -53,7 +54,7 @@ func TestIngressesCreate(t *testing.T) {
 	}
 	err = cl.Get(context.Background(), persistedName, persisted)
 	assert.Equal(t, persistedName.Name, persisted.Name)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestIngressesUpdate(t *testing.T) {
@@ -87,7 +88,7 @@ func TestIngressesUpdate(t *testing.T) {
 
 	// test
 	_, err := r.Reconcile(reconcile.Request{NamespacedName: nsn})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// verify
 	persisted := &networkingv1.Ingress{}
@@ -97,7 +98,7 @@ func TestIngressesUpdate(t *testing.T) {
 	}
 	err = cl.Get(context.Background(), persistedName, persisted)
 	assert.Equal(t, "new-value", persisted.Annotations["key"])
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestIngressesDelete(t *testing.T) {
@@ -125,7 +126,7 @@ func TestIngressesDelete(t *testing.T) {
 
 	// test
 	_, err := r.Reconcile(reconcile.Request{NamespacedName: nsn})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// verify
 	persisted := &networkingv1.Ingress{}
@@ -135,7 +136,7 @@ func TestIngressesDelete(t *testing.T) {
 	}
 	err = cl.Get(context.Background(), persistedName, persisted)
 	assert.Empty(t, persisted.Name)
-	assert.Error(t, err) // not found
+	require.Error(t, err) // not found
 }
 
 func TestIngressesCreateExistingNameInAnotherNamespace(t *testing.T) {
@@ -179,18 +180,18 @@ func TestIngressesCreateExistingNameInAnotherNamespace(t *testing.T) {
 	res, err := r.Reconcile(req)
 
 	// verify
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, res.Requeue, "We don't requeue for now")
 
 	persisted := &networkingv1.Ingress{}
 	err = cl.Get(context.Background(), nsn, persisted)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, nsn.Name, persisted.Name)
 	assert.Equal(t, nsn.Namespace, persisted.Namespace)
 
 	persistedExisting := &networkingv1.Ingress{}
 	err = cl.Get(context.Background(), nsnExisting, persistedExisting)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, nsnExisting.Name, persistedExisting.Name)
 	assert.Equal(t, nsnExisting.Namespace, persistedExisting.Namespace)
 }

--- a/pkg/controller/jaeger/jaeger_controller_test.go
+++ b/pkg/controller/jaeger/jaeger_controller_test.go
@@ -186,7 +186,7 @@ func TestSyncOnJaegerChanges(t *testing.T) {
 
 	err = syncOnJaegerChanges(cl, cl, jaeger.Name)
 	assert.Equal(t, 4, cl.counter)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	cl.counter = 0
 
 	cl.updateErr = errUpdate
@@ -219,13 +219,13 @@ func TestNewJaegerInstance(t *testing.T) {
 	res, err := r.Reconcile(req)
 
 	// verify
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, res.Requeue, "We don't requeue for now")
 
 	persisted := &v1.Jaeger{}
 	err = cl.Get(context.Background(), req.NamespacedName, persisted)
 	assert.Equal(t, persisted.Name, nsn.Name)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// these are filled with default values
 	assert.Equal(t, v1.DeploymentStrategyAllInOne, persisted.Spec.Strategy)
@@ -259,7 +259,7 @@ func TestDeletedInstance(t *testing.T) {
 	res, err := r.Reconcile(req)
 
 	// verify
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, res.Requeue, "We don't requeue for now")
 
 	persisted := &v1.Jaeger{}
@@ -287,7 +287,7 @@ func TestSetOwnerOnNewInstance(t *testing.T) {
 	_, err := r.Reconcile(req)
 
 	// verify
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	persisted := &v1.Jaeger{}
 	cl.Get(context.Background(), req.NamespacedName, persisted)
 	assert.NotNil(t, persisted.Labels)
@@ -315,7 +315,7 @@ func TestSkipOnNonOwnedCR(t *testing.T) {
 	_, err := r.Reconcile(req)
 
 	// verify
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	persisted := &v1.Jaeger{}
 	cl.Get(context.Background(), req.NamespacedName, persisted)
 	assert.NotNil(t, persisted.Labels)
@@ -347,10 +347,10 @@ func TestGetResourceFromNonCachedClient(t *testing.T) {
 	_, err := r.Reconcile(req)
 
 	// verify
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	persisted := &v1.Jaeger{}
 	err = client.Get(context.Background(), req.NamespacedName, persisted)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.True(t, errors.IsNotFound(err))
 }
 
@@ -362,12 +362,12 @@ func TestGetSecretsForNamespace(t *testing.T) {
 
 	secrets := []corev1.Secret{secretOne, secretTwo}
 	filteredSecrets := r.getSecretsForNamespace(secrets, "foo")
-	assert.Equal(t, 2, len(filteredSecrets))
+	assert.Len(t, filteredSecrets, 2)
 
 	secretThree := createSecret("bar", "secretThree")
 	secrets = append(secrets, secretThree)
 	filteredSecrets = r.getSecretsForNamespace(secrets, "bar")
-	assert.Equal(t, 1, len(filteredSecrets))
+	assert.Len(t, filteredSecrets, 1)
 	assert.Contains(t, filteredSecrets, secretThree)
 }
 
@@ -388,7 +388,7 @@ func TestElasticsearchProvisioning(t *testing.T) {
 	secrets := &corev1.SecretList{}
 	err = cl.List(context.Background(), secrets, client.InNamespace("jaeger"))
 	require.NoError(t, err)
-	assert.Equal(t, 4, len(secrets.Items))
+	assert.Len(t, secrets.Items, 4)
 	assert.NotNil(t, getSecret("prod-jaeger-elasticsearch", *secrets))
 	assert.NotNil(t, getSecret("prod-master-certs", *secrets))
 	assert.NotNil(t, getSecret("prod-curator", *secrets))

--- a/pkg/controller/jaeger/kafka_test.go
+++ b/pkg/controller/jaeger/kafka_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -61,7 +62,7 @@ func TestKafkaCreate(t *testing.T) {
 	res, err := r.Reconcile(req)
 
 	// verify
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, res.Requeue, "We don't requeue for now")
 
 	persisted := &v1beta2.Kafka{}
@@ -71,7 +72,7 @@ func TestKafkaCreate(t *testing.T) {
 	}
 	err = cl.Get(context.Background(), persistedName, persisted)
 	assert.Equal(t, persistedName.Name, persisted.GetName())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestKafkaUpdate(t *testing.T) {
@@ -133,7 +134,7 @@ func TestKafkaUpdate(t *testing.T) {
 
 	// test
 	_, err := r.Reconcile(reconcile.Request{NamespacedName: nsn})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// verify
 	persisted := &v1beta2.Kafka{}
@@ -142,9 +143,9 @@ func TestKafkaUpdate(t *testing.T) {
 		Namespace: orig.GetNamespace(),
 	}
 	err = cl.Get(context.Background(), persistedName, persisted)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "new-value", persisted.Annotations["key"])
 }
 
@@ -181,7 +182,7 @@ func TestKafkaDelete(t *testing.T) {
 
 	// test
 	_, err := r.Reconcile(reconcile.Request{NamespacedName: nsn})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// verify
 	persisted := &v1beta2.Kafka{}
@@ -191,7 +192,7 @@ func TestKafkaDelete(t *testing.T) {
 	}
 	err = cl.Get(context.Background(), persistedName, persisted)
 	assert.Empty(t, persisted.GetName())
-	assert.Error(t, err) // not found
+	require.Error(t, err) // not found
 }
 
 func TestKafkaCreateExistingNameInAnotherNamespace(t *testing.T) {
@@ -258,18 +259,18 @@ func TestKafkaCreateExistingNameInAnotherNamespace(t *testing.T) {
 	res, err := r.Reconcile(req)
 
 	// verify
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, res.Requeue, "We don't requeue for now")
 
 	persisted := &v1beta2.Kafka{}
 	err = cl.Get(context.Background(), nsn, persisted)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, nsn.Name, persisted.GetName())
 	assert.Equal(t, nsn.Namespace, persisted.GetNamespace())
 
 	persistedExisting := &v1beta2.Kafka{}
 	err = cl.Get(context.Background(), nsnExisting, persistedExisting)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, nsnExisting.Name, persistedExisting.GetName())
 	assert.Equal(t, nsnExisting.Namespace, persistedExisting.GetNamespace())
 }

--- a/pkg/controller/jaeger/kafkauser_test.go
+++ b/pkg/controller/jaeger/kafkauser_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -61,7 +62,7 @@ func TestKafkaUserCreate(t *testing.T) {
 	res, err := r.Reconcile(req)
 
 	// verify
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, res.Requeue, "We don't requeue for now")
 
 	persisted := &v1beta2.KafkaUser{}
@@ -71,7 +72,7 @@ func TestKafkaUserCreate(t *testing.T) {
 	}
 	err = cl.Get(context.Background(), persistedName, persisted)
 	assert.Equal(t, persistedName.Name, persisted.GetName())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestKafkaUserUpdate(t *testing.T) {
@@ -133,7 +134,7 @@ func TestKafkaUserUpdate(t *testing.T) {
 
 	// test
 	_, err := r.Reconcile(reconcile.Request{NamespacedName: nsn})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// verify
 	persisted := &v1beta2.KafkaUser{}
@@ -142,9 +143,9 @@ func TestKafkaUserUpdate(t *testing.T) {
 		Namespace: orig.GetNamespace(),
 	}
 	err = cl.Get(context.Background(), persistedName, persisted)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "new-value", persisted.Annotations["key"])
 }
 
@@ -180,7 +181,7 @@ func TestKafkaUserDelete(t *testing.T) {
 
 	// test
 	_, err := r.Reconcile(reconcile.Request{NamespacedName: nsn})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// verify
 	persisted := &v1beta2.KafkaUser{}
@@ -190,7 +191,7 @@ func TestKafkaUserDelete(t *testing.T) {
 	}
 	err = cl.Get(context.Background(), persistedName, persisted)
 	assert.Empty(t, persisted.GetName())
-	assert.Error(t, err) // not found
+	require.Error(t, err) // not found
 }
 
 func TestKafkaUserCreateExistingNameInAnotherNamespace(t *testing.T) {
@@ -257,18 +258,18 @@ func TestKafkaUserCreateExistingNameInAnotherNamespace(t *testing.T) {
 	res, err := r.Reconcile(req)
 
 	// verify
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, res.Requeue, "We don't requeue for now")
 
 	persisted := &v1beta2.KafkaUser{}
 	err = cl.Get(context.Background(), nsn, persisted)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, nsn.Name, persisted.GetName())
 	assert.Equal(t, nsn.Namespace, persisted.GetNamespace())
 
 	persistedExisting := &v1beta2.KafkaUser{}
 	err = cl.Get(context.Background(), nsnExisting, persistedExisting)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, nsnExisting.Name, persistedExisting.GetName())
 	assert.Equal(t, nsnExisting.Namespace, persistedExisting.GetNamespace())
 }

--- a/pkg/controller/jaeger/route_test.go
+++ b/pkg/controller/jaeger/route_test.go
@@ -7,6 +7,7 @@ import (
 	osv1 "github.com/openshift/api/route/v1"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -47,7 +48,7 @@ func TestRoutesCreate(t *testing.T) {
 	res, err := r.Reconcile(req)
 
 	// verify
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, res.Requeue, "We don't requeue for now")
 
 	persisted := &osv1.Route{}
@@ -57,7 +58,7 @@ func TestRoutesCreate(t *testing.T) {
 	}
 	err = cl.Get(context.Background(), persistedName, persisted)
 	assert.Equal(t, persistedName.Name, persisted.Name)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestRoutesUpdate(t *testing.T) {
@@ -94,7 +95,7 @@ func TestRoutesUpdate(t *testing.T) {
 
 	// test
 	_, err := r.Reconcile(reconcile.Request{NamespacedName: nsn})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// verify
 	persisted := &osv1.Route{}
@@ -104,7 +105,7 @@ func TestRoutesUpdate(t *testing.T) {
 	}
 	err = cl.Get(context.Background(), persistedName, persisted)
 	assert.Equal(t, "new-value", persisted.Annotations["key"])
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestRoutesDelete(t *testing.T) {
@@ -135,7 +136,7 @@ func TestRoutesDelete(t *testing.T) {
 
 	// test
 	_, err := r.Reconcile(reconcile.Request{NamespacedName: nsn})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// verify
 	persisted := &osv1.Route{}
@@ -145,7 +146,7 @@ func TestRoutesDelete(t *testing.T) {
 	}
 	err = cl.Get(context.Background(), persistedName, persisted)
 	assert.Empty(t, persisted.Name)
-	assert.Error(t, err) // not found
+	require.Error(t, err) // not found
 }
 
 func TestRoutesCreateExistingNameInAnotherNamespace(t *testing.T) {
@@ -192,18 +193,18 @@ func TestRoutesCreateExistingNameInAnotherNamespace(t *testing.T) {
 	res, err := r.Reconcile(req)
 
 	// verify
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, res.Requeue, "We don't requeue for now")
 
 	persisted := &osv1.Route{}
 	err = cl.Get(context.Background(), nsn, persisted)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, nsn.Name, persisted.Name)
 	assert.Equal(t, nsn.Namespace, persisted.Namespace)
 
 	persistedExisting := &osv1.Route{}
 	err = cl.Get(context.Background(), nsnExisting, persistedExisting)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, nsnExisting.Name, persistedExisting.Name)
 	assert.Equal(t, nsnExisting.Namespace, persistedExisting.Namespace)
 }

--- a/pkg/controller/jaeger/secret_test.go
+++ b/pkg/controller/jaeger/secret_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -43,7 +44,7 @@ func TestSecretsCreate(t *testing.T) {
 	res, err := r.Reconcile(req)
 
 	// verify
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, res.Requeue, "We don't requeue for now")
 
 	persisted := &corev1.Secret{}
@@ -53,7 +54,7 @@ func TestSecretsCreate(t *testing.T) {
 	}
 	err = cl.Get(context.Background(), persistedName, persisted)
 	assert.Equal(t, persistedName.Name, persisted.Name)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestSecretsUpdate(t *testing.T) {
@@ -87,7 +88,7 @@ func TestSecretsUpdate(t *testing.T) {
 
 	// test
 	_, err := r.Reconcile(reconcile.Request{NamespacedName: nsn})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// verify
 	persisted := &corev1.Secret{}
@@ -97,7 +98,7 @@ func TestSecretsUpdate(t *testing.T) {
 	}
 	err = cl.Get(context.Background(), persistedName, persisted)
 	assert.Equal(t, "new-value", persisted.Annotations["key"])
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestSecretsDelete(t *testing.T) {
@@ -125,7 +126,7 @@ func TestSecretsDelete(t *testing.T) {
 
 	// test
 	_, err := r.Reconcile(reconcile.Request{NamespacedName: nsn})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// verify
 	persisted := &corev1.Secret{}
@@ -135,7 +136,7 @@ func TestSecretsDelete(t *testing.T) {
 	}
 	err = cl.Get(context.Background(), persistedName, persisted)
 	assert.Empty(t, persisted.Name)
-	assert.Error(t, err) // not found
+	require.Error(t, err) // not found
 }
 
 func TestSecretsCreateExistingNameInAnotherNamespace(t *testing.T) {
@@ -179,18 +180,18 @@ func TestSecretsCreateExistingNameInAnotherNamespace(t *testing.T) {
 	res, err := r.Reconcile(req)
 
 	// verify
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, res.Requeue, "We don't requeue for now")
 
 	persisted := &corev1.Secret{}
 	err = cl.Get(context.Background(), nsn, persisted)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, nsn.Name, persisted.Name)
 	assert.Equal(t, nsn.Namespace, persisted.Namespace)
 
 	persistedExisting := &corev1.Secret{}
 	err = cl.Get(context.Background(), nsnExisting, persistedExisting)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, nsnExisting.Name, persistedExisting.Name)
 	assert.Equal(t, nsnExisting.Namespace, persistedExisting.Namespace)
 }

--- a/pkg/controller/jaeger/service_test.go
+++ b/pkg/controller/jaeger/service_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -43,7 +44,7 @@ func TestServicesCreate(t *testing.T) {
 	res, err := r.Reconcile(req)
 
 	// verify
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, res.Requeue, "We don't requeue for now")
 
 	persisted := &corev1.Service{}
@@ -53,7 +54,7 @@ func TestServicesCreate(t *testing.T) {
 	}
 	err = cl.Get(context.Background(), persistedName, persisted)
 	assert.Equal(t, persistedName.Name, persisted.Name)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestServicesUpdate(t *testing.T) {
@@ -87,7 +88,7 @@ func TestServicesUpdate(t *testing.T) {
 
 	// test
 	_, err := r.Reconcile(reconcile.Request{NamespacedName: nsn})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// verify
 	persisted := &corev1.Service{}
@@ -97,7 +98,7 @@ func TestServicesUpdate(t *testing.T) {
 	}
 	err = cl.Get(context.Background(), persistedName, persisted)
 	assert.Equal(t, "new-value", persisted.Annotations["key"])
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestServicesDelete(t *testing.T) {
@@ -125,7 +126,7 @@ func TestServicesDelete(t *testing.T) {
 
 	// test
 	_, err := r.Reconcile(reconcile.Request{NamespacedName: nsn})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// verify
 	persisted := &corev1.Service{}
@@ -135,7 +136,7 @@ func TestServicesDelete(t *testing.T) {
 	}
 	err = cl.Get(context.Background(), persistedName, persisted)
 	assert.Empty(t, persisted.Name)
-	assert.Error(t, err) // not found
+	require.Error(t, err) // not found
 }
 
 func TestServicesCreateExistingNameInAnotherNamespace(t *testing.T) {
@@ -179,18 +180,18 @@ func TestServicesCreateExistingNameInAnotherNamespace(t *testing.T) {
 	res, err := r.Reconcile(req)
 
 	// verify
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, res.Requeue, "We don't requeue for now")
 
 	persisted := &corev1.Service{}
 	err = cl.Get(context.Background(), nsn, persisted)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, nsn.Name, persisted.Name)
 	assert.Equal(t, nsn.Namespace, persisted.Namespace)
 
 	persistedExisting := &corev1.Service{}
 	err = cl.Get(context.Background(), nsnExisting, persistedExisting)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, nsnExisting.Name, persistedExisting.Name)
 	assert.Equal(t, nsnExisting.Namespace, persistedExisting.Namespace)
 }

--- a/pkg/controller/jaeger/upgrade_test.go
+++ b/pkg/controller/jaeger/upgrade_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
 
 	v1 "github.com/jaegertracing/jaeger-operator/apis/v1"
@@ -28,7 +29,7 @@ func TestDirectNextMinor(t *testing.T) {
 	j, err := r.applyUpgrades(context.Background(), j)
 
 	// verify
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// we cannot make any other assumptions here, but we know that 1.12.0 is an older
 	// version, so, at least the status field should have been updated
@@ -44,7 +45,7 @@ func TestSetVersionOnNewInstance(t *testing.T) {
 	j, err := r.applyUpgrades(context.Background(), j)
 
 	// verify
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// we cannot make any other assumptions here, but we know that 1.12.0 is an older
 	// version, so, at least the status field should have been updated

--- a/pkg/controller/namespace/namespace_controller_test.go
+++ b/pkg/controller/namespace/namespace_controller_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -200,7 +201,7 @@ func TestReconcilieDeployment(t *testing.T) {
 			}
 
 			persisted := &appsv1.DeploymentList{}
-			assert.Nil(t, cl.List(context.Background(), persisted))
+			require.NoError(t, cl.List(context.Background(), persisted))
 
 			for _, p := range persisted.Items {
 				const notFound = -2
@@ -225,7 +226,7 @@ func TestReconcilieDeployment(t *testing.T) {
 				} else {
 					assert.True(t, ok)
 					rev, err := strconv.Atoi(revStr)
-					assert.Nil(t, err)
+					require.NoError(t, err)
 					assert.Equal(t, expectedRevision, rev)
 				}
 			}

--- a/pkg/cronjob/es_index_cleaner_test.go
+++ b/pkg/cronjob/es_index_cleaner_test.go
@@ -31,10 +31,10 @@ func TestCreateEsIndexCleaner(t *testing.T) {
 	jaeger.Spec.Storage.EsIndexCleaner.SuccessfulJobsHistoryLimit = &historyLimits
 	cronJob := CreateEsIndexCleaner(jaeger).(*batchv1.CronJob)
 
-	assert.Equal(t, 2, len(cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Args))
+	assert.Len(t, cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Args, 2)
 	// default number of days (7) is applied in normalize in controller
 	assert.Equal(t, []string{"0", "http://nowhere:666"}, cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Args)
-	assert.Equal(t, 1, len(cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Env))
+	assert.Len(t, cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Env, 1)
 	assert.Equal(t, "INDEX_PREFIX", cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Env[0].Name)
 	assert.Equal(t, "tenant1", cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Env[0].Value)
 	assert.Equal(t, historyLimits, *cronJob.Spec.SuccessfulJobsHistoryLimit)
@@ -62,12 +62,12 @@ func TestCreateEsIndexCleanerTypeMeta(t *testing.T) {
 		cronJobs := CreateEsIndexCleaner(jaeger)
 		switch tt := cronJobs.(type) {
 		case *batchv1beta1.CronJob:
-			assert.Equal(t, tt.Kind, "CronJob")
-			assert.Equal(t, tt.APIVersion, v1.FlagCronJobsVersionBatchV1Beta1)
+			assert.Equal(t, "CronJob", tt.Kind)
+			assert.Equal(t, v1.FlagCronJobsVersionBatchV1Beta1, tt.APIVersion)
 			viper.SetDefault(v1.FlagCronJobsVersion, v1.FlagCronJobsVersionBatchV1)
 		case *batchv1.CronJob:
-			assert.Equal(t, tt.Kind, "CronJob")
-			assert.Equal(t, tt.APIVersion, v1.FlagCronJobsVersionBatchV1)
+			assert.Equal(t, "CronJob", tt.Kind)
+			assert.Equal(t, v1.FlagCronJobsVersionBatchV1, tt.APIVersion)
 		}
 	}
 }

--- a/pkg/cronjob/es_rollover_test.go
+++ b/pkg/cronjob/es_rollover_test.go
@@ -28,7 +28,7 @@ func init() {
 
 func TestCreateRollover(t *testing.T) {
 	cj := CreateRollover(v1.NewJaeger(types.NamespacedName{Name: "pikachu"}))
-	assert.Equal(t, 2, len(cj))
+	assert.Len(t, cj, 2)
 }
 
 func TestCreateRolloverTypeMeta(t *testing.T) {
@@ -44,16 +44,16 @@ func TestCreateRolloverTypeMeta(t *testing.T) {
 			viper.SetDefault(v1.FlagCronJobsVersion, v1.FlagCronJobsVersionBatchV1Beta1)
 		}
 		cjs := CreateRollover(v1.NewJaeger(types.NamespacedName{Name: "pikachu"}))
-		assert.Equal(t, 2, len(cjs))
+		assert.Len(t, cjs, 2)
 		for _, cj := range cjs {
 			switch tt := cj.(type) {
 			case *batchv1beta1.CronJob:
-				assert.Equal(t, tt.Kind, "CronJob")
-				assert.Equal(t, tt.APIVersion, v1.FlagCronJobsVersionBatchV1Beta1)
+				assert.Equal(t, "CronJob", tt.Kind)
+				assert.Equal(t, v1.FlagCronJobsVersionBatchV1Beta1, tt.APIVersion)
 				viper.SetDefault(v1.FlagCronJobsVersion, v1.FlagCronJobsVersionBatchV1)
 			case *batchv1.CronJob:
-				assert.Equal(t, tt.Kind, "CronJob")
-				assert.Equal(t, tt.APIVersion, v1.FlagCronJobsVersionBatchV1)
+				assert.Equal(t, "CronJob", tt.Kind)
+				assert.Equal(t, v1.FlagCronJobsVersionBatchV1, tt.APIVersion)
 			}
 		}
 	}
@@ -72,7 +72,7 @@ func TestRollover(t *testing.T) {
 	assert.Equal(t, j.Namespace, cjob.Namespace)
 	assert.Equal(t, []metav1.OwnerReference{util.AsOwner(j)}, cjob.OwnerReferences)
 	assert.Equal(t, util.Labels("eevee-es-rollover", "cronjob-es-rollover", *j), cjob.Labels)
-	assert.Equal(t, 1, len(cjob.Spec.JobTemplate.Spec.Template.Spec.Containers))
+	assert.Len(t, cjob.Spec.JobTemplate.Spec.Template.Spec.Containers, 1)
 	assert.Equal(t, j.Spec.Storage.EsRollover.Image, cjob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Image)
 	assert.Equal(t, []string{"rollover", "foo"}, cjob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Args)
 	assert.Equal(t, []corev1.EnvVar{{Name: "INDEX_PREFIX", Value: "shortone"}, {Name: "CONDITIONS", Value: "weheee"}}, cjob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Env)
@@ -118,7 +118,7 @@ func TestLookback(t *testing.T) {
 	assert.Equal(t, j.Namespace, cjob.Namespace)
 	assert.Equal(t, []metav1.OwnerReference{util.AsOwner(j)}, cjob.OwnerReferences)
 	assert.Equal(t, util.Labels("squirtle-es-lookback", "cronjob-es-lookback", *j), cjob.Labels)
-	assert.Equal(t, 1, len(cjob.Spec.JobTemplate.Spec.Template.Spec.Containers))
+	assert.Len(t, cjob.Spec.JobTemplate.Spec.Template.Spec.Containers, 1)
 	assert.Equal(t, j.Spec.Storage.EsRollover.Image, cjob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Image)
 	assert.Equal(t, []string{"lookback", "foo"}, cjob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Args)
 	assert.Equal(t, []corev1.EnvVar{{Name: "INDEX_PREFIX", Value: "shortone"}, {Name: "UNIT", Value: "hours"}, {Name: "UNIT_COUNT", Value: "2"}}, cjob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Env)

--- a/pkg/cronjob/spark_dependencies_test.go
+++ b/pkg/cronjob/spark_dependencies_test.go
@@ -151,12 +151,12 @@ func TestCreateTypeMeta(t *testing.T) {
 		assert.NotNil(t, sd)
 		switch tt := sd.(type) {
 		case *batchv1beta1.CronJob:
-			assert.Equal(t, tt.Kind, "CronJob")
-			assert.Equal(t, tt.APIVersion, v1.FlagCronJobsVersionBatchV1Beta1)
+			assert.Equal(t, "CronJob", tt.Kind)
+			assert.Equal(t, v1.FlagCronJobsVersionBatchV1Beta1, tt.APIVersion)
 			viper.SetDefault(v1.FlagCronJobsVersion, v1.FlagCronJobsVersionBatchV1)
 		case *batchv1.CronJob:
-			assert.Equal(t, tt.Kind, "CronJob")
-			assert.Equal(t, tt.APIVersion, v1.FlagCronJobsVersionBatchV1)
+			assert.Equal(t, "CronJob", tt.Kind)
+			assert.Equal(t, v1.FlagCronJobsVersionBatchV1, tt.APIVersion)
 		}
 	}
 }

--- a/pkg/deployment/agent_test.go
+++ b/pkg/deployment/agent_test.go
@@ -269,12 +269,12 @@ func TestAgentArgumentsOpenshiftTLS(t *testing.T) {
 			assert.Len(t, dep.Spec.Template.Spec.Containers[0].Args, len(tt.expectedArgs))
 
 			for _, arg := range tt.expectedArgs {
-				assert.Greater(t, len(util.FindItem(arg, dep.Spec.Template.Spec.Containers[0].Args)), 0)
+				assert.NotEmpty(t, util.FindItem(arg, dep.Spec.Template.Spec.Containers[0].Args))
 			}
 
 			if tt.nonExpectedArgs != nil {
 				for _, arg := range tt.nonExpectedArgs {
-					assert.Equal(t, len(util.FindItem(arg, dep.Spec.Template.Spec.Containers[0].Args)), 0)
+					assert.Empty(t, util.FindItem(arg, dep.Spec.Template.Spec.Containers[0].Args))
 				}
 			}
 

--- a/pkg/deployment/all_in_one_test.go
+++ b/pkg/deployment/all_in_one_test.go
@@ -253,7 +253,7 @@ func TestAllInOneMountGlobalVolumes(t *testing.T) {
 	// Count includes the sampling configmap
 	assert.Len(t, podSpec.Containers[0].VolumeMounts, 2)
 	// allInOne volume is mounted
-	assert.Equal(t, podSpec.Containers[0].VolumeMounts[0].Name, "globalVolume")
+	assert.Equal(t, "globalVolume", podSpec.Containers[0].VolumeMounts[0].Name)
 }
 
 func TestAllInOneVolumeMountsWithSameName(t *testing.T) {
@@ -277,7 +277,7 @@ func TestAllInOneVolumeMountsWithSameName(t *testing.T) {
 	// Count includes the sampling configmap
 	assert.Len(t, podSpec.Containers[0].VolumeMounts, 2)
 	// allInOne volume is mounted
-	assert.Equal(t, podSpec.Containers[0].VolumeMounts[0].ReadOnly, false)
+	assert.False(t, podSpec.Containers[0].VolumeMounts[0].ReadOnly)
 }
 
 func TestAllInOneVolumeWithSameName(t *testing.T) {
@@ -301,7 +301,7 @@ func TestAllInOneVolumeWithSameName(t *testing.T) {
 	// Count includes the sampling configmap
 	assert.Len(t, podSpec.Volumes, 2)
 	// allInOne volume is mounted
-	assert.Equal(t, podSpec.Volumes[0].VolumeSource.HostPath.Path, "/data2")
+	assert.Equal(t, "/data2", podSpec.Volumes[0].VolumeSource.HostPath.Path)
 }
 
 func TestAllInOneResources(t *testing.T) {
@@ -447,7 +447,7 @@ func TestAllInOneArgumentsOpenshiftTLS(t *testing.T) {
 
 		if tt.nonExpectedArgs != nil {
 			for _, arg := range tt.nonExpectedArgs {
-				assert.Equal(t, len(util.FindItem(arg, dep.Spec.Template.Spec.Containers[0].Args)), 0)
+				assert.Empty(t, util.FindItem(arg, dep.Spec.Template.Spec.Containers[0].Args))
 			}
 		}
 	}
@@ -554,7 +554,7 @@ func TestAllInOneGRPCPlugin(t *testing.T) {
 			},
 		},
 	}, dep.Spec.Template.Spec.InitContainers)
-	require.Equal(t, 1, len(dep.Spec.Template.Spec.Containers))
+	require.Len(t, dep.Spec.Template.Spec.Containers, 1)
 	assert.Equal(t, []string{"--grpc-storage-plugin.binary=/plugin/plugin", "--sampling.strategies-file=/etc/jaeger/sampling/sampling.json"}, dep.Spec.Template.Spec.Containers[0].Args)
 }
 

--- a/pkg/deployment/collector_test.go
+++ b/pkg/deployment/collector_test.go
@@ -261,7 +261,7 @@ func TestCollectorMountGlobalVolumes(t *testing.T) {
 	// Count includes the sampling configmap
 	assert.Len(t, podSpec.Containers[0].VolumeMounts, 2)
 	// collector volume is mounted
-	assert.Equal(t, podSpec.Containers[0].VolumeMounts[0].Name, "globalVolume")
+	assert.Equal(t, "globalVolume", podSpec.Containers[0].VolumeMounts[0].Name)
 }
 
 func TestCollectorVolumeMountsWithSameName(t *testing.T) {
@@ -289,7 +289,7 @@ func TestCollectorVolumeMountsWithSameName(t *testing.T) {
 	// Count includes the sampling configmap
 	assert.Len(t, podSpec.Containers[0].VolumeMounts, 2)
 	// collector volume is mounted
-	assert.Equal(t, podSpec.Containers[0].VolumeMounts[0].ReadOnly, false)
+	assert.False(t, podSpec.Containers[0].VolumeMounts[0].ReadOnly)
 }
 
 func TestCollectorVolumeWithSameName(t *testing.T) {
@@ -317,7 +317,7 @@ func TestCollectorVolumeWithSameName(t *testing.T) {
 	// Count includes the sampling configmap
 	assert.Len(t, podSpec.Volumes, 2)
 	// collector volume is mounted
-	assert.Equal(t, podSpec.Volumes[0].VolumeSource.HostPath.Path, "/data2")
+	assert.Equal(t, "/data2", podSpec.Volumes[0].VolumeSource.HostPath.Path)
 }
 
 func TestCollectorResources(t *testing.T) {
@@ -558,7 +558,7 @@ func TestCollectorAutoscalersDisabledByExplicitReplicaSize(t *testing.T) {
 		a := c.Autoscalers()
 
 		// verify
-		assert.Len(t, a, 0)
+		assert.Empty(t, a)
 	}
 }
 
@@ -574,7 +574,7 @@ func TestCollectorAutoscalersDisabledByExplicitOption(t *testing.T) {
 	a := c.Autoscalers()
 
 	// verify
-	assert.Len(t, a, 0)
+	assert.Empty(t, a)
 }
 
 func TestCollectorAutoscalersSetMaxReplicas(t *testing.T) {
@@ -665,7 +665,7 @@ func TestCollectoArgumentsOpenshiftTLS(t *testing.T) {
 
 			if tt.nonExpectedArgs != nil {
 				for _, arg := range tt.nonExpectedArgs {
-					assert.Equal(t, len(util.FindItem(arg, dep.Spec.Template.Spec.Containers[0].Args)), 0)
+					assert.Empty(t, util.FindItem(arg, dep.Spec.Template.Spec.Containers[0].Args))
 				}
 			}
 		})
@@ -774,7 +774,7 @@ func TestCollectorGRPCPlugin(t *testing.T) {
 			},
 		},
 	}, dep.Spec.Template.Spec.InitContainers)
-	require.Equal(t, 1, len(dep.Spec.Template.Spec.Containers))
+	require.Len(t, dep.Spec.Template.Spec.Containers, 1)
 	assert.Equal(t, []string{"--grpc-storage-plugin.binary=/plugin/plugin", "--sampling.strategies-file=/etc/jaeger/sampling/sampling.json"}, dep.Spec.Template.Spec.Containers[0].Args)
 }
 

--- a/pkg/deployment/ingester_test.go
+++ b/pkg/deployment/ingester_test.go
@@ -249,7 +249,7 @@ func TestIngesterMountGlobalVolumes(t *testing.T) {
 
 	assert.Len(t, podSpec.Containers[0].VolumeMounts, 1)
 	// ingester volume is mounted
-	assert.Equal(t, podSpec.Containers[0].VolumeMounts[0].Name, "globalVolume")
+	assert.Equal(t, "globalVolume", podSpec.Containers[0].VolumeMounts[0].Name)
 }
 
 func TestIngesterVolumeMountsWithSameName(t *testing.T) {
@@ -276,7 +276,7 @@ func TestIngesterVolumeMountsWithSameName(t *testing.T) {
 
 	assert.Len(t, podSpec.Containers[0].VolumeMounts, 1)
 	// ingester volume is mounted
-	assert.Equal(t, podSpec.Containers[0].VolumeMounts[0].ReadOnly, false)
+	assert.False(t, podSpec.Containers[0].VolumeMounts[0].ReadOnly)
 }
 
 func TestIngesterVolumeWithSameName(t *testing.T) {
@@ -303,7 +303,7 @@ func TestIngesterVolumeWithSameName(t *testing.T) {
 
 	assert.Len(t, podSpec.Volumes, 1)
 	// ingester volume is mounted
-	assert.Equal(t, podSpec.Volumes[0].VolumeSource.HostPath.Path, "/data2")
+	assert.Equal(t, "/data2", podSpec.Volumes[0].VolumeSource.HostPath.Path)
 }
 
 func TestIngesterResources(t *testing.T) {
@@ -438,7 +438,7 @@ func TestIngesterAutoscalersDisabledByExplicitReplicaSize(t *testing.T) {
 		a := c.Autoscalers()
 
 		// verify
-		assert.Len(t, a, 0)
+		assert.Empty(t, a)
 	}
 }
 
@@ -453,7 +453,7 @@ func TestIngesterAutoscalersDisabledByExplicitOption(t *testing.T) {
 	a := c.Autoscalers()
 
 	// verify
-	assert.Len(t, a, 0)
+	assert.Empty(t, a)
 }
 
 func TestIngesterAutoscalersSetMaxReplicas(t *testing.T) {
@@ -577,7 +577,7 @@ func TestIngesterGRPCPlugin(t *testing.T) {
 			},
 		},
 	}, dep.Spec.Template.Spec.InitContainers)
-	require.Equal(t, 1, len(dep.Spec.Template.Spec.Containers))
+	require.Len(t, dep.Spec.Template.Spec.Containers, 1)
 	assert.Equal(t, []string{"--grpc-storage-plugin.binary=/plugin/plugin"}, dep.Spec.Template.Spec.Containers[0].Args)
 }
 

--- a/pkg/deployment/query_test.go
+++ b/pkg/deployment/query_test.go
@@ -229,7 +229,7 @@ func TestQueryMountGlobalVolumes(t *testing.T) {
 
 	assert.Len(t, podSpec.Containers[0].VolumeMounts, 1)
 	// query volume is mounted
-	assert.Equal(t, podSpec.Containers[0].VolumeMounts[0].Name, "globalVolume")
+	assert.Equal(t, "globalVolume", podSpec.Containers[0].VolumeMounts[0].Name)
 }
 
 func TestQueryVolumeMountsWithSameName(t *testing.T) {
@@ -256,7 +256,7 @@ func TestQueryVolumeMountsWithSameName(t *testing.T) {
 
 	assert.Len(t, podSpec.Containers[0].VolumeMounts, 1)
 	// query volume is mounted
-	assert.Equal(t, podSpec.Containers[0].VolumeMounts[0].ReadOnly, false)
+	assert.False(t, podSpec.Containers[0].VolumeMounts[0].ReadOnly)
 }
 
 func TestQueryVolumeWithSameName(t *testing.T) {
@@ -283,7 +283,7 @@ func TestQueryVolumeWithSameName(t *testing.T) {
 
 	assert.Len(t, podSpec.Volumes, 1)
 	// query volume is mounted
-	assert.Equal(t, podSpec.Volumes[0].VolumeSource.HostPath.Path, "/data2")
+	assert.Equal(t, "/data2", podSpec.Volumes[0].VolumeSource.HostPath.Path)
 }
 
 func TestQueryResources(t *testing.T) {
@@ -453,7 +453,7 @@ func TestQueryGRPCPlugin(t *testing.T) {
 			},
 		},
 	}, dep.Spec.Template.Spec.InitContainers)
-	require.Equal(t, 1, len(dep.Spec.Template.Spec.Containers))
+	require.Len(t, dep.Spec.Template.Spec.Containers, 1)
 	assert.Equal(t, []string{"--grpc-storage-plugin.binary=/plugin/plugin"}, dep.Spec.Template.Spec.Containers[0].Args)
 }
 

--- a/pkg/inject/oauth_proxy_test.go
+++ b/pkg/inject/oauth_proxy_test.go
@@ -46,7 +46,7 @@ func TestOAuthProxyTLSSecretVolumeIsAdded(t *testing.T) {
 func TestOAuthProxyTLSSecretVolumeIsNotAddedByDefault(t *testing.T) {
 	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
 	dep := OAuthProxy(jaeger, deployment.NewQuery(jaeger).Get())
-	assert.Len(t, dep.Spec.Template.Spec.Volumes, 0)
+	assert.Empty(t, dep.Spec.Template.Spec.Volumes)
 }
 
 func TestOAuthProxyConsistentServiceAccountName(t *testing.T) {

--- a/pkg/inject/sidecar_test.go
+++ b/pkg/inject/sidecar_test.go
@@ -52,9 +52,9 @@ func TestInjectSidecar(t *testing.T) {
 	assert.Equal(t, dep.Labels[Label], jaeger.Name)
 	assert.Len(t, dep.Spec.Template.Spec.Containers, 2)
 	assert.Contains(t, dep.Spec.Template.Spec.Containers[1].Image, "jaeger-agent")
-	assert.Len(t, dep.Spec.Template.Spec.Containers[0].Env, 0)
-	assert.Len(t, dep.Spec.Template.Spec.Containers[1].VolumeMounts, 0)
-	assert.Len(t, dep.Spec.Template.Spec.Volumes, 0)
+	assert.Empty(t, dep.Spec.Template.Spec.Containers[0].Env)
+	assert.Empty(t, dep.Spec.Template.Spec.Containers[1].VolumeMounts)
+	assert.Empty(t, dep.Spec.Template.Spec.Volumes)
 }
 
 func TestInjectSidecarOpenShift(t *testing.T) {
@@ -62,21 +62,21 @@ func TestInjectSidecarOpenShift(t *testing.T) {
 	defer reset()
 
 	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
-	assert.Len(t, jaeger.Spec.Agent.VolumeMounts, 0)
-	assert.Len(t, jaeger.Spec.Agent.Volumes, 0)
+	assert.Empty(t, jaeger.Spec.Agent.VolumeMounts)
+	assert.Empty(t, jaeger.Spec.Agent.Volumes)
 
 	dep := dep(map[string]string{}, map[string]string{})
 	dep = Sidecar(jaeger, dep)
 	assert.Equal(t, dep.Labels[Label], jaeger.Name)
 	assert.Len(t, dep.Spec.Template.Spec.Containers, 2)
 	assert.Contains(t, dep.Spec.Template.Spec.Containers[1].Image, "jaeger-agent")
-	assert.Len(t, dep.Spec.Template.Spec.Containers[0].Env, 0)
+	assert.Empty(t, dep.Spec.Template.Spec.Containers[0].Env)
 	assert.Len(t, dep.Spec.Template.Spec.Containers[1].VolumeMounts, 2)
 	assert.Len(t, dep.Spec.Template.Spec.Volumes, 2)
 
 	// CR should not be touched.
-	assert.Len(t, jaeger.Spec.Agent.VolumeMounts, 0)
-	assert.Len(t, jaeger.Spec.Agent.Volumes, 0)
+	assert.Empty(t, jaeger.Spec.Agent.VolumeMounts)
+	assert.Empty(t, jaeger.Spec.Agent.Volumes)
 }
 
 func TestInjectSidecarWithEnvVars(t *testing.T) {
@@ -218,7 +218,7 @@ func TestInjectSidecarWithEnvFromK8sAppName(t *testing.T) {
 
 	// verify
 	assert.Len(t, dep.Spec.Template.Spec.Containers, 2)
-	assert.Len(t, dep.Spec.Template.Spec.Containers[0].Env, 0)
+	assert.Empty(t, dep.Spec.Template.Spec.Containers[0].Env)
 	assert.Len(t, dep.Spec.Template.Spec.Containers[0].EnvFrom, 1)
 	actualConfigName := dep.Spec.Template.Spec.Containers[0].EnvFrom[0].ConfigMapRef.Name
 	assert.Contains(t, "test-config", actualConfigName)
@@ -318,8 +318,8 @@ func TestSidecarImagePullSecrets(t *testing.T) {
 	dep = Sidecar(jaeger, dep)
 
 	assert.Len(t, dep.Spec.Template.Spec.ImagePullSecrets, 2)
-	assert.Equal(t, dep.Spec.Template.Spec.ImagePullSecrets[0].Name, "deploymentImagePullSecret")
-	assert.Equal(t, dep.Spec.Template.Spec.ImagePullSecrets[1].Name, "agentImagePullSecret")
+	assert.Equal(t, "deploymentImagePullSecret", dep.Spec.Template.Spec.ImagePullSecrets[0].Name)
+	assert.Equal(t, "agentImagePullSecret", dep.Spec.Template.Spec.ImagePullSecrets[1].Name)
 }
 
 func TestSidecarDefaultPorts(t *testing.T) {
@@ -606,7 +606,7 @@ func TestSidecarOrderOfArguments(t *testing.T) {
 	containsOptionWithPrefix(t, dep.Spec.Template.Spec.Containers[1].Args, "--agent.tags")
 	containsOptionWithPrefix(t, dep.Spec.Template.Spec.Containers[1].Args, "--reporter.grpc.host-port")
 	agentTagsMap := parseAgentTags(dep.Spec.Template.Spec.Containers[1].Args)
-	assert.Equal(t, agentTagsMap["container.name"], "only_container")
+	assert.Equal(t, "only_container", agentTagsMap["container.name"])
 }
 
 func TestSidecarExplicitTags(t *testing.T) {
@@ -621,7 +621,7 @@ func TestSidecarExplicitTags(t *testing.T) {
 	// verify
 	assert.Len(t, dep.Spec.Template.Spec.Containers, 2)
 	agentTags := parseAgentTags(dep.Spec.Template.Spec.Containers[1].Args)
-	assert.Equal(t, agentTags, map[string]string{"key": "val"})
+	assert.Equal(t, map[string]string{"key": "val"}, agentTags)
 }
 
 func TestSidecarCustomReporterPort(t *testing.T) {
@@ -682,11 +682,11 @@ func TestCleanSidecars(t *testing.T) {
 	}
 	jaeger := v1.NewJaeger(nsn)
 	dep1 := Sidecar(jaeger, dep(map[string]string{}, map[string]string{}))
-	assert.Equal(t, 2, len(dep1.Spec.Template.Spec.Containers))
-	assert.Equal(t, 0, len(dep1.Spec.Template.Spec.Volumes))
+	assert.Len(t, dep1.Spec.Template.Spec.Containers, 2)
+	assert.Empty(t, dep1.Spec.Template.Spec.Volumes)
 	CleanSidecar(instanceName, dep1)
-	assert.Equal(t, 1, len(dep1.Spec.Template.Spec.Containers))
-	assert.Equal(t, 0, len(dep1.Spec.Template.Spec.Volumes))
+	assert.Len(t, dep1.Spec.Template.Spec.Containers, 1)
+	assert.Empty(t, dep1.Spec.Template.Spec.Volumes)
 }
 
 func TestCleanSidecarsOpenShift(t *testing.T) {
@@ -703,15 +703,15 @@ func TestCleanSidecarsOpenShift(t *testing.T) {
 	dep1 := Sidecar(jaeger, dep(map[string]string{}, map[string]string{}))
 
 	// sanity check
-	require.Equal(t, 2, len(dep1.Spec.Template.Spec.Containers))
-	require.Equal(t, 2, len(dep1.Spec.Template.Spec.Volumes))
+	require.Len(t, dep1.Spec.Template.Spec.Containers, 2)
+	require.Len(t, dep1.Spec.Template.Spec.Volumes, 2)
 
 	// test
 	CleanSidecar(instanceName, dep1)
 
 	// verify
-	assert.Equal(t, 1, len(dep1.Spec.Template.Spec.Containers))
-	assert.Equal(t, 0, len(dep1.Spec.Template.Spec.Volumes))
+	assert.Len(t, dep1.Spec.Template.Spec.Containers, 1)
+	assert.Empty(t, dep1.Spec.Template.Spec.Volumes)
 }
 
 func TestSidecarWithLabel(t *testing.T) {
@@ -722,12 +722,12 @@ func TestSidecarWithLabel(t *testing.T) {
 	jaeger := v1.NewJaeger(nsn)
 	dep1 := dep(map[string]string{}, map[string]string{})
 	dep1 = Sidecar(jaeger, dep1)
-	assert.Equal(t, dep1.Labels[Label], "my-instance")
+	assert.Equal(t, "my-instance", dep1.Labels[Label])
 	dep2 := dep(map[string]string{}, map[string]string{})
 	dep2.Labels = map[string]string{"anotherLabel": "anotherValue"}
 	dep2 = Sidecar(jaeger, dep2)
-	assert.Equal(t, len(dep2.Labels), 2)
-	assert.Equal(t, dep2.Labels["anotherLabel"], "anotherValue")
+	assert.Len(t, dep2.Labels, 2)
+	assert.Equal(t, "anotherValue", dep2.Labels["anotherLabel"])
 	assert.Equal(t, dep2.Labels[Label], jaeger.Name)
 }
 
@@ -756,8 +756,8 @@ func TestSidecarWithPrometheusAnnotations(t *testing.T) {
 	dep = Sidecar(jaeger, dep)
 
 	// verify
-	assert.Equal(t, dep.Annotations["prometheus.io/scrape"], "false")
-	assert.Equal(t, dep.Annotations["prometheus.io/port"], "9090")
+	assert.Equal(t, "false", dep.Annotations["prometheus.io/scrape"])
+	assert.Equal(t, "9090", dep.Annotations["prometheus.io/port"])
 }
 
 func TestSidecarAgentTagsWithMultipleContainers(t *testing.T) {
@@ -782,7 +782,7 @@ func TestSidecarAgentContainerNameTagWithDoubleInjectedContainer(t *testing.T) {
 	assert.Equal(t, "jaeger-agent", dep.Spec.Template.Spec.Containers[1].Name)
 	containsOptionWithPrefix(t, dep.Spec.Template.Spec.Containers[1].Args, "--agent.tags")
 	agentTagsMap := parseAgentTags(dep.Spec.Template.Spec.Containers[1].Args)
-	assert.Equal(t, agentTagsMap["container.name"], "only_container")
+	assert.Equal(t, "only_container", agentTagsMap["container.name"])
 
 	// inject - 2nd time due to deployment/namespace reconciliation
 	dep = Sidecar(jaeger, dep)
@@ -790,7 +790,7 @@ func TestSidecarAgentContainerNameTagWithDoubleInjectedContainer(t *testing.T) {
 	assert.Equal(t, "jaeger-agent", dep.Spec.Template.Spec.Containers[1].Name)
 	containsOptionWithPrefix(t, dep.Spec.Template.Spec.Containers[1].Args, "--agent.tags")
 	agentTagsMap = parseAgentTags(dep.Spec.Template.Spec.Containers[1].Args)
-	assert.Equal(t, agentTagsMap["container.name"], "only_container")
+	assert.Equal(t, "only_container", agentTagsMap["container.name"])
 }
 
 func ns(annotations map[string]string) *corev1.Namespace {
@@ -942,12 +942,12 @@ func TestSidecarArgumentsOpenshiftTLS(t *testing.T) {
 			assert.Len(t, dep.Spec.Template.Spec.Containers[1].Args, len(tt.expectedArgs))
 
 			for _, arg := range tt.expectedArgs {
-				assert.Greater(t, len(util.FindItem(arg, dep.Spec.Template.Spec.Containers[1].Args)), 0)
+				assert.NotEmpty(t, util.FindItem(arg, dep.Spec.Template.Spec.Containers[1].Args))
 			}
 
 			if tt.nonExpectedArgs != nil {
 				for _, arg := range tt.nonExpectedArgs {
-					assert.Equal(t, len(util.FindItem(arg, dep.Spec.Template.Spec.Containers[1].Args)), 0)
+					assert.Empty(t, util.FindItem(arg, dep.Spec.Template.Spec.Containers[1].Args))
 				}
 			}
 
@@ -1007,7 +1007,7 @@ func TestSidecarWithSecurityContext(t *testing.T) {
 	dep := dep(map[string]string{}, map[string]string{})
 	dep = Sidecar(jaeger, dep)
 	assert.Len(t, dep.Spec.Template.Spec.Containers, 2)
-	assert.Equal(t, dep.Spec.Template.Spec.Containers[1].SecurityContext, expectedSecurityContext)
+	assert.Equal(t, expectedSecurityContext, dep.Spec.Template.Spec.Containers[1].SecurityContext)
 }
 
 func TestSortedTags(t *testing.T) {
@@ -1046,7 +1046,7 @@ func TestSortedTagsWithContainer(t *testing.T) {
 
 func TestParseEmptyAgentTags(t *testing.T) {
 	tags := parseAgentTags([]string{})
-	assert.Equal(t, tags, map[string]string{})
+	assert.Equal(t, map[string]string{}, tags)
 }
 
 func TestGetContainerNameWithOneAppContainer(t *testing.T) {
@@ -1085,7 +1085,7 @@ func TestGetConfigMapsMatchedEnvFromInDeploymentWithEnvFromSecretRef(t *testing.
 
 	matchedConfigMaps := GetConfigMapsMatchedEnvFromInDeployment(*deploy, configMaps)
 
-	assert.Len(t, matchedConfigMaps, 0)
+	assert.Empty(t, matchedConfigMaps)
 }
 
 func TestGetConfigMapsMatchedEnvFromInDeploymentWithEnvFromConfigMapRef(t *testing.T) {
@@ -1096,7 +1096,7 @@ func TestGetConfigMapsMatchedEnvFromInDeploymentWithEnvFromConfigMapRef(t *testi
 	matchedConfigMaps := GetConfigMapsMatchedEnvFromInDeployment(*deploy, configMaps)
 
 	assert.Len(t, matchedConfigMaps, 1)
-	assert.Equal(t, matchedConfigMaps[0].Name, "test-config")
+	assert.Equal(t, "test-config", matchedConfigMaps[0].Name)
 }
 
 func TestGetConfigMapsMatchedEnvFromInDeploymentWithEnvFromConfigAndSecret(t *testing.T) {
@@ -1111,7 +1111,7 @@ func TestGetConfigMapsMatchedEnvFromInDeploymentWithEnvFromConfigAndSecret(t *te
 	matchedConfigMaps := GetConfigMapsMatchedEnvFromInDeployment(*deploy, configMaps)
 
 	assert.Len(t, matchedConfigMaps, 1)
-	assert.Equal(t, matchedConfigMaps[0].Name, "test-config")
+	assert.Equal(t, "test-config", matchedConfigMaps[0].Name)
 }
 
 func TestGetJaeger(t *testing.T) {

--- a/pkg/inventory/account_test.go
+++ b/pkg/inventory/account_test.go
@@ -52,8 +52,8 @@ func TestAccountInventory(t *testing.T) {
 	// but this might be set by the cluster -- in this case,
 	// we keep whatever is there, not touching the fields at all
 	assert.Equal(t, &trueVar, inv.Update[0].AutomountServiceAccountToken)
-	assert.Len(t, inv.Update[0].Secrets, 0)
-	assert.Len(t, inv.Update[0].ImagePullSecrets, 0)
+	assert.Empty(t, inv.Update[0].Secrets)
+	assert.Empty(t, inv.Update[0].ImagePullSecrets)
 
 	assert.Len(t, inv.Delete, 1)
 	assert.Equal(t, "to-delete", inv.Delete[0].Name)
@@ -76,6 +76,6 @@ func TestAccountInventoryWithSameNameInstances(t *testing.T) {
 	assert.Len(t, inv.Create, 2)
 	assert.Contains(t, inv.Create, create[0])
 	assert.Contains(t, inv.Create, create[1])
-	assert.Len(t, inv.Update, 0)
-	assert.Len(t, inv.Delete, 0)
+	assert.Empty(t, inv.Update)
+	assert.Empty(t, inv.Delete)
 }

--- a/pkg/inventory/configmap_test.go
+++ b/pkg/inventory/configmap_test.go
@@ -70,6 +70,6 @@ func TestConfigMapInventoryWithSameNameInstances(t *testing.T) {
 	assert.Len(t, inv.Create, 2)
 	assert.Contains(t, inv.Create, create[0])
 	assert.Contains(t, inv.Create, create[1])
-	assert.Len(t, inv.Update, 0)
-	assert.Len(t, inv.Delete, 0)
+	assert.Empty(t, inv.Update)
+	assert.Empty(t, inv.Delete)
 }

--- a/pkg/inventory/cronjob_test.go
+++ b/pkg/inventory/cronjob_test.go
@@ -85,8 +85,8 @@ func TestCronJobInventoryWithSameNameInstances(t *testing.T) {
 	assert.Len(t, inv.Create, 2)
 	assert.Contains(t, inv.Create, createObj[0])
 	assert.Contains(t, inv.Create, createObj[1])
-	assert.Len(t, inv.Update, 0)
-	assert.Len(t, inv.Delete, 0)
+	assert.Empty(t, inv.Update)
+	assert.Empty(t, inv.Delete)
 }
 
 func TestCronJobInventoryWithRepeats(t *testing.T) {
@@ -112,5 +112,5 @@ func TestCronJobInventoryWithRepeats(t *testing.T) {
 	for _, v := range inventory.Update {
 		fmt.Printf(v.(*batchv1.CronJob).Name)
 	}
-	assert.Len(t, inventory.Delete, 0)
+	assert.Empty(t, inventory.Delete)
 }

--- a/pkg/inventory/daemonset_test.go
+++ b/pkg/inventory/daemonset_test.go
@@ -70,6 +70,6 @@ func TestDaemonSetInventoryWithSameNameInstances(t *testing.T) {
 	assert.Len(t, inv.Create, 2)
 	assert.Contains(t, inv.Create, create[0])
 	assert.Contains(t, inv.Create, create[1])
-	assert.Len(t, inv.Update, 0)
-	assert.Len(t, inv.Delete, 0)
+	assert.Empty(t, inv.Update)
+	assert.Empty(t, inv.Delete)
 }

--- a/pkg/inventory/deployment_test.go
+++ b/pkg/inventory/deployment_test.go
@@ -76,8 +76,8 @@ func TestDeploymentInventoryWithSameNameInstances(t *testing.T) {
 	assert.Len(t, inv.Create, 2)
 	assert.Contains(t, create, create[0])
 	assert.Contains(t, create, create[1])
-	assert.Len(t, inv.Update, 0)
-	assert.Len(t, inv.Delete, 0)
+	assert.Empty(t, inv.Update)
+	assert.Empty(t, inv.Delete)
 }
 
 func TestDeploymentInventoryNewWithSameNameAsExisting(t *testing.T) {
@@ -104,7 +104,7 @@ func TestDeploymentInventoryNewWithSameNameAsExisting(t *testing.T) {
 	assert.Len(t, inv.Update, 1)
 	assert.Equal(t, inv.Update[0], existing[0])
 
-	assert.Len(t, inv.Delete, 0)
+	assert.Empty(t, inv.Delete)
 }
 
 func TestDeploymentKeepReplicasWhenDesiredIsNil(t *testing.T) {

--- a/pkg/inventory/elasticsearch_test.go
+++ b/pkg/inventory/elasticsearch_test.go
@@ -71,6 +71,6 @@ func TestElasticsearchInventoryWithSameNameInstances(t *testing.T) {
 	assert.Len(t, inv.Create, 2)
 	assert.Contains(t, inv.Create, create[0])
 	assert.Contains(t, inv.Create, create[1])
-	assert.Len(t, inv.Update, 0)
-	assert.Len(t, inv.Delete, 0)
+	assert.Empty(t, inv.Update)
+	assert.Empty(t, inv.Delete)
 }

--- a/pkg/inventory/horizontalpodautoscaler_test.go
+++ b/pkg/inventory/horizontalpodautoscaler_test.go
@@ -87,8 +87,8 @@ func TestHorizontalPodAutoscalerInventoryWithSameNameInstances(t *testing.T) {
 	assert.Len(t, inv.Create, 2)
 	assert.Contains(t, create, create[0])
 	assert.Contains(t, create, create[1])
-	assert.Len(t, inv.Update, 0)
-	assert.Len(t, inv.Delete, 0)
+	assert.Empty(t, inv.Update)
+	assert.Empty(t, inv.Delete)
 }
 
 func TestHorizontalPodAutoscalerInventoryNewWithSameNameAsExisting(t *testing.T) {
@@ -118,7 +118,7 @@ func TestHorizontalPodAutoscalerInventoryNewWithSameNameAsExisting(t *testing.T)
 	assert.Len(t, inv.Update, 1)
 	assert.Equal(t, inv.Update[0], existing[0])
 
-	assert.Len(t, inv.Delete, 0)
+	assert.Empty(t, inv.Delete)
 }
 
 func TestHorizontalPodAutoscalerInventoryNewWithSameNameAsExistingBeta2(t *testing.T) {
@@ -148,5 +148,5 @@ func TestHorizontalPodAutoscalerInventoryNewWithSameNameAsExistingBeta2(t *testi
 	assert.Len(t, inv.Update, 1)
 	assert.Equal(t, inv.Update[0], existing[0])
 
-	assert.Len(t, inv.Delete, 0)
+	assert.Empty(t, inv.Delete)
 }

--- a/pkg/inventory/ingress_test.go
+++ b/pkg/inventory/ingress_test.go
@@ -78,6 +78,6 @@ func TestIngressInventoryWithSameNameInstances(t *testing.T) {
 	assert.Len(t, inv.Create, 2)
 	assert.Contains(t, inv.Create, create[0])
 	assert.Contains(t, inv.Create, create[1])
-	assert.Len(t, inv.Update, 0)
-	assert.Len(t, inv.Delete, 0)
+	assert.Empty(t, inv.Update)
+	assert.Empty(t, inv.Delete)
 }

--- a/pkg/inventory/kafka_test.go
+++ b/pkg/inventory/kafka_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "github.com/jaegertracing/jaeger-operator/apis/v1"
@@ -54,7 +55,7 @@ func TestKafkaInventory(t *testing.T) {
 	assert.Len(t, inv.Update, 1)
 	assert.Equal(t, "to-update", inv.Update[0].Name)
 	contentMap, err := inv.Update[0].Spec.GetMap()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "changed", contentMap["key"])
 
 	assert.Len(t, inv.Delete, 1)
@@ -78,6 +79,6 @@ func TestKafkaInventoryWithSameNameInstances(t *testing.T) {
 	assert.Len(t, inv.Create, 2)
 	assert.Contains(t, inv.Create, create[0])
 	assert.Contains(t, inv.Create, create[1])
-	assert.Len(t, inv.Update, 0)
-	assert.Len(t, inv.Delete, 0)
+	assert.Empty(t, inv.Update)
+	assert.Empty(t, inv.Delete)
 }

--- a/pkg/inventory/kafkauser_test.go
+++ b/pkg/inventory/kafkauser_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "github.com/jaegertracing/jaeger-operator/apis/v1"
@@ -54,7 +55,7 @@ func TestKafkaUserInventory(t *testing.T) {
 	assert.Len(t, inv.Update, 1)
 	assert.Equal(t, "to-update", inv.Update[0].Name)
 	contentMap, err := inv.Update[0].Spec.GetMap()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "changed", contentMap["key"])
 
 	assert.Len(t, inv.Delete, 1)
@@ -78,6 +79,6 @@ func TestKafkaUserInventoryWithSameNameInstances(t *testing.T) {
 	assert.Len(t, inv.Create, 2)
 	assert.Contains(t, inv.Create, create[0])
 	assert.Contains(t, inv.Create, create[1])
-	assert.Len(t, inv.Update, 0)
-	assert.Len(t, inv.Delete, 0)
+	assert.Empty(t, inv.Update)
+	assert.Empty(t, inv.Delete)
 }

--- a/pkg/inventory/route_test.go
+++ b/pkg/inventory/route_test.go
@@ -70,6 +70,6 @@ func TestRouteInventoryWithSameNameInstances(t *testing.T) {
 	assert.Len(t, inv.Create, 2)
 	assert.Contains(t, inv.Create, create[0])
 	assert.Contains(t, inv.Create, create[1])
-	assert.Len(t, inv.Update, 0)
-	assert.Len(t, inv.Delete, 0)
+	assert.Empty(t, inv.Update)
+	assert.Empty(t, inv.Delete)
 }

--- a/pkg/inventory/secret_test.go
+++ b/pkg/inventory/secret_test.go
@@ -70,6 +70,6 @@ func TestSecretInventoryWithSameNameInstances(t *testing.T) {
 	assert.Len(t, inv.Create, 2)
 	assert.Contains(t, inv.Create, create[0])
 	assert.Contains(t, inv.Create, create[1])
-	assert.Len(t, inv.Update, 0)
-	assert.Len(t, inv.Delete, 0)
+	assert.Empty(t, inv.Update)
+	assert.Empty(t, inv.Delete)
 }

--- a/pkg/inventory/service_test.go
+++ b/pkg/inventory/service_test.go
@@ -74,6 +74,6 @@ func TestServiceInventoryWithSameNameInstances(t *testing.T) {
 	assert.Len(t, inv.Create, 2)
 	assert.Contains(t, inv.Create, create[0])
 	assert.Contains(t, inv.Create, create[1])
-	assert.Len(t, inv.Update, 0)
-	assert.Len(t, inv.Delete, 0)
+	assert.Empty(t, inv.Update)
+	assert.Empty(t, inv.Delete)
 }

--- a/pkg/kafka/streaming_test.go
+++ b/pkg/kafka/streaming_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -22,9 +23,9 @@ func TestKafkaUserName(t *testing.T) {
 	assert.Equal(t, jaeger.Name, u.GetName())
 
 	contentMap, err := u.Spec.GetMap()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	v, found, err := unstructured.NestedString(contentMap, "authentication", "type")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, found)
 	assert.Equal(t, "tls", v)
 }
@@ -49,24 +50,24 @@ func TestKafkaSizing(t *testing.T) {
 
 	// verify
 	contentMap, err := u.Spec.GetMap()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	v, found, err := unstructured.NestedFieldNoCopy(contentMap, "kafka", "replicas")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, found)
 	assert.EqualValues(t, 3, v)
 
 	storage, found, err := unstructured.NestedMap(contentMap, "kafka", "storage")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, found)
 
 	volumes, found, err := unstructured.NestedSlice(storage, "volumes")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, found)
 	assert.Len(t, volumes, 1)
 	assert.Equal(t, "100Gi", volumes[0].(map[string]interface{})["size"])
 
 	v, found, err = unstructured.NestedFieldNoCopy(contentMap, "zookeeper", "replicas")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, found)
 	assert.EqualValues(t, 3, v)
 }
@@ -82,24 +83,24 @@ func TestKafkaMinimalSizing(t *testing.T) {
 
 	// verify
 	contentMap, err := u.Spec.GetMap()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	v, found, err := unstructured.NestedFieldNoCopy(contentMap, "kafka", "replicas")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, found)
 	assert.EqualValues(t, 1, v)
 
 	storage, found, err := unstructured.NestedMap(contentMap, "kafka", "storage")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, found)
 
 	volumes, found, err := unstructured.NestedSlice(storage, "volumes")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, found)
 	assert.Len(t, volumes, 1)
 	assert.Equal(t, "10Gi", volumes[0].(map[string]interface{})["size"])
 
 	v, found, err = unstructured.NestedFieldNoCopy(contentMap, "zookeeper", "replicas")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, found)
 	assert.EqualValues(t, 1, v)
 }

--- a/pkg/service/agent_test.go
+++ b/pkg/service/agent_test.go
@@ -35,6 +35,6 @@ func TestAgentServiceNameAndPorts(t *testing.T) {
 	}
 
 	for k, v := range ports {
-		assert.Equal(t, true, v, "Expected port %v to be specified, but wasn't", k)
+		assert.True(t, v, "Expected port %v to be specified, but wasn't", k)
 	}
 }

--- a/pkg/service/collector_test.go
+++ b/pkg/service/collector_test.go
@@ -36,7 +36,7 @@ func TestCollectorServiceNameAndPorts(t *testing.T) {
 	}
 
 	for k, v := range ports {
-		assert.Equal(t, v, true, "Expected port %v to be specified, but wasn't", k)
+		assert.True(t, v, "Expected port %v to be specified, but wasn't", k)
 	}
 
 	// we ensure the ports are the same for both services
@@ -55,7 +55,7 @@ func TestCollectorServiceWithClusterIPEmptyAndNone(t *testing.T) {
 	assert.Len(t, svcs, 2)
 	assert.NotEqual(t, svcs[0].Name, svcs[1].Name) // they can't have the same name
 	assert.Equal(t, "None", svcs[0].Spec.ClusterIP)
-	assert.Len(t, svcs[1].Spec.ClusterIP, 0)
+	assert.Empty(t, svcs[1].Spec.ClusterIP)
 }
 
 func TestCollectorGRPCPortName(t *testing.T) {
@@ -143,7 +143,7 @@ func TestCollectorServiceLoadBalancer(t *testing.T) {
 	svc := NewCollectorServices(jaeger, selector)
 
 	// Only the non-headless service will receive the type
-	assert.Equal(t, svc[1].Spec.Type, corev1.ServiceTypeLoadBalancer)
+	assert.Equal(t, corev1.ServiceTypeLoadBalancer, svc[1].Spec.Type)
 }
 
 func TestCollectorServiceAnnotations(t *testing.T) {

--- a/pkg/service/query_test.go
+++ b/pkg/service/query_test.go
@@ -30,8 +30,8 @@ func TestQueryServiceNameAndPorts(t *testing.T) {
 	assert.Equal(t, intstr.FromInt(16686), svc.Spec.Ports[0].TargetPort)
 	assert.Equal(t, intstr.FromInt(16685), svc.Spec.Ports[1].TargetPort)
 	assert.Equal(t, intstr.FromInt(16687), svc.Spec.Ports[2].TargetPort)
-	assert.Len(t, svc.Spec.ClusterIP, 0)                        // make sure we get a cluster IP
-	assert.Equal(t, svc.Spec.Type, corev1.ServiceTypeClusterIP) // make sure we get a ClusterIP service
+	assert.Empty(t, svc.Spec.ClusterIP)                         // make sure we get a cluster IP
+	assert.Equal(t, corev1.ServiceTypeClusterIP, svc.Spec.Type) // make sure we get a ClusterIP service
 }
 
 func TestQueryDottedServiceName(t *testing.T) {
@@ -81,7 +81,7 @@ func TestQueryServiceNodePortWithIngress(t *testing.T) {
 	assert.Equal(t, intstr.FromInt(16686), svc.Spec.Ports[0].TargetPort)
 	assert.Equal(t, intstr.FromInt(16685), svc.Spec.Ports[1].TargetPort)
 	assert.Equal(t, intstr.FromInt(16687), svc.Spec.Ports[2].TargetPort)
-	assert.Equal(t, svc.Spec.Type, corev1.ServiceTypeNodePort) // make sure we get a NodePort service
+	assert.Equal(t, corev1.ServiceTypeNodePort, svc.Spec.Type) // make sure we get a NodePort service
 }
 
 func TestQueryServiceLoadBalancerWithIngress(t *testing.T) {
@@ -103,7 +103,7 @@ func TestQueryServiceLoadBalancerWithIngress(t *testing.T) {
 	assert.Equal(t, intstr.FromInt(16686), svc.Spec.Ports[0].TargetPort)
 	assert.Equal(t, intstr.FromInt(16685), svc.Spec.Ports[1].TargetPort)
 	assert.Equal(t, intstr.FromInt(16687), svc.Spec.Ports[2].TargetPort)
-	assert.Equal(t, svc.Spec.Type, corev1.ServiceTypeLoadBalancer) // make sure we get a LoadBalancer service
+	assert.Equal(t, corev1.ServiceTypeLoadBalancer, svc.Spec.Type) // make sure we get a LoadBalancer service
 }
 
 func TestQueryServiceSpecifiedNodePortWithIngress(t *testing.T) {
@@ -127,7 +127,7 @@ func TestQueryServiceSpecifiedNodePortWithIngress(t *testing.T) {
 	assert.Equal(t, intstr.FromInt(16686), svc.Spec.Ports[0].TargetPort)
 	assert.Equal(t, intstr.FromInt(16685), svc.Spec.Ports[1].TargetPort)
 	assert.Equal(t, intstr.FromInt(16687), svc.Spec.Ports[2].TargetPort)
-	assert.Equal(t, svc.Spec.Type, corev1.ServiceTypeNodePort)
+	assert.Equal(t, corev1.ServiceTypeNodePort, svc.Spec.Type)
 }
 
 func TestQueryServiceSpecAnnotations(t *testing.T) {

--- a/pkg/storage/cassandra_dependencies_test.go
+++ b/pkg/storage/cassandra_dependencies_test.go
@@ -90,7 +90,7 @@ func TestCassandraCreateSchemaDisabled(t *testing.T) {
 	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestCassandraCreateSchemaDisabled"})
 	jaeger.Spec.Storage.CassandraCreateSchema.Enabled = &falseVar
 
-	assert.Len(t, cassandraDeps(jaeger), 0)
+	assert.Empty(t, cassandraDeps(jaeger))
 }
 
 func TestCassandraCreateSchemaEnabled(t *testing.T) {
@@ -147,7 +147,7 @@ func TestCassandraCreateSchemaSecurityContext(t *testing.T) {
 	b := cassandraDeps(jaeger)
 
 	assert.Len(t, b, 1)
-	assert.Equal(t, b[0].Spec.Template.Spec.SecurityContext, expectedSecurityContext)
+	assert.Equal(t, expectedSecurityContext, b[0].Spec.Template.Spec.SecurityContext)
 }
 
 func TestCassandraCreateSchemaSecret(t *testing.T) {

--- a/pkg/storage/dependency_test.go
+++ b/pkg/storage/dependency_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestDefaultDependencies(t *testing.T) {
 	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestCassandraDependencies"})
-	assert.Len(t, Dependencies(jaeger), 0)
+	assert.Empty(t, Dependencies(jaeger))
 }
 
 func TestCassandraDependencies(t *testing.T) {

--- a/pkg/storage/elasticsearch_dependencies_test.go
+++ b/pkg/storage/elasticsearch_dependencies_test.go
@@ -55,13 +55,13 @@ func TestElasticsearchDependencies(t *testing.T) {
 	j.Spec.Storage.Options = v1.NewOptions(map[string]interface{}{"es.server-urls": "foo,bar", "es.index-prefix": "shortone"})
 
 	deps := elasticsearchDependencies(j)
-	assert.Equal(t, 1, len(deps))
+	assert.Len(t, deps, 1)
 	job := deps[0]
 
 	assert.Equal(t, j.Namespace, job.Namespace)
 	assert.Equal(t, []metav1.OwnerReference{util.AsOwner(j)}, job.OwnerReferences)
 	assert.Equal(t, util.Labels("eevee-es-rollover-create-mapping", "job-es-rollover-create-mapping", *j), job.Labels)
-	assert.Equal(t, 1, len(job.Spec.Template.Spec.Containers))
+	assert.Len(t, job.Spec.Template.Spec.Containers, 1)
 	assert.Equal(t, j.Spec.Storage.EsRollover.Image, job.Spec.Template.Spec.Containers[0].Image)
 	assert.Equal(t, []string{"init", "foo"}, job.Spec.Template.Spec.Containers[0].Args)
 	assert.Equal(t, []corev1.EnvVar{{Name: "INDEX_PREFIX", Value: "shortone"}}, job.Spec.Template.Spec.Containers[0].Env)

--- a/pkg/storage/elasticsearch_secrets_test.go
+++ b/pkg/storage/elasticsearch_secrets_test.go
@@ -24,7 +24,7 @@ func TestCreateESSecretsError(t *testing.T) {
 	require.NoError(t, err)
 	defer es.CleanCerts()
 	err = es.CreateCerts()
-	assert.EqualError(t, err, "error running script /foo: exit status 127")
+	require.EqualError(t, err, "error running script /foo: exit status 127")
 }
 
 func TestCreateESSecrets(t *testing.T) {
@@ -34,7 +34,7 @@ func TestCreateESSecrets(t *testing.T) {
 	require.NoError(t, err)
 	defer es.CleanCerts()
 	err = es.CreateCerts()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	sec := es.ExtractSecrets()
 	assert.Equal(t, []string{
 		masterSecret.instanceName(j),
@@ -46,11 +46,11 @@ func TestCreateESSecrets(t *testing.T) {
 	for _, s := range sec {
 		if s.Name == jaegerSecret.instanceName(j) {
 			ca, err := os.ReadFile(fmt.Sprintf("%s/%s/ca.crt", tmpWorkingDir, j.Name))
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			key, err := os.ReadFile(fmt.Sprintf("%s/%s/user.jaeger.key", tmpWorkingDir, j.Name))
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			cert, err := os.ReadFile(fmt.Sprintf("%s/%s/user.jaeger.crt", tmpWorkingDir, j.Name))
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, map[string][]byte{"ca": ca, "key": key, "cert": cert}, s.Data)
 		}
 	}
@@ -72,9 +72,9 @@ func TestGetWorkingFileDirContent(t *testing.T) {
 	dir := "/tmp/_" + t.Name()
 	defer os.RemoveAll(dir)
 	err := os.MkdirAll(dir, os.ModePerm)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = os.WriteFile(dir+"/foobar", []byte("foo"), 0o644)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	b := getDirFileContents(dir, "foobar")
 	assert.Equal(t, "foo", string(b))
 }
@@ -104,9 +104,9 @@ func TestExtractSecretsToFile(t *testing.T) {
 		[]corev1.Secret{{ObjectMeta: metav1.ObjectMeta{Name: j.Name + "-sec"}, Data: map[string][]byte{"ca": []byte(content)}}},
 		secret{name: "sec", keyFileNameMap: map[string]string{"ca": "ca.crt"}},
 	)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ca, err := os.ReadFile(caFile)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, []byte(content), ca)
 }
 
@@ -114,18 +114,17 @@ func TestExtractSecretsToFile_Err(t *testing.T) {
 	err := extractSecretToFile("/root", map[string][]byte{"foo": {}}, secret{keyFileNameMap: map[string]string{"foo": "foo"}})
 
 	// Avoid assertions on OS-dependent error messages which may differ between OSes.
-	patherr, ok := err.(*os.PathError)
-	assert.Error(t, patherr)
-	assert.True(t, ok)
+	var patherr *os.PathError
+	require.ErrorAs(t, err, &patherr)
 }
 
 func TestExtractSecretsToFile_FileExists(t *testing.T) {
 	defer os.RemoveAll(tmpWorkingDir + "/bar/houdy")
 	content := "115dasrez"
 	err := os.MkdirAll(tmpWorkingDir+"/bar/houdy", os.ModePerm)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = os.WriteFile(tmpWorkingDir+"/bar/houdy/ca.crt", []byte(content), os.ModePerm)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	j := v1.NewJaeger(types.NamespacedName{Name: "houdy"})
 	j.Namespace = "bar"
@@ -134,9 +133,9 @@ func TestExtractSecretsToFile_FileExists(t *testing.T) {
 		[]corev1.Secret{{ObjectMeta: metav1.ObjectMeta{Name: "houdy-sec"}, Data: map[string][]byte{"ca": []byte("should not be there")}}},
 		secret{name: "sec", keyFileNameMap: map[string]string{"ca": "ca.crt"}},
 	)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ca, err := os.ReadFile(tmpWorkingDir + "/bar/houdy/ca.crt")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, []byte(content), ca)
 }
 
@@ -168,11 +167,11 @@ func TestWriteToWorkingDir(t *testing.T) {
 		if test.wantErrType != nil {
 			// Avoid assertions on OS-dependent error messages which may differ between OSes.
 			errType := reflect.TypeOf(err)
-			assert.True(t, test.wantErrType == errType)
+			assert.Equal(t, test.wantErrType, errType)
 		} else {
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			stat, err := os.Stat(fmt.Sprintf("%s/%s", test.dir, test.file))
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, test.file, stat.Name())
 		}
 	}

--- a/pkg/storage/grpc_plugin_test.go
+++ b/pkg/storage/grpc_plugin_test.go
@@ -57,13 +57,13 @@ func TestUpdatesOnlyAffectsGRPCStoragePlugin(t *testing.T) {
 	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
 	commonSpec := &v1.JaegerCommonSpec{}
 	UpdateGRPCPlugin(jaeger, commonSpec)
-	assert.Len(t, commonSpec.Volumes, 0)
-	assert.Len(t, commonSpec.VolumeMounts, 0)
+	assert.Empty(t, commonSpec.Volumes)
+	assert.Empty(t, commonSpec.VolumeMounts)
 }
 
 func TestGetInitContainersOnlyAffectsGRPCStoragePlugin(t *testing.T) {
 	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
-	assert.Len(t, GetGRPCPluginInitContainers(jaeger, nil), 0)
+	assert.Empty(t, GetGRPCPluginInitContainers(jaeger, nil))
 }
 
 func TestGetInitContainersGRPCStoragePlugin(t *testing.T) {

--- a/pkg/strategy/all_in_one_test.go
+++ b/pkg/strategy/all_in_one_test.go
@@ -75,7 +75,7 @@ func TestDelegateAllInOneDependencies(t *testing.T) {
 func TestNoAutoscaleForAllInOne(t *testing.T) {
 	j := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
 	c := newAllInOneStrategy(context.Background(), j)
-	assert.Len(t, c.HorizontalPodAutoscalers(), 0)
+	assert.Empty(t, c.HorizontalPodAutoscalers())
 }
 
 func assertDeploymentsAndServicesForAllInOne(t *testing.T, instance *v1.Jaeger, s S, hasDaemonSet bool, hasOAuthProxy bool, hasConfigMap bool) {
@@ -160,9 +160,9 @@ func testSparkDependencies(t *testing.T, fce func(jaeger *v1.Jaeger) S) {
 		s := fce(test.jaeger)
 		cronJobs := s.CronJobs()
 		if test.sparkCronJobEnabled {
-			assert.Equal(t, 1, len(cronJobs))
+			assert.Len(t, cronJobs, 1)
 		} else {
-			assert.Equal(t, 0, len(cronJobs))
+			assert.Empty(t, cronJobs)
 		}
 	}
 }
@@ -206,9 +206,9 @@ func testEsIndexCleaner(t *testing.T, fce func(jaeger *v1.Jaeger) S) {
 		s := fce(test.jaeger)
 		cronJobs := s.CronJobs()
 		if test.sparkCronJobEnabled {
-			assert.Equal(t, 1, len(cronJobs))
+			assert.Len(t, cronJobs, 1)
 		} else {
-			assert.Equal(t, 0, len(cronJobs))
+			assert.Empty(t, cronJobs)
 		}
 	}
 }

--- a/pkg/strategy/controller_test.go
+++ b/pkg/strategy/controller_test.go
@@ -16,7 +16,7 @@ func TestNewControllerForAllInOneAsDefault(t *testing.T) {
 	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
 
 	ctrl := For(context.TODO(), jaeger)
-	assert.Equal(t, ctrl.Type(), v1.DeploymentStrategyAllInOne)
+	assert.Equal(t, v1.DeploymentStrategyAllInOne, ctrl.Type())
 }
 
 func TestNewControllerForAllInOneAsExplicitValue(t *testing.T) {
@@ -24,7 +24,7 @@ func TestNewControllerForAllInOneAsExplicitValue(t *testing.T) {
 	jaeger.Spec.Strategy = v1.DeploymentStrategyDeprecatedAllInOne // same as 'all-in-one'
 
 	ctrl := For(context.TODO(), jaeger)
-	assert.Equal(t, ctrl.Type(), v1.DeploymentStrategyAllInOne)
+	assert.Equal(t, v1.DeploymentStrategyAllInOne, ctrl.Type())
 }
 
 func TestNewControllerForProduction(t *testing.T) {
@@ -33,7 +33,7 @@ func TestNewControllerForProduction(t *testing.T) {
 	jaeger.Spec.Storage.Type = v1.JaegerESStorage
 
 	ctrl := For(context.TODO(), jaeger)
-	assert.Equal(t, ctrl.Type(), v1.DeploymentStrategyProduction)
+	assert.Equal(t, v1.DeploymentStrategyProduction, ctrl.Type())
 }
 
 func TestUnknownStorage(t *testing.T) {
@@ -63,7 +63,7 @@ func TestElasticsearchAsStorageOptions(t *testing.T) {
 		}
 	}
 
-	assert.Equal(t, len(deps), counter)
+	assert.Len(t, deps, counter)
 }
 
 func TestDefaultName(t *testing.T) {

--- a/pkg/strategy/production_test.go
+++ b/pkg/strategy/production_test.go
@@ -184,7 +184,7 @@ func TestAgentSidecarIsInjectedIntoQueryForStreamingForProduction(t *testing.T) 
 	for _, dep := range c.Deployments() {
 		if strings.HasSuffix(dep.Name, "-query") {
 			assert.Equal(t, "TestAgentSidecarIsInjectedIntoQueryForStreamingForProduction", dep.Annotations["sidecar.jaegertracing.io/inject"])
-			assert.Equal(t, 1, len(dep.Spec.Template.Spec.Containers))
+			assert.Len(t, dep.Spec.Template.Spec.Containers, 1)
 			assert.Equal(t, "jaeger-query", dep.Spec.Template.Spec.Containers[0].Name)
 		}
 	}
@@ -197,7 +197,7 @@ func TestAgentSidecarNotInjectedTracingEnabledFalseForProduction(t *testing.T) {
 	c := newProductionStrategy(context.Background(), j)
 	for _, dep := range c.Deployments() {
 		if strings.HasSuffix(dep.Name, "-query") {
-			assert.Equal(t, 1, len(dep.Spec.Template.Spec.Containers))
+			assert.Len(t, dep.Spec.Template.Spec.Containers, 1)
 		}
 	}
 }
@@ -212,14 +212,14 @@ func TestElasticsearchInject(t *testing.T) {
 	j.Spec.Storage.Options = v1.NewOptions(map[string]interface{}{"es.use-aliases": true})
 	c := newProductionStrategy(context.Background(), j)
 	// there should be index-cleaner, rollover, lookback
-	assert.Equal(t, 3, len(c.cronJobs))
+	assert.Len(t, c.cronJobs, 3)
 	assertEsInjectSecrets(t, c.cronJobs[0].(*batchv1.CronJob).Spec.JobTemplate.Spec.Template.Spec)
 	assertEsInjectSecrets(t, c.cronJobs[1].(*batchv1.CronJob).Spec.JobTemplate.Spec.Template.Spec)
 	assertEsInjectSecrets(t, c.cronJobs[2].(*batchv1.CronJob).Spec.JobTemplate.Spec.Template.Spec)
 }
 
 func assertEsInjectSecrets(t *testing.T, p corev1.PodSpec) {
-	assert.Equal(t, 1, len(p.Volumes))
+	assert.Len(t, p.Volumes, 1)
 	assert.Equal(t, "certs", p.Volumes[0].Name)
 	assert.Equal(t, "certs", p.Containers[0].VolumeMounts[0].Name)
 	envs := map[string]corev1.EnvVar{}

--- a/pkg/strategy/streaming_test.go
+++ b/pkg/strategy/streaming_test.go
@@ -50,7 +50,7 @@ func TestStreamingNoKafkaProvisioningWhenConsumerBrokersSet(t *testing.T) {
 	c := newStreamingStrategy(context.Background(), jaeger)
 
 	// one Kafka, one KafkaUser
-	assert.Len(t, c.Kafkas(), 0)
+	assert.Empty(t, c.Kafkas())
 }
 
 func TestStreamingNoKafkaProvisioningWhenProducerBrokersSet(t *testing.T) {
@@ -62,7 +62,7 @@ func TestStreamingNoKafkaProvisioningWhenProducerBrokersSet(t *testing.T) {
 	c := newStreamingStrategy(context.Background(), jaeger)
 
 	// one Kafka, one KafkaUser
-	assert.Len(t, c.Kafkas(), 0)
+	assert.Empty(t, c.Kafkas())
 }
 
 func TestCreateStreamingDeploymentOnOpenShift(t *testing.T) {
@@ -233,7 +233,7 @@ func TestAgentSidecarIsInjectedIntoQueryForStreaming(t *testing.T) {
 	c := newStreamingStrategy(context.Background(), j)
 	for _, dep := range c.Deployments() {
 		if strings.HasSuffix(dep.Name, "-query") {
-			assert.Equal(t, 2, len(dep.Spec.Template.Spec.Containers))
+			assert.Len(t, dep.Spec.Template.Spec.Containers, 2)
 			assert.Equal(t, "jaeger-agent", dep.Spec.Template.Spec.Containers[1].Name)
 		}
 	}
@@ -246,7 +246,7 @@ func TestAgentSidecarNotInjectedTracingEnabledFalseForStreaming(t *testing.T) {
 	c := newStreamingStrategy(context.Background(), j)
 	for _, dep := range c.Deployments() {
 		if strings.HasSuffix(dep.Name, "-query") {
-			assert.Equal(t, 1, len(dep.Spec.Template.Spec.Containers))
+			assert.Len(t, dep.Spec.Template.Spec.Containers, 1)
 		}
 	}
 }
@@ -374,7 +374,7 @@ func TestAutoProvisionedKafkaAndElasticsearch(t *testing.T) {
 
 	c := newStreamingStrategy(context.Background(), jaeger)
 	// there should be index-cleaner, rollover, lookback
-	assert.Equal(t, 3, len(c.cronJobs))
+	assert.Len(t, c.cronJobs, 3)
 	assertEsInjectSecretsStreaming(t, c.cronJobs[0].(*batchv1.CronJob).Spec.JobTemplate.Spec.Template.Spec)
 	assertEsInjectSecretsStreaming(t, c.cronJobs[1].(*batchv1.CronJob).Spec.JobTemplate.Spec.Template.Spec)
 	assertEsInjectSecretsStreaming(t, c.cronJobs[2].(*batchv1.CronJob).Spec.JobTemplate.Spec.Template.Spec)
@@ -382,7 +382,7 @@ func TestAutoProvisionedKafkaAndElasticsearch(t *testing.T) {
 
 func assertEsInjectSecretsStreaming(t *testing.T, p corev1.PodSpec) {
 	// first two volumes are from the common spec
-	assert.Equal(t, 3, len(p.Volumes))
+	assert.Len(t, p.Volumes, 3)
 	assert.Equal(t, "certs", p.Volumes[2].Name)
 	assert.Equal(t, "certs", p.Containers[0].VolumeMounts[2].Name)
 	envs := map[string]corev1.EnvVar{}

--- a/pkg/upgrade/main_test.go
+++ b/pkg/upgrade/main_test.go
@@ -9,6 +9,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	v1 "github.com/jaegertracing/jaeger-operator/apis/v1"
 )
@@ -34,7 +35,7 @@ func TestVersions(t *testing.T) {
 	}
 
 	semVersions, err := versions(maptoTest)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, semVersions, sortedSemVersions)
 }
 
@@ -48,5 +49,5 @@ func TestVersionsError(t *testing.T) {
 	}
 
 	_, err := versions(maptoTest)
-	assert.Error(t, err)
+	require.Error(t, err)
 }

--- a/pkg/upgrade/upgrade_test.go
+++ b/pkg/upgrade/upgrade_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -31,11 +32,11 @@ func TestVersionUpgradeToLatest(t *testing.T) {
 	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 
 	// test
-	assert.NoError(t, ManagedInstances(context.Background(), cl, cl, "1.12.0"))
+	require.NoError(t, ManagedInstances(context.Background(), cl, cl, "1.12.0"))
 
 	// verify
 	persisted := &v1.Jaeger{}
-	assert.NoError(t, cl.Get(context.Background(), nsn, persisted))
+	require.NoError(t, cl.Get(context.Background(), nsn, persisted))
 	assert.Equal(t, "1.12.0", persisted.Status.Version)
 }
 
@@ -59,11 +60,11 @@ func TestVersionUpgradeToLatestMultinamespace(t *testing.T) {
 	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 
 	// test
-	assert.NoError(t, ManagedInstances(context.Background(), cl, cl, "1.12.0"))
+	require.NoError(t, ManagedInstances(context.Background(), cl, cl, "1.12.0"))
 
 	// verify
 	persisted := &v1.Jaeger{}
-	assert.NoError(t, cl.Get(context.Background(), nsn, persisted))
+	require.NoError(t, cl.Get(context.Background(), nsn, persisted))
 	assert.Equal(t, "1.12.0", persisted.Status.Version)
 }
 
@@ -87,11 +88,11 @@ func TestVersionUpgradeToLatestOwnedResource(t *testing.T) {
 	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 
 	// test
-	assert.NoError(t, ManagedInstances(context.Background(), cl, cl, "1.12.0"))
+	require.NoError(t, ManagedInstances(context.Background(), cl, cl, "1.12.0"))
 
 	// verify
 	persisted := &v1.Jaeger{}
-	assert.NoError(t, cl.Get(context.Background(), nsn, persisted))
+	require.NoError(t, cl.Get(context.Background(), nsn, persisted))
 	assert.Equal(t, "1.12.0", persisted.Status.Version)
 }
 
@@ -109,11 +110,11 @@ func TestUnknownVersion(t *testing.T) {
 	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 
 	// test
-	assert.NoError(t, ManagedInstances(context.Background(), cl, cl, "1.12.0"))
+	require.NoError(t, ManagedInstances(context.Background(), cl, cl, "1.12.0"))
 
 	// verify
 	persisted := &v1.Jaeger{}
-	assert.NoError(t, cl.Get(context.Background(), nsn, persisted))
+	require.NoError(t, cl.Get(context.Background(), nsn, persisted))
 	assert.Equal(t, "1.10.0", persisted.Status.Version)
 }
 
@@ -137,11 +138,11 @@ func TestSkipForNonOwnedInstances(t *testing.T) {
 	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 
 	// test
-	assert.NoError(t, ManagedInstances(context.Background(), cl, cl, opver.Get().Jaeger))
+	require.NoError(t, ManagedInstances(context.Background(), cl, cl, opver.Get().Jaeger))
 
 	// verify
 	persisted := &v1.Jaeger{}
-	assert.NoError(t, cl.Get(context.Background(), nsn, persisted))
+	require.NoError(t, cl.Get(context.Background(), nsn, persisted))
 	assert.Equal(t, "1.11.0", persisted.Status.Version)
 }
 
@@ -156,7 +157,7 @@ func TestErrorForInvalidSemVer(t *testing.T) {
 	}
 	_, err := versions(testUpdates)
 	// test
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestSkipUpgradeForVersionsGreaterThanLatest(t *testing.T) {
@@ -173,15 +174,15 @@ func TestSkipUpgradeForVersionsGreaterThanLatest(t *testing.T) {
 	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 
 	// test
-	assert.NoError(t, ManagedInstances(context.Background(), cl, cl, opver.Get().Jaeger))
+	require.NoError(t, ManagedInstances(context.Background(), cl, cl, opver.Get().Jaeger))
 
 	// verify
 	persisted := &v1.Jaeger{}
-	assert.NoError(t, cl.Get(context.Background(), nsn, persisted))
+	require.NoError(t, cl.Get(context.Background(), nsn, persisted))
 	assert.Equal(t, existing.Status.Version, persisted.Status.Version)
 }
 
 func TestVersionMapIsValid(t *testing.T) {
 	_, err := versions(upgrades)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }

--- a/pkg/upgrade/v1_15_0_test.go
+++ b/pkg/upgrade/v1_15_0_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -29,11 +30,11 @@ func TestUpgradeDeprecatedOptionsv1_15_0(t *testing.T) {
 	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 
 	// test
-	assert.NoError(t, ManagedInstances(context.Background(), cl, cl, latestVersion))
+	require.NoError(t, ManagedInstances(context.Background(), cl, cl, latestVersion))
 
 	// verify
 	persisted := &v1.Jaeger{}
-	assert.NoError(t, cl.Get(context.Background(), nsn, persisted))
+	require.NoError(t, cl.Get(context.Background(), nsn, persisted))
 	assert.Equal(t, latestVersion, persisted.Status.Version)
 
 	opts := persisted.Spec.Collector.Options.Map()
@@ -59,7 +60,7 @@ func TestRemoveDeprecatedFlagWithNoReplacementv1_15_0(t *testing.T) {
 	updated, err := upgrade1_15_0(context.Background(), nil, *existing)
 
 	// verify
-	assert.NoError(t, err)
-	assert.Len(t, updated.Spec.Collector.Options.Map(), 0)
+	require.NoError(t, err)
+	assert.Empty(t, updated.Spec.Collector.Options.Map())
 	assert.NotContains(t, updated.Spec.Collector.Options.Map(), "cassandra.enable-dependencies-v2")
 }

--- a/pkg/upgrade/v1_17_0_test.go
+++ b/pkg/upgrade/v1_17_0_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -37,11 +38,11 @@ func TestUpgradeDeprecatedOptionsv1_17_0(t *testing.T) {
 	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 
 	// test
-	assert.NoError(t, ManagedInstances(context.Background(), cl, cl, latestVersion))
+	require.NoError(t, ManagedInstances(context.Background(), cl, cl, latestVersion))
 
 	// verify
 	persisted := &v1.Jaeger{}
-	assert.NoError(t, cl.Get(context.Background(), nsn, persisted))
+	require.NoError(t, cl.Get(context.Background(), nsn, persisted))
 	assert.Equal(t, latestVersion, persisted.Status.Version)
 
 	opts := persisted.Spec.Collector.Options.Map()
@@ -70,7 +71,7 @@ func TestAddTLSOptionsForKafka_v1_17_0(t *testing.T) {
 
 	result, err := upgrade1_17_0(context.Background(), nil, *jaeger)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "true", result.Spec.Collector.Options.Map()["kafka.producer.tls.enabled"])
 	assert.Equal(t, "true", result.Spec.Ingester.Options.Map()["kafka.producer.tls.enabled"])
 	assert.Equal(t, "true", result.Spec.Ingester.Options.Map()["kafka.consumer.tls.enabled"])

--- a/pkg/upgrade/v1_18_0_test.go
+++ b/pkg/upgrade/v1_18_0_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -45,11 +46,11 @@ func TestUpgradeDeprecatedOptionsv1_18_0(t *testing.T) {
 	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 
 	// test
-	assert.NoError(t, ManagedInstances(context.Background(), cl, cl, latestVersion))
+	require.NoError(t, ManagedInstances(context.Background(), cl, cl, latestVersion))
 
 	// verify
 	persisted := &v1.Jaeger{}
-	assert.NoError(t, cl.Get(context.Background(), nsn, persisted))
+	require.NoError(t, cl.Get(context.Background(), nsn, persisted))
 	// assert.Equal(t, latest.v, persisted.Status.Version)
 
 	opts := persisted.Spec.Collector.Options.Map()
@@ -88,11 +89,11 @@ func TestUpgradeAgentWithTChannelEnablev1_18_0_(t *testing.T) {
 	s.AddKnownTypes(v1.GroupVersion, &v1.JaegerList{})
 	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 
-	assert.NoError(t, ManagedInstances(context.Background(), cl, cl, latestVersion))
+	require.NoError(t, ManagedInstances(context.Background(), cl, cl, latestVersion))
 
 	// verify
 	persisted := &v1.Jaeger{}
-	assert.NoError(t, cl.Get(context.Background(), nsn, persisted))
+	require.NoError(t, cl.Get(context.Background(), nsn, persisted))
 
 	collectorOpts := persisted.Spec.Agent.Options.Map()
 

--- a/pkg/upgrade/v1_20_0_test.go
+++ b/pkg/upgrade/v1_20_0_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -30,11 +31,11 @@ func TestUpgradeDeprecatedOptionsv1_20_0NonConflicting(t *testing.T) {
 	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 
 	// test
-	assert.NoError(t, ManagedInstances(context.Background(), cl, cl, latestVersion))
+	require.NoError(t, ManagedInstances(context.Background(), cl, cl, latestVersion))
 
 	// verify
 	persisted := &v1.Jaeger{}
-	assert.NoError(t, cl.Get(context.Background(), nsn, persisted))
+	require.NoError(t, cl.Get(context.Background(), nsn, persisted))
 	assert.Equal(t, latestVersion, persisted.Status.Version)
 
 	opts := persisted.Spec.Collector.Options.Map()

--- a/pkg/upgrade/v1_22_0_test.go
+++ b/pkg/upgrade/v1_22_0_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -45,11 +46,11 @@ func TestUpgradeJaegerTagssv1_22_0(t *testing.T) {
 	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 
 	// test
-	assert.NoError(t, ManagedInstances(context.Background(), cl, cl, latestVersion))
+	require.NoError(t, ManagedInstances(context.Background(), cl, cl, latestVersion))
 
 	// verify
 	persisted := &v1.Jaeger{}
-	assert.NoError(t, cl.Get(context.Background(), nsn, persisted))
+	require.NoError(t, cl.Get(context.Background(), nsn, persisted))
 	assert.Equal(t, latestVersion, persisted.Status.Version)
 
 	aioOpts := persisted.Spec.AllInOne.Options.Map()
@@ -89,12 +90,12 @@ func TestDeleteQueryRemovedFlags(t *testing.T) {
 	s.AddKnownTypes(v1.GroupVersion, &v1.Jaeger{})
 	s.AddKnownTypes(v1.GroupVersion, &v1.JaegerList{})
 	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
-	assert.NoError(t, ManagedInstances(context.Background(), cl, cl, latestVersion))
+	require.NoError(t, ManagedInstances(context.Background(), cl, cl, latestVersion))
 
 	persisted := &v1.Jaeger{}
-	assert.NoError(t, cl.Get(context.Background(), nsn, persisted))
+	require.NoError(t, cl.Get(context.Background(), nsn, persisted))
 	assert.Equal(t, latestVersion, persisted.Status.Version)
-	assert.Len(t, persisted.Spec.Query.Options.Map(), 0)
+	assert.Empty(t, persisted.Spec.Query.Options.Map())
 	assert.NotContains(t, persisted.Spec.Query.Options.Map(), "downsampling.hashsalt")
 	assert.NotContains(t, persisted.Spec.Query.Options.Map(), "downsampling.ratio")
 }
@@ -138,10 +139,10 @@ func TestCassandraVerifyHostFlags(t *testing.T) {
 			s.AddKnownTypes(v1.GroupVersion, &v1.Jaeger{})
 			s.AddKnownTypes(v1.GroupVersion, &v1.JaegerList{})
 			cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
-			assert.NoError(t, ManagedInstances(context.Background(), cl, cl, latestVersion))
+			require.NoError(t, ManagedInstances(context.Background(), cl, cl, latestVersion))
 
 			persisted := &v1.Jaeger{}
-			assert.NoError(t, cl.Get(context.Background(), nsn, persisted))
+			require.NoError(t, cl.Get(context.Background(), nsn, persisted))
 			assert.Equal(t, latestVersion, persisted.Status.Version)
 			if tt.flagPresent {
 				assert.Len(t, persisted.Spec.Collector.Options.Map(), 1)
@@ -149,7 +150,7 @@ func TestCassandraVerifyHostFlags(t *testing.T) {
 				assert.Contains(t, persisted.Spec.Collector.Options.Map(), newFlag)
 				assert.Equal(t, tt.flagValue, persisted.Spec.Collector.Options.Map()[newFlag])
 			} else {
-				assert.Len(t, persisted.Spec.Collector.Options.Map(), 0)
+				assert.Empty(t, persisted.Spec.Collector.Options.Map())
 				assert.NotContains(t, persisted.Spec.Collector.Options.Map(), oldFlag)
 			}
 		})
@@ -243,10 +244,10 @@ func TestMigrateQueryHostPortFlagsv1_22_0(t *testing.T) {
 		s.AddKnownTypes(v1.GroupVersion, &v1.Jaeger{})
 		s.AddKnownTypes(v1.GroupVersion, &v1.JaegerList{})
 		cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
-		assert.NoError(t, ManagedInstances(context.Background(), cl, cl, latestVersion))
+		require.NoError(t, ManagedInstances(context.Background(), cl, cl, latestVersion))
 
 		persisted := &v1.Jaeger{}
-		assert.NoError(t, cl.Get(context.Background(), nsn, persisted))
+		require.NoError(t, cl.Get(context.Background(), nsn, persisted))
 		assert.Equal(t, latestVersion, persisted.Status.Version)
 		assert.Equal(t, tt.expectedOps, persisted.Spec.Query.Options.StringMap())
 

--- a/pkg/upgrade/v1_31_0.go
+++ b/pkg/upgrade/v1_31_0.go
@@ -24,7 +24,7 @@ func upgrade1_31_0(ctx context.Context, c client.Client, jaeger v1.Jaeger) (v1.J
 		}
 		err := client.IgnoreNotFound(c.Delete(ctx, &es))
 		if err != nil {
-			return jaeger, fmt.Errorf("failed to delete Elasticsearch, deletion is needed for certificate migration to Elasticsearch operator: %v", err)
+			return jaeger, fmt.Errorf("failed to delete Elasticsearch, deletion is needed for certificate migration to Elasticsearch operator: %w", err)
 		}
 	}
 

--- a/pkg/upgrade/v1_31_0_test.go
+++ b/pkg/upgrade/v1_31_0_test.go
@@ -8,7 +8,7 @@ import (
 
 	v1 "github.com/jaegertracing/jaeger-operator/apis/v1"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -30,10 +30,10 @@ func TestUpgradeJaegerv1_31_0(t *testing.T) {
 	// Should return an error related to missing type (because we haven't added ES type to schema)
 	cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
 	_, err := upgrade1_31_0(context.Background(), cl, *existing)
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// Should not return an error, ven if the ES instance doesn't exist.
 	s.AddKnownTypes(esv1.GroupVersion, &esv1.Elasticsearch{})
 	_, err = upgrade1_31_0(context.Background(), cl, *existing)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -48,7 +48,7 @@ func TestRemoveDuplicatedVolumeMounts(t *testing.T) {
 
 	assert.Len(t, RemoveDuplicatedVolumeMounts(volumeMounts), 2)
 	assert.Equal(t, "data1", volumeMounts[0].Name)
-	assert.Equal(t, false, volumeMounts[0].ReadOnly)
+	assert.False(t, volumeMounts[0].ReadOnly)
 	assert.Equal(t, "data2", volumeMounts[1].Name)
 }
 
@@ -187,7 +187,7 @@ func TestMergeMountVolumes(t *testing.T) {
 	merged := Merge([]v1.JaegerCommonSpec{specificSpec, generalSpec})
 
 	assert.Equal(t, "data1", merged.VolumeMounts[0].Name)
-	assert.Equal(t, false, merged.VolumeMounts[0].ReadOnly)
+	assert.False(t, merged.VolumeMounts[0].ReadOnly)
 	assert.Equal(t, "data2", merged.VolumeMounts[1].Name)
 }
 
@@ -392,7 +392,7 @@ func TestFindItem(t *testing.T) {
 	args := opts.ToArgs()
 
 	assert.Equal(t, "--reporter.type=thrift", FindItem("--reporter.type=", args))
-	assert.Len(t, FindItem("--c-option", args), 0)
+	assert.Empty(t, FindItem("--c-option", args))
 }
 
 func TestGetPortDefault(t *testing.T) {
@@ -679,7 +679,7 @@ func TestFindEnvVars(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			result := FindEnvVar(envVars, tc.envName)
-			assert.Equal(t, result, tc.expected)
+			assert.Equal(t, tc.expected, result)
 		})
 	}
 }
@@ -710,7 +710,7 @@ func TestIsOTLPEnable(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			enable := IsOTLPEnable(AllArgs(tc.options))
-			assert.Equal(t, enable, tc.expected)
+			assert.Equal(t, tc.expected, enable)
 		})
 	}
 }
@@ -741,7 +741,7 @@ func TestIsOTLPExplcitSet(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			enable := IsOTLPExplcitSet(AllArgs(tc.options))
-			assert.Equal(t, enable, tc.expected)
+			assert.Equal(t, tc.expected, enable)
 		})
 	}
 }

--- a/tests/assert-jobs/index/main.go
+++ b/tests/assert-jobs/index/main.go
@@ -32,7 +32,7 @@ const (
 func filterIndices(indices *[]elasticsearch.EsIndex, pattern string) ([]elasticsearch.EsIndex, error) {
 	regexPattern, err := regexp.Compile(pattern)
 	if err != nil {
-		return nil, fmt.Errorf("there was a problem with the pattern: %s", err)
+		return nil, fmt.Errorf("there was a problem with the pattern: %w", err)
 	}
 
 	var matchingIndices []elasticsearch.EsIndex

--- a/tests/assert-jobs/utils/elasticsearch/elasticsearch.go
+++ b/tests/assert-jobs/utils/elasticsearch/elasticsearch.go
@@ -46,12 +46,12 @@ func (connection *EsConnection) LoadCertificate(secretPath string) error {
 
 	certificate, err := tls.LoadX509KeyPair(certFile, keyFile)
 	if err != nil {
-		return fmt.Errorf("something failed while loading the x509 key pair: %s", err)
+		return fmt.Errorf("something failed while loading the x509 key pair: %w", err)
 	}
 
 	caCert, err := os.ReadFile(filepath.Clean(caFile))
 	if err != nil {
-		return fmt.Errorf("something failed while reading the CA file: %s", err)
+		return fmt.Errorf("something failed while reading the CA file: %w", err)
 	}
 
 	rootCAs := x509.NewCertPool()
@@ -133,12 +133,12 @@ func (index *EsIndex) GetIndexSpans() ([]EsSpan, error) {
 
 	bodyBytes, err := executeEsRequest(index.es, http.MethodPost, fmt.Sprintf("/%s/_search?format=json", index.Index), bodyReq)
 	if err != nil {
-		return []EsSpan{}, fmt.Errorf("something failed while quering the ES REST API: %s", err)
+		return []EsSpan{}, fmt.Errorf("something failed while quering the ES REST API: %w", err)
 	}
 
 	err = json.Unmarshal(bodyBytes, &searchResponse)
 	if err != nil {
-		return []EsSpan{}, fmt.Errorf("something failed while unmarshalling API response: %s", err)
+		return []EsSpan{}, fmt.Errorf("something failed while unmarshalling API response: %w", err)
 	}
 
 	spans := []EsSpan{}
@@ -154,7 +154,7 @@ func (index *EsIndex) GetIndexSpans() ([]EsSpan, error) {
 func CheckESConnection(es EsConnection) error {
 	_, err := executeEsRequest(es, http.MethodGet, "/", nil)
 	if err != nil {
-		return fmt.Errorf("there was a problem while connecting to the ES instance: %s", err)
+		return fmt.Errorf("there was a problem while connecting to the ES instance: %w", err)
 	}
 	return nil
 }
@@ -183,7 +183,7 @@ func GetEsIndex(es EsConnection, indexName string) EsIndex {
 func GetEsIndices(es EsConnection) ([]EsIndex, error) {
 	bodyBytes, err := executeEsRequest(es, http.MethodGet, "/_cat/indices?format=json", nil)
 	if err != nil {
-		return nil, fmt.Errorf("something failed while quering the ES REST API: %s", err)
+		return nil, fmt.Errorf("something failed while quering the ES REST API: %w", err)
 	}
 
 	// Convert JSON data to struct format
@@ -192,7 +192,7 @@ func GetEsIndices(es EsConnection) ([]EsIndex, error) {
 	if err != nil {
 		logrus.Debugln("Response:")
 		logrus.Debugf("%s", bodyBytes)
-		return nil, fmt.Errorf("something failed while unmarshalling API response: %s", err)
+		return nil, fmt.Errorf("something failed while unmarshalling API response: %w", err)
 	}
 
 	for i := range esIndices {
@@ -229,7 +229,7 @@ func executeEsRequest(es EsConnection, httpMethod, api string, body []byte) ([]b
 
 	req, err := http.NewRequest(httpMethod, esURL, bytes.NewBuffer(body))
 	if err != nil {
-		return nil, fmt.Errorf("the HTTP request creation failed: %s", err)
+		return nil, fmt.Errorf("the HTTP request creation failed: %w", err)
 	}
 
 	req.Header.Set("Content-Type", "application/json")
@@ -237,7 +237,7 @@ func executeEsRequest(es EsConnection, httpMethod, api string, body []byte) ([]b
 	logrus.Debugln("Executing request...")
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("the HTTP request failed: %s", err)
+		return nil, fmt.Errorf("the HTTP request failed: %w", err)
 	}
 
 	defer resp.Body.Close()


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- <!-- Example: Resolves #123 -->

## Description of the changes
- applies errorlint and testifylint linters

## How was this change tested?
- The ci passes

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
