### PR TITLE
fixes #1568

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -221,6 +221,7 @@ rules:
 - apiGroups:
   - networking.k8s.io
   resources:
+  - ingressclasses
   - ingresses
   verbs:
   - create

--- a/controllers/jaegertracing/jaeger_controller.go
+++ b/controllers/jaegertracing/jaeger_controller.go
@@ -48,7 +48,7 @@ func NewReconciler(client client.Client, clientReader client.Reader, scheme *run
 // +kubebuilder:rbac:groups=apps,resources=deployments;daemonsets;replicasets;statefulsets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=extensions,resources=ingresses,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses;ingressclasses,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=console.openshift.io,resources=consolelinks,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=batch,resources=jobs;cronjobs,verbs=get;list;watch;create;update;patch;delete

--- a/pkg/ingress/query.go
+++ b/pkg/ingress/query.go
@@ -1,10 +1,12 @@
 package ingress
 
 import (
+	"context"
 	"fmt"
-
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 
 	v1 "github.com/jaegertracing/jaeger-operator/apis/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/service"
@@ -52,6 +54,38 @@ func (i *QueryIngress) Get() *networkingv1.Ingress {
 
 	if i.jaeger.Spec.Ingress.IngressClassName != nil {
 		spec.IngressClassName = i.jaeger.Spec.Ingress.IngressClassName
+	} else {
+		class := ""
+		nginxIngressAvailable := false
+		config, err := rest.InClusterConfig()
+		if err == nil {
+			clientSet, err := kubernetes.NewForConfig(config)
+			if err == nil {
+				ingressList, err := clientSet.NetworkingV1().IngressClasses().List(context.Background(), metav1.ListOptions{})
+				if err == nil {
+					for _, ingress := range ingressList.Items {
+						if ingress.Name == "nginx" {
+							nginxIngressAvailable = true
+						}
+						for k, v := range ingress.Annotations {
+							if k == "ingressclass.kubernetes.io/is-default-class" {
+								if v == "true" {
+									class = ingress.Name
+									break
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+
+		if len(class) > 0 {
+			spec.IngressClassName = &class
+		} else if nginxIngressAvailable {
+			class = "nginx"
+			spec.IngressClassName = &class
+		}
 	}
 
 	return &networkingv1.Ingress{


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #1568

## Description of the changes
- if spec.IngressClassName is not specified in CRD, then this will query kubernetes API for getting list of IngressClasses and look for if any default IngressClass is available, if present the it attach that IngressClass to networkingv1.IngressSpec of jaegerIngress and if not available then it check for nginx ingress controller and attach that and if nothing is avalable then it do nothing.

## How was this change tested?
- tested over multinode cluster with nginx ingress controller enabled

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
