### PR TITLE
Add minimum Kubernetes and OpenShift versions

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -11,6 +11,9 @@ LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.13.0+git
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 
+# OpenShift specific labels.
+LABEL com.redhat.openshift.versions=v4.12
+
 # Copy files to locations specified by labels.
 COPY bundle/manifests /manifests/
 COPY bundle/metadata /metadata/

--- a/bundle/manifests/jaeger-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/jaeger-operator.clusterserviceversion.yaml
@@ -517,6 +517,7 @@ spec:
   - email: jaeger-tracing@googlegroups.com
     name: Jaeger Google Group
   maturity: alpha
+  minKubeVersion: 1.19.0
   provider:
     name: CNCF
   replaces: jaeger-operator.v1.53.0

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -9,3 +9,6 @@ annotations:
   operators.operatorframework.io.metrics.builder: operator-sdk-v1.13.0+git
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
+
+  # OpenShift annotations
+  com.redhat.openshift.versions: v4.12

--- a/config/manifests/bases/jaeger-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/jaeger-operator.clusterserviceversion.yaml
@@ -122,6 +122,7 @@ spec:
   - email: jaeger-tracing@googlegroups.com
     name: Jaeger Google Group
   maturity: alpha
+  minKubeVersion: 1.19.0
   provider:
     name: CNCF
   replaces: jaeger-operator.v1.53.0


### PR DESCRIPTION
Add minimum Kubernetes and OpenShift versions
Ref. https://github.com/k8s-operatorhub/community-operators/pull/3764#issuecomment-1896105588

## Which problem is this PR solving?
The `.spec.minKubeVersion` annotation is missing, see https://github.com/k8s-operatorhub/community-operators/pull/3764#issuecomment-1896105588

## Description of the changes
- added `.spec.minKubeVersion` to the CSV
- added `com.redhat.openshift.versions` to the labels and annotations (see https://docs.openshift.com/container-platform/4.15/operators/operator_sdk/osdk-working-bundle-images.html#osdk-control-compat_osdk-working-bundle-images)

## How was this change tested?
- manual check if the relevant files were updated

## Checklist
- [X] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [X] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
