### PR TITLE
Extended compatibility matrix

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -3,6 +3,12 @@ The following table shows the compatibility of jaeger operator with different co
 
 | Jaeger Operator | Kubernetes      | Strimzi Operator   | Cert-Manager |
 |-----------------|-----------------|--------------------|--------------|
+| v1.55.x         | v1.19 to v1.28  | v0.32              | v1.6.1       |
+| v1.54.x         | v1.19 to v1.28  | v0.32              | v1.6.1       |
+| v1.53.x         | v1.19 to v1.28  | v0.32              | v1.6.1       |
+| v1.52.x         | v1.19 to v1.28  | v0.32              | v1.6.1       |
+| v1.51.x         | v1.19 to v1.28  | v0.32              | v1.6.1       |
+| v1.50.x         | v1.19 to v1.28  | v0.32              | v1.6.1       |
 | v1.49.x         | v1.19 to v1.28  | v0.32              | v1.6.1       |
 | v1.48.x         | v1.19 to v1.27  | v0.32              | v1.6.1       |
 | v1.47.x         | v1.19 to v1.27  | v0.32              | v1.6.1       |

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,5 +1,4 @@
-The following table shows the compatibility of jaeger operator with different components, in this particular case we shows Kubernetes and Strimzi operator compatibility
-
+The following table shows the compatibility of Jaeger Operator with three different components: Kubernetes, Strimzi Operator, and Cert-Manager.
 
 | Jaeger Operator | Kubernetes      | Strimzi Operator   | Cert-Manager |
 |-----------------|-----------------|--------------------|--------------|
@@ -8,7 +7,6 @@ The following table shows the compatibility of jaeger operator with different co
 | v1.53.x         | v1.19 to v1.28  | v0.32              | v1.6.1       |
 | v1.52.x         | v1.19 to v1.28  | v0.32              | v1.6.1       |
 | v1.51.x         | v1.19 to v1.28  | v0.32              | v1.6.1       |
-| v1.50.x         | v1.19 to v1.28  | v0.32              | v1.6.1       |
 | v1.49.x         | v1.19 to v1.28  | v0.32              | v1.6.1       |
 | v1.48.x         | v1.19 to v1.27  | v0.32              | v1.6.1       |
 | v1.47.x         | v1.19 to v1.27  | v0.32              | v1.6.1       |

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -7,6 +7,7 @@ The following table shows the compatibility of Jaeger Operator with three differ
 | v1.53.x         | v1.19 to v1.28  | v0.32              | v1.6.1       |
 | v1.52.x         | v1.19 to v1.28  | v0.32              | v1.6.1       |
 | v1.51.x         | v1.19 to v1.28  | v0.32              | v1.6.1       |
+| v1.50.x         | v1.19 to v1.28  | v0.32              | v1.6.1       |
 | v1.49.x         | v1.19 to v1.28  | v0.32              | v1.6.1       |
 | v1.48.x         | v1.19 to v1.27  | v0.32              | v1.6.1       |
 | v1.47.x         | v1.19 to v1.27  | v0.32              | v1.6.1       |


### PR DESCRIPTION
## Which problem is this PR solving?
Resolves https://github.com/jaegertracing/jaeger-operator/issues/2506

## Description of the changes
This PR extends the compatibility matrix by adding the missing Jaeger Operator versions.

## How was this change tested?
Ran the command: `make lint test`

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
