### PR TITLE
Improve OSSF score

### DIFF
--- a/.ci/after-success.sh
+++ b/.ci/after-success.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-echo "Uploading code coverage results"
-bash <(curl -s https://codecov.io/bash)

--- a/.ci/upload-test-coverage.sh
+++ b/.ci/upload-test-coverage.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/base-checks.yaml
+++ b/.github/workflows/base-checks.yaml
@@ -37,6 +37,6 @@ jobs:
       run: make install-tools ci
 
     - name: "upload test coverage report"
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      run: ./.ci/upload-test-coverage.sh
+      uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ ARG TARGETARCH
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} GO111MODULE=on go build -ldflags="-X ${VERSION_PKG}.version=${VERSION} -X ${VERSION_PKG}.buildDate=${VERSION_DATE} -X ${VERSION_PKG}.defaultJaeger=${JAEGER_VERSION}" -a -o jaeger-operator main.go
 
-FROM quay.io/centos/centos:stream9
+FROM quay.io/centos/centos:stream9@sha256:3e26f56ecab0f2c62fb60eec5d963a57512aff7f0b687d019af47b4772d1fed8
 
 ENV USER_UID=1001 \
     USER_NAME=jaeger-operator


### PR DESCRIPTION
## Which problem is this PR solving?
- OSSF Scorecard conformity

## Description of the changes
-  Pin quay.io/centos/centos:stream9 Docker image version
- Use codecov/codecov-action instead of `bash <(curl -s https://codecov.io/bash)`
- Remove unused scripts (.ci/after-success.sh and .ci/upload-test-coverage.sh)

## How was this change tested?
- CI

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
