### PR TITLE
fixes [Bug]: imagePullSecrets is not set for agent DaemonSet #2210

### DIFF
--- a/pkg/deployment/agent.go
+++ b/pkg/deployment/agent.go
@@ -144,7 +144,7 @@ func (a *Agent) Get() *appsv1.DaemonSet {
 					Annotations: commonSpec.Annotations,
 				},
 				Spec: corev1.PodSpec{
-					ImagePullSecrets: a.jaeger.Spec.ImagePullSecrets,
+					ImagePullSecrets: a.jaeger.Spec.Agent.ImagePullSecrets,
 					Containers: []corev1.Container{{
 						Image: util.ImageName(a.jaeger.Spec.Agent.Image, "jaeger-agent-image"),
 						Name:  "jaeger-agent-daemonset",

--- a/pkg/deployment/agent_test.go
+++ b/pkg/deployment/agent_test.go
@@ -288,7 +288,7 @@ func TestAgentImagePullSecrets(t *testing.T) {
 	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestAllInOneImagePullSecrets"})
 	const pullSecret = "mysecret"
 	jaeger.Spec.Agent.Strategy = "daemonset"
-	jaeger.Spec.ImagePullSecrets = []corev1.LocalObjectReference{
+	jaeger.Spec.Agent.ImagePullSecrets = []corev1.LocalObjectReference{
 		{
 			Name: pullSecret,
 		},


### PR DESCRIPTION
Resolve #2210 
Modify ImagePullSecrets input in agent.go definition to accept imagePullSecrets defined under agent for daemonset strategy.
Verified the changes by running TestAgentImagePullSecrets test in agent_test.go and also modified the spec referencd for ImagePullSecrets test.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
