### PR TITLE
Update compatibility matrix for v1.57.x

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -2,6 +2,7 @@ The following table shows the compatibility of Jaeger Operator with three differ
 
 | Jaeger Operator | Kubernetes      | Strimzi Operator   | Cert-Manager |
 |-----------------|-----------------|--------------------|--------------|
+| v1.57.x         | v1.19 to v1.28  | v0.32              | v1.6.1       |
 | v1.56.x         | v1.19 to v1.28  | v0.32              | v1.6.1       |
 | v1.55.x         | v1.19 to v1.28  | v0.32              | v1.6.1       |
 | v1.54.x         | v1.19 to v1.28  | v0.32              | v1.6.1       |


### PR DESCRIPTION
## Which problem is this PR solving?
Resolves #2574 

## Description of the changes
Updated compatibility matrix with the following map:

| Jaeger Operator | Kubernetes      | Strimzi Operator   | Cert-Manager |
|-----------------|-----------------|--------------------|--------------|
| v1.57.x         | v1.19 to v1.28  | v0.32              | v1.6.1       |


## How was this change tested?
- 

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
