### PR TITLE
checkout before setup-go

### DIFF
--- a/.github/workflows/base-checks.yaml
+++ b/.github/workflows/base-checks.yaml
@@ -16,13 +16,13 @@ jobs:
     env:
       USER: jaegertracing
     steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v4
+
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
         go-version: "1.21"
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
 
     - name: "install kubebuilder"
       run: ./hack/install/install-kubebuilder.sh


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- The cache of go dependencies is not working properly in base-check workflow

## Description of the changes
- Trigger checkout before setup-go

## How was this change tested?
- CI

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
