### PR TITLE
Add ok-to-test label to dependabot merge-requests by default

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,18 +6,30 @@ updates:
       interval: daily
       time: "03:00"
       timezone: "Europe/Berlin"
+    labels:
+      - dependencies
+      - docker
+      - ok-to-test
   - package-ecosystem: docker
     directory: "/tests"
     schedule:
       interval: daily
       time: "03:00"
       timezone: "Europe/Berlin"
+    labels:
+      - dependencies
+      - docker
+      - ok-to-test
   - package-ecosystem: gomod
     directory: "/"
     schedule:
       interval: daily
       time: "03:00"
       timezone: "Europe/Berlin"
+    labels:
+      - dependencies
+      - go
+      - ok-to-test
     groups:
       golang-org-x:
         patterns:
@@ -44,3 +56,7 @@ updates:
       interval: "daily"
       time: "03:00"
       timezone: "Europe/Berlin"
+    labels:
+      - dependencies
+      - github_actions
+      - ok-to-test


### PR DESCRIPTION
## Which problem is this PR solving?
- The maintainer needs to wait for around 1h30 between the addition of 'ok-to-test' label and the end of the workflows executions

## Description of the changes
- This PR provides default dependabot labels plus 'ok-to-test' so it doesn't need to be added by the maintainer.

## How was this change tested?
- CI

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
