### PR TITLE
Revert jaeger agent deprecation

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -31,6 +31,7 @@ jobs:
          - { name: "examples", label: "Examples" }
          - { name: "generate", label: "Generate" }
          - { name: "miscellaneous", label: "Miscellaneous" }
+         - { name: "sidecar", label: "Sidecar" }
          - { name: "streaming", label: "Streaming" }
          - { name: "ui", label: "UI" }
          - { name: "upgrade", label: "Upgrade" }

--- a/apis/v1/jaeger_types.go
+++ b/apis/v1/jaeger_types.go
@@ -508,7 +508,7 @@ type JaegerIngesterSpec struct {
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 }
 
-// JaegerAgentSpec is deprecated and disabled.
+// JaegerAgentSpec defines the options to be used when deploying the agent
 type JaegerAgentSpec struct {
 	// Strategy can be either 'DaemonSet' or 'Sidecar' (default)
 	// +optional

--- a/apis/v1/jaeger_webhook.go
+++ b/apis/v1/jaeger_webhook.go
@@ -2,7 +2,6 @@ package v1
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"regexp"
 
@@ -49,6 +48,7 @@ func (j *Jaeger) objsWithOptions() []*Options {
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (j *Jaeger) Default() {
 	jaegerlog.Info("default", "name", j.Name)
+	jaegerlog.Info("WARNING jaeger-agent is deprecated and will removed in v1.55.0. See https://github.com/jaegertracing/jaeger/issues/4739", "component", "agent")
 
 	if j.Spec.Storage.Elasticsearch.Name == "" {
 		j.Spec.Storage.Elasticsearch.Name = defaultElasticsearchName
@@ -96,15 +96,6 @@ func (j *Jaeger) ValidateCreate() (admission.Warnings, error) {
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (j *Jaeger) ValidateUpdate(_ runtime.Object) (admission.Warnings, error) {
 	jaegerlog.Info("validate update", "name", j.Name)
-
-	got, err := json.Marshal(j.Spec.Agent)
-	if err != nil {
-		return nil, err
-	}
-	want, _ := json.Marshal(JaegerAgentSpec{})
-	if string(got) != string(want) {
-		return nil, fmt.Errorf("Jaeger agent configuration is no longer supported. Please remove any agent configuration. For more details see https://github.com/jaegertracing/jaeger/issues/4739.")
-	}
 
 	if ShouldInjectOpenShiftElasticsearchConfiguration(j.Spec.Storage) && j.Spec.Storage.Elasticsearch.DoNotProvision {
 		// check if ES instance exists

--- a/apis/v1/jaeger_webhook_test.go
+++ b/apis/v1/jaeger_webhook_test.go
@@ -269,20 +269,6 @@ func TestValidate(t *testing.T) {
 			},
 			err: `tls flags incomplete, got: [--something.tls.else=fails]`,
 		},
-		{
-			name: "configured jaeger agent spec",
-			current: &Jaeger{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "project1",
-				},
-				Spec: JaegerSpec{
-					Agent: JaegerAgentSpec{
-						Strategy: "something",
-					},
-				},
-			},
-			err: `Jaeger agent configuration is no longer supported. Please remove any agent configuration. For more details see https://github.com/jaegertracing/jaeger/issues/4739.`,
-		},
 	}
 
 	for _, test := range tests {

--- a/bundle/manifests/jaeger-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/jaeger-operator.clusterserviceversion.yaml
@@ -135,6 +135,26 @@ spec:
           - update
           - watch
         - apiGroups:
+          - apps
+          resources:
+          - deployments
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
           - autoscaling
           resources:
           - horizontalpodautoscalers
@@ -198,6 +218,26 @@ spec:
           - patch
           - update
           - watch
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces/status
+          verbs:
+          - get
+          - patch
+          - update
         - apiGroups:
           - extensions
           resources:
@@ -493,6 +533,32 @@ spec:
       name: jaeger-operator
   version: 1.57.0
   webhookdefinitions:
+  - admissionReviewVersions:
+    - v1
+    containerPort: 443
+    deploymentName: jaeger-operator
+    failurePolicy: Ignore
+    generateName: deployment.sidecar-injector.jaegertracing.io
+    objectSelector:
+      matchExpressions:
+      - key: name
+        operator: NotIn
+        values:
+        - jaeger-operator
+    rules:
+    - apiGroups:
+      - apps
+      apiVersions:
+      - v1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - deployments
+    sideEffects: None
+    targetPort: 9443
+    type: MutatingAdmissionWebhook
+    webhookPath: /mutate-v1-deployment
   - admissionReviewVersions:
     - v1
     containerPort: 443

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -20,6 +20,26 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - autoscaling
   resources:
   - horizontalpodautoscalers
@@ -83,6 +103,26 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces/status
+  verbs:
+  - get
+  - patch
+  - update
 - apiGroups:
   - extensions
   resources:

--- a/config/webhook/deployment_inject_patch.yaml
+++ b/config/webhook/deployment_inject_patch.yaml
@@ -1,0 +1,12 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+webhooks:
+  - name: deployment.sidecar-injector.jaegertracing.io
+    objectSelector: # Skip resources with the name jaeger-operator
+      matchExpressions:
+        - key: name
+          operator: NotIn
+          values:
+            - "jaeger-operator"

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -8,4 +8,4 @@ configurations:
 - kustomizeconfig.yaml
 
 patchesStrategicMerge:
-  - remove_deployment_webhook_patch.yaml
+  - deployment_inject_patch.yaml

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -24,6 +24,26 @@ webhooks:
     resources:
     - jaegers
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-v1-deployment
+  failurePolicy: Ignore
+  name: deployment.sidecar-injector.jaegertracing.io
+  rules:
+  - apiGroups:
+    - apps
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - deployments
+  sideEffects: None
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/config/webhook/remove_deployment_webhook_patch.yaml
+++ b/config/webhook/remove_deployment_webhook_patch.yaml
@@ -1,8 +1,0 @@
----
-apiVersion: admissionregistration.k8s.io/v1
-kind: MutatingWebhookConfiguration
-metadata:
-  name: mutating-webhook-configuration
-webhooks:
-- name: deployment.sidecar-injector.jaegertracing.io
-  $patch: delete

--- a/controllers/appsv1/deployment_webhook.go
+++ b/controllers/appsv1/deployment_webhook.go
@@ -1,0 +1,222 @@
+package appsv1
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/spf13/viper"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	v1 "github.com/jaegertracing/jaeger-operator/apis/v1"
+	"github.com/jaegertracing/jaeger-operator/pkg/config/ca"
+	"github.com/jaegertracing/jaeger-operator/pkg/inject"
+	"github.com/jaegertracing/jaeger-operator/pkg/tracing"
+)
+
+var _ webhook.AdmissionHandler = (*deploymentInterceptor)(nil)
+
+// NewDeploymentInterceptorWebhook creates a new deployment mutating webhook to be registered
+func NewDeploymentInterceptorWebhook(c client.Client, decoder *admission.Decoder) webhook.AdmissionHandler {
+	return &deploymentInterceptor{
+		client:  c,
+		decoder: decoder,
+	}
+}
+
+// You need to ensure the path here match the path in the marker.
+// +kubebuilder:webhook:path=/mutate-v1-deployment,mutating=true,failurePolicy=ignore,groups="apps",resources=deployments,sideEffects=None,verbs=create;update,versions=v1,name=deployment.sidecar-injector.jaegertracing.io,admissionReviewVersions=v1
+
+// +kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=namespaces/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=apps,resources=deployments/status,verbs=get;update;patch
+
+// deploymentInterceptor label pods if Sidecar is specified in deployment
+type deploymentInterceptor struct {
+	client  client.Client
+	decoder *admission.Decoder
+}
+
+func (d *deploymentInterceptor) shouldHandleDeployment(req admission.Request) bool {
+	if namespaces := viper.GetString(v1.ConfigWatchNamespace); namespaces != v1.WatchAllNamespaces {
+		for _, ns := range strings.Split(namespaces, ",") {
+			if strings.EqualFold(ns, req.Namespace) {
+				return true
+			}
+		}
+		return false
+	}
+	return true
+}
+
+// Handle adds a label to a generated pod if deployment or namespace provide annotaion
+func (d *deploymentInterceptor) Handle(ctx context.Context, req admission.Request) admission.Response {
+	tracer := otel.GetTracerProvider().Tracer(v1.ReconciliationTracer)
+	ctx, span := tracer.Start(ctx, "reconcileDeployment")
+	span.SetAttributes(
+		attribute.String("kind", req.Kind.String()),
+		attribute.String("name", req.Name),
+		attribute.String("namespace", req.Namespace),
+	)
+
+	if !d.shouldHandleDeployment(req) {
+		return admission.Allowed("not watching in namespace, we do not touch the deployment")
+	}
+
+	defer span.End()
+
+	logger := log.Log.WithValues("namespace", req.Namespace)
+	logger.V(-1).Info("verify deployment")
+
+	dep := &appsv1.Deployment{}
+	err := d.decoder.Decode(req, dep)
+	if err != nil {
+		logger.Error(err, "failed to decode deployment")
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	if dep.Labels["app"] == "jaeger" && dep.Labels["app.kubernetes.io/component"] != "query" {
+		// Don't touch jaeger deployments
+		return admission.Allowed("is jaeger deployment, we do not touch it")
+	}
+
+	ns := &corev1.Namespace{}
+	err = d.client.Get(ctx, types.NamespacedName{Name: req.Namespace}, ns)
+	// we shouldn't fail if the namespace object can't be obtained
+	if err != nil {
+		msg := "failed to get the namespace for the deployment, skipping injection based on namespace annotation"
+		logger.Error(err, msg)
+		span.AddEvent(msg, trace.WithAttributes(attribute.String("error", err.Error())))
+	}
+
+	jaegers := &v1.JaegerList{}
+	opts := []client.ListOption{}
+
+	if viper.GetString(v1.ConfigOperatorScope) == v1.OperatorScopeNamespace {
+		opts = append(opts, client.InNamespace(viper.GetString(v1.ConfigWatchNamespace)))
+	}
+
+	if err := d.client.List(ctx, jaegers, opts...); err != nil {
+		logger.Error(err, "failed to get the available Jaeger pods")
+		return admission.Errored(http.StatusInternalServerError, tracing.HandleError(err, span))
+	}
+
+	if inject.Needed(dep, ns) {
+		jaeger := inject.Select(dep, ns, jaegers)
+		if jaeger != nil && jaeger.GetDeletionTimestamp() == nil {
+			logger := logger.WithValues(
+				"jaeger", jaeger.Name,
+				"jaeger-namespace", jaeger.Namespace,
+			)
+			if jaeger.Namespace != dep.Namespace {
+				if err := reconcileConfigMaps(ctx, d.client, jaeger, dep); err != nil {
+					const msg = "failed to reconcile config maps for the namespace"
+					logger.Error(err, msg)
+					span.AddEvent(msg)
+				}
+			}
+
+			// a suitable jaeger instance was found! let's inject a sidecar pointing to it then
+			// Verified that jaeger instance was found and is not marked for deletion.
+			{
+				msg := "injecting Jaeger Agent sidecar"
+				logger.Info(msg)
+				span.AddEvent(msg)
+			}
+
+			envConfigMaps := corev1.ConfigMapList{}
+			d.client.List(ctx, &envConfigMaps, client.InNamespace(dep.Namespace))
+			dep = inject.Sidecar(jaeger, dep, inject.WithEnvFromConfigMaps(inject.GetConfigMapsMatchedEnvFromInDeployment(*dep, envConfigMaps.Items)))
+			marshaledDeploy, err := json.Marshal(dep)
+			if err != nil {
+				return admission.Errored(http.StatusInternalServerError, tracing.HandleError(err, span))
+			}
+
+			return admission.PatchResponseFromRaw(req.Object.Raw, marshaledDeploy)
+		}
+
+		const msg = "no suitable Jaeger instances found to inject a sidecar"
+		span.AddEvent(msg)
+		logger.V(-1).Info(msg)
+		return admission.Allowed(msg)
+	}
+
+	if hasAgent, _ := inject.HasJaegerAgent(dep); hasAgent {
+		if _, hasLabel := dep.Labels[inject.Label]; hasLabel {
+			const msg = "remove sidecar"
+			logger.Info(msg)
+			span.AddEvent(msg)
+			inject.CleanSidecar(dep.Labels[inject.Label], dep)
+			marshaledDeploy, err := json.Marshal(dep)
+			if err != nil {
+				return admission.Errored(http.StatusInternalServerError, tracing.HandleError(err, span))
+			}
+
+			return admission.PatchResponseFromRaw(req.Object.Raw, marshaledDeploy)
+		}
+	}
+	return admission.Allowed("no action needed")
+}
+
+// deploymentInterceptor implements admission.DecoderInjector.
+// A decoder will be automatically injected.
+
+// InjectDecoder injects the decoder.
+func (d *deploymentInterceptor) InjectDecoder(decoder *admission.Decoder) error {
+	d.decoder = decoder
+	return nil
+}
+
+func reconcileConfigMaps(ctx context.Context, cl client.Client, jaeger *v1.Jaeger, dep *appsv1.Deployment) error {
+	tracer := otel.GetTracerProvider().Tracer(v1.ReconciliationTracer)
+	ctx, span := tracer.Start(ctx, "reconcileConfigMaps")
+	defer span.End()
+
+	cms := []*corev1.ConfigMap{}
+	if cm := ca.GetTrustedCABundle(jaeger); cm != nil {
+		cms = append(cms, cm)
+	}
+	if cm := ca.GetServiceCABundle(jaeger); cm != nil {
+		cms = append(cms, cm)
+	}
+
+	for _, cm := range cms {
+		if err := reconcileConfigMap(ctx, cl, cm, dep); err != nil {
+			return tracing.HandleError(err, span)
+		}
+	}
+
+	return nil
+}
+
+func reconcileConfigMap(ctx context.Context, cl client.Client, cm *corev1.ConfigMap, dep *appsv1.Deployment) error {
+	tracer := otel.GetTracerProvider().Tracer(v1.ReconciliationTracer)
+	ctx, span := tracer.Start(ctx, "reconcileConfigMap")
+	defer span.End()
+
+	// Update the namespace to be the same as the Deployment being injected
+	cm.Namespace = dep.Namespace
+	span.SetAttributes(attribute.String("name", cm.Name), attribute.String("namespace", cm.Namespace))
+
+	if err := cl.Create(ctx, cm); err != nil {
+		if errors.IsAlreadyExists(err) {
+			span.AddEvent("config map exists already")
+		} else {
+			return tracing.HandleError(err, span)
+		}
+	}
+
+	return nil
+}

--- a/controllers/appsv1/deployment_webhook_test.go
+++ b/controllers/appsv1/deployment_webhook_test.go
@@ -1,0 +1,436 @@
+package appsv1
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	jsonpatch "gomodules.xyz/jsonpatch/v2"
+	admissionv1 "k8s.io/api/admission/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	v1 "github.com/jaegertracing/jaeger-operator/apis/v1"
+	"github.com/jaegertracing/jaeger-operator/pkg/autodetect"
+	"github.com/jaegertracing/jaeger-operator/pkg/inject"
+)
+
+func TestReconcileConfigMaps(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		existing []runtime.Object
+		errors   errorGroup
+		expect   error
+	}{
+		{
+			desc: "all config maps missing",
+		},
+		{
+			desc: "none missing",
+			existing: []runtime.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns1",
+						Name:      "my-instance-trusted-ca",
+					},
+				},
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns1",
+						Name:      "my-instance-service-ca",
+					},
+				},
+			},
+		},
+		{
+			desc:   "can not create",
+			errors: errorGroup{createErr: fmt.Errorf("ups, cant create things")},
+			expect: fmt.Errorf("ups, cant create things"),
+			existing: []runtime.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns1",
+						Name:      "my-instance-trusted-ca",
+					},
+				},
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ns1",
+						Name:      "my-instance-service-ca",
+					},
+				},
+			},
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			// prepare
+			jaeger := v1.NewJaeger(types.NamespacedName{
+				Namespace: "observability",
+				Name:      "my-instance",
+			})
+			dep := appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "ns1",
+					Name:      "my-dep",
+				},
+			}
+
+			cl := &failingClient{
+				WithWatch: fake.NewClientBuilder().WithRuntimeObjects(tC.existing...).Build(),
+				errors:    tC.errors,
+			}
+
+			autodetect.OperatorConfiguration.SetPlatform(autodetect.OpenShiftPlatform)
+
+			// test
+			err := reconcileConfigMaps(context.Background(), cl, jaeger, &dep)
+
+			// verify
+			assert.Equal(t, tC.expect, err)
+
+			cms := corev1.ConfigMapList{}
+			err = cl.List(context.Background(), &cms)
+			require.NoError(t, err)
+
+			assert.Len(t, cms.Items, 2)
+		})
+	}
+}
+
+type failingClient struct {
+	client.WithWatch
+
+	errors errorGroup
+}
+
+type errorGroup struct {
+	listErr   error
+	getErr    error
+	createErr error
+}
+
+func (u *failingClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	if u.errors.listErr != nil {
+		return u.errors.listErr
+	}
+	return u.WithWatch.List(ctx, list, opts...)
+}
+
+func (u *failingClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if u.errors.getErr != nil {
+		return u.errors.getErr
+	}
+	return u.WithWatch.Get(ctx, key, obj, opts...)
+}
+
+func (u *failingClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	if u.errors.createErr != nil {
+		return u.errors.createErr
+	}
+	return u.WithWatch.Create(ctx, obj, opts...)
+}
+
+func TestReconcilieDeployment(t *testing.T) {
+	namespacedName := types.NamespacedName{
+		Name:      "jaeger-query",
+		Namespace: "my-ns",
+	}
+
+	jaeger := v1.NewJaeger(types.NamespacedName{
+		Namespace: "observability",
+		Name:      "my-instance",
+	})
+
+	s := scheme.Scheme
+	s.AddKnownTypes(v1.GroupVersion, jaeger)
+	s.AddKnownTypes(v1.GroupVersion, &v1.JaegerList{})
+
+	testCases := []struct {
+		desc         string
+		dep          *appsv1.Deployment
+		jaeger       *v1.Jaeger
+		resp         admission.Response
+		errors       errorGroup
+		emptyRequest bool
+		watch_ns     string
+	}{
+		{
+			desc: "no content to decode",
+			dep:  &appsv1.Deployment{},
+			resp: admission.Response{
+				AdmissionResponse: admissionv1.AdmissionResponse{
+					Allowed: false,
+					Result: &metav1.Status{
+						Message: "there is no content to decode",
+						Code:    400,
+					},
+				},
+			},
+			emptyRequest: true,
+		},
+		{
+			desc: "can not get namespaces and list jaegers",
+			errors: errorGroup{
+				listErr: fmt.Errorf("ups cant list"),
+				getErr:  fmt.Errorf("ups cant get"),
+			},
+			dep: inject.Sidecar(jaeger, &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        namespacedName.Name,
+					Namespace:   namespacedName.Namespace,
+					Annotations: map[string]string{},
+					Labels: map[string]string{
+						"app": "not jaeger",
+					},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Name: "only_container",
+							}},
+						},
+					},
+				},
+			}),
+			resp: admission.Response{
+				AdmissionResponse: admissionv1.AdmissionResponse{
+					Allowed: false,
+					Result: &metav1.Status{
+						Message: "ups cant list",
+						Code:    500,
+					},
+				},
+			},
+		},
+		{
+			desc: "Should not remove the instance from a jaeger component",
+			dep: inject.Sidecar(jaeger, &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        namespacedName.Name,
+					Namespace:   namespacedName.Namespace,
+					Annotations: map[string]string{},
+					Labels: map[string]string{
+						"app": "jaeger",
+					},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Name: "only_container",
+							}},
+						},
+					},
+				},
+			}),
+			resp: admission.Response{
+				AdmissionResponse: admissionv1.AdmissionResponse{
+					Allowed: true,
+					Result: &metav1.Status{
+						Message: "is jaeger deployment, we do not touch it",
+						Code:    200,
+					},
+				},
+			},
+		},
+		{
+			desc: "Should remove the instance",
+			dep: inject.Sidecar(jaeger, &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        namespacedName.Name,
+					Namespace:   namespacedName.Namespace,
+					Annotations: map[string]string{},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Name: "only_container",
+							}},
+						},
+					},
+				},
+			}),
+			resp: admission.Response{
+				Patches: []jsonpatch.JsonPatchOperation{
+					{
+						Operation: "remove",
+						Path:      "/metadata/labels",
+					},
+					{
+						Operation: "remove",
+						Path:      "/spec/template/spec/containers/1",
+					},
+				},
+				AdmissionResponse: admissionv1.AdmissionResponse{
+					Allowed:   true,
+					PatchType: func() *admissionv1.PatchType { str := admissionv1.PatchTypeJSONPatch; return &str }(),
+				},
+			},
+		},
+		{
+			desc: "Should inject but no jaeger instace found",
+			dep: inject.Sidecar(jaeger, &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      namespacedName.Name,
+					Namespace: namespacedName.Namespace,
+					Annotations: map[string]string{
+						inject.Annotation: "true",
+					},
+					Labels: map[string]string{
+						"app": "something",
+					},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Name: "only_container",
+							}},
+						},
+					},
+				},
+			}),
+			resp: admission.Response{
+				AdmissionResponse: admissionv1.AdmissionResponse{
+					Allowed: true,
+					Result: &metav1.Status{
+						Message: "no suitable Jaeger instances found to inject a sidecar",
+						Code:    200,
+					},
+				},
+			},
+		},
+		{
+			desc: "Should inject but empty instance - no patch",
+			dep: inject.Sidecar(jaeger, &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      namespacedName.Name,
+					Namespace: namespacedName.Namespace,
+					Annotations: map[string]string{
+						inject.Annotation: "true",
+					},
+					Labels: map[string]string{
+						"app": "something",
+					},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Name: "only_container",
+							}},
+						},
+					},
+				},
+			}),
+			resp: admission.Response{
+				Patches: []jsonpatch.JsonPatchOperation{},
+				AdmissionResponse: admissionv1.AdmissionResponse{
+					Allowed: true,
+				},
+			},
+			jaeger: &v1.Jaeger{},
+		},
+		{
+			desc: "should not touch deployment on other namespaces != watch_namespaces",
+			dep: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        namespacedName.Name,
+					Namespace:   namespacedName.Namespace,
+					Annotations: map[string]string{},
+					Labels: map[string]string{
+						"app": "not jaeger",
+					},
+				},
+				Spec: appsv1.DeploymentSpec{},
+			},
+			resp: admission.Response{
+				AdmissionResponse: admissionv1.AdmissionResponse{
+					Allowed: true,
+					Result: &metav1.Status{
+						Message: "not watching in namespace, we do not touch the deployment",
+						Code:    200,
+					},
+				},
+			},
+			watch_ns: "my-other-ns, other-ns-2",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			viper.Set(v1.ConfigWatchNamespace, tc.watch_ns)
+			defer viper.Reset()
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: namespacedName.Namespace,
+				},
+			}
+
+			res := []runtime.Object{tc.dep, ns}
+			if tc.jaeger != nil {
+				res = append(res, tc.jaeger)
+			}
+
+			cl := &failingClient{
+				WithWatch: fake.NewClientBuilder().WithRuntimeObjects(res...).Build(),
+				errors:    tc.errors,
+			}
+
+			decoder := admission.NewDecoder(scheme.Scheme)
+			r := NewDeploymentInterceptorWebhook(cl, decoder)
+
+			req := admission.Request{}
+			if !tc.emptyRequest {
+				req = admission.Request{
+					AdmissionRequest: admissionv1.AdmissionRequest{
+						Name:      tc.dep.Name,
+						Namespace: tc.dep.Namespace,
+						Object: runtime.RawExtension{
+							Raw: func() []byte {
+								var buf bytes.Buffer
+								if getErr := json.NewEncoder(&buf).Encode(tc.dep); getErr != nil {
+									t.Fatal(getErr)
+								}
+								return buf.Bytes()
+							}(),
+						},
+					},
+				}
+			}
+
+			resp := r.Handle(context.Background(), req)
+
+			assert.Len(t, resp.Patches, len(tc.resp.Patches))
+			sort.Slice(resp.Patches, func(i, j int) bool {
+				return resp.Patches[i].Path < resp.Patches[j].Path
+			})
+			sort.Slice(tc.resp.Patches, func(i, j int) bool {
+				return tc.resp.Patches[i].Path < tc.resp.Patches[j].Path
+			})
+
+			assert.Equal(t, tc.resp, resp)
+		})
+	}
+}

--- a/controllers/appsv1/namespace_controller.go
+++ b/controllers/appsv1/namespace_controller.go
@@ -1,0 +1,43 @@
+package appsv1
+
+import (
+	"context"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/jaegertracing/jaeger-operator/pkg/controller/namespace"
+)
+
+// NamespaceReconciler reconciles a Deployment object
+type NamespaceReconciler struct {
+	reconcilier *namespace.ReconcileNamespace
+}
+
+// NewNamespaceReconciler creates a new namespace reconcilier controller
+func NewNamespaceReconciler(client client.Client, clientReader client.Reader, scheme *runtime.Scheme) *NamespaceReconciler {
+	return &NamespaceReconciler{
+		reconcilier: namespace.New(client, clientReader, scheme),
+	}
+}
+
+// +kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=namespaces/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=apps,resources=deployments/status,verbs=get;update;patch
+
+// Reconcile namespace resource
+func (r *NamespaceReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
+	return r.reconcilier.Reconcile(request)
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *NamespaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	err := ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Namespace{}).
+		Complete(r)
+	return err
+}

--- a/controllers/appsv1/namespace_controller_test.go
+++ b/controllers/appsv1/namespace_controller_test.go
@@ -1,0 +1,30 @@
+package appsv1_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	k8sconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/jaegertracing/jaeger-operator/controllers/appsv1"
+)
+
+func TestNamespaceControllerRegisterWithManager(t *testing.T) {
+	t.Skip("this test requires a real cluster, otherwise the GetConfigOrDie will die")
+
+	// prepare
+	mgr, err := manager.New(k8sconfig.GetConfigOrDie(), manager.Options{})
+	require.NoError(t, err)
+	reconciler := appsv1.NewNamespaceReconciler(
+		k8sClient,
+		k8sClient,
+		testScheme,
+	)
+
+	// test
+	err = reconciler.SetupWithManager(mgr)
+
+	// verify
+	require.NoError(t, err)
+}

--- a/controllers/appsv1/suite_test.go
+++ b/controllers/appsv1/suite_test.go
@@ -1,0 +1,57 @@
+package appsv1_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	v1 "github.com/jaegertracing/jaeger-operator/apis/v1"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	// +kubebuilder:scaffold:imports
+)
+
+var (
+	k8sClient  client.Client
+	testEnv    *envtest.Environment
+	testScheme *runtime.Scheme = scheme.Scheme
+)
+
+func TestMain(m *testing.M) {
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{filepath.Join("..", "..", "config", "crd", "bases")},
+	}
+
+	cfg, err := testEnv.Start()
+	if err != nil {
+		fmt.Printf("failed to start testEnv: %v", err)
+		os.Exit(1)
+	}
+
+	if err := v1.AddToScheme(scheme.Scheme); err != nil {
+		fmt.Printf("failed to register scheme: %v", err)
+		os.Exit(1)
+	}
+
+	// +kubebuilder:scaffold:scheme
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: testScheme})
+	if err != nil {
+		fmt.Printf("failed to setup a Kubernetes client: %v", err)
+		os.Exit(1)
+	}
+
+	code := m.Run()
+
+	err = testEnv.Stop()
+	if err != nil {
+		fmt.Printf("failed to stop testEnv: %v", err)
+		os.Exit(1)
+	}
+
+	os.Exit(code)
+}

--- a/examples/agent-as-daemonset.yaml
+++ b/examples/agent-as-daemonset.yaml
@@ -1,0 +1,9 @@
+apiVersion: jaegertracing.io/v1
+kind: Jaeger
+metadata:
+  name: agent-as-daemonset
+spec:
+  agent:
+    strategy: DaemonSet
+    options:
+      log-level: debug

--- a/examples/agent-with-priority-class.yaml
+++ b/examples/agent-with-priority-class.yaml
@@ -1,0 +1,16 @@
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: high-priority # priorityClassName here
+value: 1000000
+globalDefault: false
+description: "This priority class should be used for XYZ service pods only."
+---
+apiVersion: jaegertracing.io/v1
+kind: Jaeger
+metadata:
+  name: agent-as-daemonset
+spec:
+  agent:
+    strategy: DaemonSet
+    priorityClassName: high-priority # priorityClassName here

--- a/examples/openshift/agent-as-daemonset.yaml
+++ b/examples/openshift/agent-as-daemonset.yaml
@@ -1,0 +1,10 @@
+apiVersion: jaegertracing.io/v1
+kind: Jaeger
+metadata:
+  name: agent-as-daemonset
+spec:
+  agent:
+    strategy: DaemonSet
+    serviceAccount: jaeger-agent-daemonset
+    options:
+      log-level: debug

--- a/examples/openshift/service_account_jaeger-agent-daemonset.yaml
+++ b/examples/openshift/service_account_jaeger-agent-daemonset.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jaeger-agent-daemonset

--- a/pkg/autoclean/main_test.go
+++ b/pkg/autoclean/main_test.go
@@ -89,9 +89,10 @@ func TestCleanDeployments(t *testing.T) {
 					},
 				},
 			}
+			dep = inject.Sidecar(jaeger, dep)
 
 			// sanity check
-			require.Len(t, dep.Spec.Template.Spec.Containers, 1)
+			require.Len(t, dep.Spec.Template.Spec.Containers, 2)
 
 			// prepare the list of existing objects
 			objs := []runtime.Object{dep}
@@ -123,8 +124,8 @@ func TestCleanDeployments(t *testing.T) {
 				assert.Len(t, persisted.Spec.Template.Spec.Containers, 1)
 				assert.NotContains(t, persisted.Labels, inject.Label)
 			} else {
-				assert.Len(t, persisted.Spec.Template.Spec.Containers, 1)
-				assert.NotContains(t, persisted.Labels, inject.Label)
+				assert.Len(t, persisted.Spec.Template.Spec.Containers, 2)
+				assert.Contains(t, persisted.Labels, inject.Label)
 			}
 		})
 	}

--- a/pkg/cmd/start/main.go
+++ b/pkg/cmd/start/main.go
@@ -19,6 +19,7 @@ import (
 func AddFlags(cmd *cobra.Command) {
 	cmd.Flags().String("log-level", "info", "The log-level for the operator. Possible values: trace, debug, info, warning, error, fatal, panic")
 	cmd.Flags().String("jaeger-version", version.DefaultJaeger(), "Deprecated: the Jaeger version is now managed entirely by the operator. This option is currently no-op.")
+	cmd.Flags().String("jaeger-agent-image", "jaegertracing/jaeger-agent", "The Docker image for the Jaeger Agent")
 	cmd.Flags().String("jaeger-query-image", "jaegertracing/jaeger-query", "The Docker image for the Jaeger Query")
 	cmd.Flags().String("jaeger-collector-image", "jaegertracing/jaeger-collector", "The Docker image for the Jaeger Collector")
 	cmd.Flags().String("jaeger-ingester-image", "jaegertracing/jaeger-ingester", "The Docker image for the Jaeger Ingester")
@@ -42,6 +43,7 @@ func AddFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool("leader-elect", false, "Enable leader election for controller manager. "+
 		"Enabling this will ensure there is only one active controller manager.")
 
+	_ = viper.BindEnv("jaeger-agent-image", "RELATED_IMAGE_JAEGER_AGENT")
 	_ = viper.BindEnv("jaeger-query-image", "RELATED_IMAGE_JAEGER_QUERY")
 	_ = viper.BindEnv("jaeger-collector-image", "RELATED_IMAGE_JAEGER_COLLECTOR")
 	_ = viper.BindEnv("jaeger-ingester-image", "RELATED_IMAGE_JAEGER_INGESTER")
@@ -71,6 +73,7 @@ func NewStartCommand() *cobra.Command {
 	AddFlags(cmd)
 	cmd.Flags().String("metrics-host", "0.0.0.0", "The host to bind the metrics port")
 	cmd.Flags().Int32("metrics-port", 8383, "The metrics port")
+	cmd.Flags().String("jaeger-agent-hostport", "localhost:6831", "The location for the Jaeger Agent")
 	cmd.Flags().Bool("tracing-enabled", false, "Whether the Operator should report its own spans to a Jaeger instance")
 
 	return cmd

--- a/pkg/controller/jaeger/jaeger_controller_test.go
+++ b/pkg/controller/jaeger/jaeger_controller_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -21,6 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	v1 "github.com/jaegertracing/jaeger-operator/apis/v1"
+	"github.com/jaegertracing/jaeger-operator/pkg/inject"
 	"github.com/jaegertracing/jaeger-operator/pkg/kafka/v1beta2"
 	"github.com/jaegertracing/jaeger-operator/pkg/strategy"
 )
@@ -85,6 +87,112 @@ func TestReconcileSyncOnJaegerChanges(t *testing.T) {
 	// test
 	_, err := r.Reconcile(req)
 	assert.Equal(t, errList, err)
+}
+
+func TestSyncOnJaegerChanges(t *testing.T) {
+	// prepare
+	jaeger := v1.NewJaeger(types.NamespacedName{
+		Namespace: "observability",
+		Name:      "my-instance",
+	})
+
+	objs := []client.Object{
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+			Name: "ns-with-annotation",
+			Annotations: map[string]string{
+				inject.Annotation: "true",
+			},
+		}},
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "dep-without-annotation",
+				Namespace: "ns-with-annotation",
+			},
+		},
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "dep-with-annotation",
+				Namespace: "ns-with-annotation",
+				Annotations: map[string]string{
+					inject.Annotation: "true",
+				},
+			},
+		},
+
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+			Name: "ns-without-annotation",
+		}},
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "dep-without-annotation",
+				Namespace: "ns-without-annotation",
+			},
+		},
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "dep-with-annotation",
+				Namespace: "ns-without-annotation",
+				Annotations: map[string]string{
+					inject.Annotation: "true",
+				},
+			},
+		},
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "dep-with-another-jaegers-label",
+				Namespace: "ns-without-annotation",
+				Annotations: map[string]string{
+					inject.Annotation: "true",
+				},
+				Labels: map[string]string{
+					inject.Label: "some-other-jaeger",
+				},
+			},
+		},
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "dep-affected-jaeger-label",
+				Namespace: "ns-without-annotation",
+				Annotations: map[string]string{
+					inject.Annotation: "true",
+				},
+				Labels: map[string]string{
+					inject.Label: jaeger.Name,
+				},
+			},
+		},
+	}
+
+	var (
+		errList   = fmt.Errorf("no no listing")
+		errGet    = fmt.Errorf("no no get")
+		errUpdate = fmt.Errorf("no no update")
+	)
+
+	cl := &modifiedClient{
+		Client:  fake.NewClientBuilder().WithObjects(objs...).Build(),
+		listErr: errList,
+		getErr:  errGet,
+	}
+
+	err := syncOnJaegerChanges(cl, cl, jaeger.Name)
+	assert.Equal(t, errList, err)
+	cl.listErr = nil
+
+	_ = syncOnJaegerChanges(cl, cl, jaeger.Name)
+	assert.Equal(t, 3, cl.counter)
+	cl.counter = 0
+	cl.getErr = nil
+
+	err = syncOnJaegerChanges(cl, cl, jaeger.Name)
+	assert.Equal(t, 4, cl.counter)
+	require.NoError(t, err)
+	cl.counter = 0
+
+	cl.updateErr = errUpdate
+	err = syncOnJaegerChanges(cl, cl, jaeger.Name)
+	assert.Equal(t, 1, cl.counter)
+	assert.Equal(t, errUpdate, err)
 }
 
 func TestNewJaegerInstance(t *testing.T) {

--- a/pkg/controller/namespace/namespace_controller.go
+++ b/pkg/controller/namespace/namespace_controller.go
@@ -1,0 +1,119 @@
+package namespace
+
+import (
+	"context"
+	"fmt"
+
+	"go.opentelemetry.io/otel"
+	otelattribute "go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	v1 "github.com/jaegertracing/jaeger-operator/apis/v1"
+	"github.com/jaegertracing/jaeger-operator/pkg/inject"
+	"github.com/jaegertracing/jaeger-operator/pkg/tracing"
+)
+
+// ReconcileNamespace reconciles a Namespace object
+type ReconcileNamespace struct {
+	// This client, initialized using mgr.Client() above, is a split client
+	// that reads objects from the cache and writes to the apiserver
+	client client.Client
+
+	// this avoid the cache, which we need to bypass because the default client will attempt to place
+	// a watch on Namespace at cluster scope, which isn't desirable to us...
+	rClient client.Reader
+
+	scheme *runtime.Scheme
+}
+
+// New creates new namespace controller
+func New(client client.Client, clientReader client.Reader, scheme *runtime.Scheme) *ReconcileNamespace {
+	return &ReconcileNamespace{
+		client:  client,
+		rClient: clientReader,
+		scheme:  scheme,
+	}
+}
+
+// Reconcile reads that state of the cluster for a Namespace object and makes changes based on the state read
+// and what is in the Namespace.Spec
+// Note:
+// The Controller will requeue the Request to be processed again if the returned error is non-nil or
+// Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
+func (r *ReconcileNamespace) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	ctx := context.Background()
+
+	tracer := otel.GetTracerProvider().Tracer(v1.ReconciliationTracer)
+	ctx, span := tracer.Start(ctx, "reconcileNamespace")
+	defer span.End()
+
+	span.SetAttributes(otelattribute.String("name", request.Name), otelattribute.String("namespace", request.Namespace))
+	logger := log.Log.WithValues(
+		"namespace", request.Namespace,
+		"name", request.Name,
+	)
+	logger.V(-1).Info("Reconciling Namespace")
+
+	ns := &corev1.Namespace{}
+	err := r.rClient.Get(ctx, request.NamespacedName, ns)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Request object not found, could have been deleted after reconcile request.
+			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
+			// Return and don't requeue
+			span.SetStatus(codes.Error, err.Error())
+			return reconcile.Result{}, nil
+		}
+		// Error reading the object - requeue the request.
+		return reconcile.Result{}, tracing.HandleError(err, span)
+	}
+
+	opts := []client.ListOption{
+		client.InNamespace(request.Name),
+	}
+
+	// Fetch the Deployment instance
+	deps := &appsv1.DeploymentList{}
+	err = r.rClient.List(ctx, deps, opts...)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Request object not found, could have been deleted after reconcile request.
+			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
+			// Return and don't requeue
+			return reconcile.Result{}, nil
+		}
+		// Error reading the object - requeue the request.
+		return reconcile.Result{}, tracing.HandleError(err, span)
+	}
+
+	for i := 0; i < len(deps.Items); i++ {
+		dep := &deps.Items[i]
+		if dep.Labels["app"] == "jaeger" {
+			// Don't touch jaeger deployments
+			continue
+		}
+
+		// NOTE: If a deployment does not provide an "inject" annotation and
+		// has an agent, we need to verify if this is caused by a annotated
+		// namespace.
+		hasAgent, _ := inject.HasJaegerAgent(dep)
+		_, hasDepAnnotation := dep.Annotations[inject.Annotation]
+		verificationNeeded := hasAgent && !hasDepAnnotation
+
+		if inject.Needed(dep, ns) || verificationNeeded {
+			inject.IncreaseRevision(dep.Annotations)
+			if err := r.client.Update(context.Background(), dep); err != nil {
+				logger.V(5).Info(fmt.Sprintf("%s", err))
+				return reconcile.Result{}, tracing.HandleError(err, span)
+			}
+		}
+	}
+	return reconcile.Result{}, nil
+}

--- a/pkg/controller/namespace/namespace_controller_test.go
+++ b/pkg/controller/namespace/namespace_controller_test.go
@@ -1,0 +1,235 @@
+package namespace
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	v1 "github.com/jaegertracing/jaeger-operator/apis/v1"
+	"github.com/jaegertracing/jaeger-operator/pkg/inject"
+)
+
+type bundle struct {
+	dep              *appsv1.Deployment
+	expectedRevision int
+}
+
+type failingClient struct {
+	client.Client
+	err error
+}
+
+func (f *failingClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	if f.err != nil {
+		return f.err
+	}
+	return f.Client.Update(ctx, obj, opts...)
+}
+
+func TestReconcilieDeployment(t *testing.T) {
+	const depNamespace = "my-ns"
+
+	jaeger := v1.NewJaeger(types.NamespacedName{
+		Namespace: "observability",
+		Name:      "my-instance",
+	})
+
+	s := scheme.Scheme
+	s.AddKnownTypes(v1.GroupVersion, jaeger)
+	s.AddKnownTypes(v1.GroupVersion, &v1.JaegerList{})
+
+	errReconcile := fmt.Errorf("no no reconcile")
+
+	testCases := []struct {
+		desc         string
+		bundle       []bundle
+		errReconcile error
+	}{
+		{
+			desc: "Should set annotations to reevaluate deployments",
+			bundle: []bundle{
+				{
+					expectedRevision: -1,
+					dep: &appsv1.Deployment{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:        "jaeger-query",
+							Namespace:   depNamespace,
+							Annotations: map[string]string{},
+							Labels: map[string]string{
+								"app": "jaeger",
+							},
+						},
+						Spec: appsv1.DeploymentSpec{
+							Template: corev1.PodTemplateSpec{
+								ObjectMeta: metav1.ObjectMeta{},
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{{
+										Name: "only_container",
+									}},
+								},
+							},
+						},
+					},
+				},
+				{
+					expectedRevision: 0,
+					dep: &appsv1.Deployment{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "app1",
+							Namespace: depNamespace,
+							Annotations: map[string]string{
+								inject.Annotation: "true",
+							},
+							Labels: map[string]string{
+								"app": "app1",
+							},
+						},
+						Spec: appsv1.DeploymentSpec{
+							Template: corev1.PodTemplateSpec{
+								ObjectMeta: metav1.ObjectMeta{},
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{{
+										Name: "only_container",
+									}},
+								},
+							},
+						},
+					},
+				},
+				{
+					expectedRevision: 6,
+					dep: &appsv1.Deployment{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "app2",
+							Namespace: depNamespace,
+							Annotations: map[string]string{
+								inject.AnnotationRev: "5",
+								inject.Annotation:    "true",
+							},
+							Labels: map[string]string{
+								"app": "app2",
+							},
+						},
+						Spec: appsv1.DeploymentSpec{
+							Template: corev1.PodTemplateSpec{
+								ObjectMeta: metav1.ObjectMeta{},
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{{
+										Name: "only_container",
+									}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc:         "Should fail updating deployment",
+			errReconcile: errReconcile,
+			bundle: []bundle{
+				{
+					expectedRevision: 6,
+					dep: &appsv1.Deployment{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "app2",
+							Namespace: depNamespace,
+							Annotations: map[string]string{
+								inject.AnnotationRev: "5",
+								inject.Annotation:    "true",
+							},
+							Labels: map[string]string{
+								"app": "app2",
+							},
+						},
+						Spec: appsv1.DeploymentSpec{
+							Template: corev1.PodTemplateSpec{
+								ObjectMeta: metav1.ObjectMeta{},
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{{
+										Name: "only_container",
+									}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: depNamespace,
+				},
+			}
+
+			objs := []runtime.Object{ns}
+			for _, b := range tc.bundle {
+				objs = append(objs, b.dep)
+			}
+			cl := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
+			r := &ReconcileNamespace{
+				client:  &failingClient{Client: cl, err: tc.errReconcile},
+				rClient: cl,
+				scheme:  s,
+			}
+			req := reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name: depNamespace,
+				},
+			}
+			_, err := r.Reconcile(req)
+			assert.Equal(t, tc.errReconcile, err)
+			if tc.errReconcile != nil {
+				return
+			}
+
+			persisted := &appsv1.DeploymentList{}
+			require.NoError(t, cl.List(context.Background(), persisted))
+
+			for _, p := range persisted.Items {
+				const notFound = -2
+				expectedRevision := notFound
+				appName, ok := p.Labels["app"]
+				assert.True(t, ok)
+				for _, b := range tc.bundle {
+					name, ok := b.dep.Labels["app"]
+					assert.True(t, ok)
+					if appName == name {
+						expectedRevision = b.expectedRevision
+						break
+					}
+				}
+				if expectedRevision == notFound {
+					t.Fatal("app not found")
+				}
+
+				revStr, ok := p.Annotations[inject.AnnotationRev]
+				if expectedRevision == -1 {
+					assert.False(t, ok)
+				} else {
+					assert.True(t, ok)
+					rev, err := strconv.Atoi(revStr)
+					require.NoError(t, err)
+					assert.Equal(t, expectedRevision, rev)
+				}
+			}
+		})
+	}
+}

--- a/pkg/deployment/agent.go
+++ b/pkg/deployment/agent.go
@@ -1,0 +1,215 @@
+package deployment
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/operator-framework/operator-lib/proxy"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	v1 "github.com/jaegertracing/jaeger-operator/apis/v1"
+	"github.com/jaegertracing/jaeger-operator/pkg/account"
+	"github.com/jaegertracing/jaeger-operator/pkg/autodetect"
+	"github.com/jaegertracing/jaeger-operator/pkg/config/ca"
+	"github.com/jaegertracing/jaeger-operator/pkg/service"
+	"github.com/jaegertracing/jaeger-operator/pkg/util"
+)
+
+// Agent builds pods for jaegertracing/jaeger-agent
+type Agent struct {
+	jaeger *v1.Jaeger
+}
+
+// NewAgent builds a new Agent struct based on the given spec
+func NewAgent(jaeger *v1.Jaeger) *Agent {
+	return &Agent{jaeger: jaeger}
+}
+
+// Get returns a Agent pod
+func (a *Agent) Get() *appsv1.DaemonSet {
+	if !strings.EqualFold(a.jaeger.Spec.Agent.Strategy, "daemonset") {
+		a.jaeger.Logger().V(-1).Info(
+			"skipping agent daemonset",
+			"strategy", a.jaeger.Spec.Agent.Strategy,
+		)
+		return nil
+	}
+
+	args := a.jaeger.Spec.Agent.Options.ToArgs()
+
+	// we only add the grpc host if we are adding the reporter type and there's no explicit value yet
+	if len(util.FindItem("--reporter.grpc.host-port=", args)) == 0 {
+		args = append(args, fmt.Sprintf("--reporter.grpc.host-port=dns:///%s.%s:14250", service.GetNameForHeadlessCollectorService(a.jaeger), a.jaeger.Namespace))
+	}
+
+	// Enable tls by default for openshift platform
+	if autodetect.OperatorConfiguration.GetPlatform() == autodetect.OpenShiftPlatform {
+		if len(util.FindItem("--reporter.grpc.tls.enabled=", args)) == 0 {
+			args = append(args, "--reporter.grpc.tls.enabled=true")
+			args = append(args, fmt.Sprintf("--reporter.grpc.tls.ca=%s", ca.ServiceCAPath))
+			args = append(args, fmt.Sprintf("--reporter.grpc.tls.server-name=%s.%s.svc.cluster.local", service.GetNameForHeadlessCollectorService(a.jaeger), a.jaeger.Namespace))
+		}
+	}
+
+	zkCompactTrft := util.GetPort("--processor.zipkin-compact.server-host-port=", args, 5775)
+	configRest := util.GetPort("--http-server.host-port=", args, 5778)
+	jgCompactTrft := util.GetPort("--processor.jaeger-compact.server-host-port=", args, 6831)
+	jgBinaryTrft := util.GetPort("--processor.jaeger-binary.server-host-port=", args, 6832)
+	adminPort := util.GetAdminPort(args, 14271)
+
+	trueVar := true
+	falseVar := false
+	labels := util.Labels(a.name(), "agent", *a.jaeger)
+
+	baseCommonSpec := v1.JaegerCommonSpec{
+		Annotations: map[string]string{
+			"prometheus.io/scrape": "true",
+			"prometheus.io/port":   strconv.Itoa(int(adminPort)),
+			"linkerd.io/inject":    "disabled",
+		},
+		Labels: labels,
+	}
+
+	commonSpec := util.Merge([]v1.JaegerCommonSpec{a.jaeger.Spec.Agent.JaegerCommonSpec, a.jaeger.Spec.JaegerCommonSpec, baseCommonSpec})
+	_, ok := commonSpec.Annotations["sidecar.istio.io/inject"]
+	if !ok {
+		commonSpec.Annotations["sidecar.istio.io/inject"] = "false"
+	}
+
+	ca.Update(a.jaeger, commonSpec)
+	ca.AddServiceCA(a.jaeger, commonSpec)
+
+	// ensure we have a consistent order of the arguments
+	// see https://github.com/jaegertracing/jaeger-operator/issues/334
+	sort.Strings(args)
+
+	hostNetwork := false
+	dnsPolicy := a.jaeger.Spec.Agent.DNSPolicy
+	if a.jaeger.Spec.Agent.HostNetwork != nil {
+		hostNetwork = *a.jaeger.Spec.Agent.HostNetwork
+		if dnsPolicy == "" {
+			dnsPolicy = corev1.DNSClusterFirstWithHostNet
+		}
+	}
+
+	priorityClassName := ""
+	if a.jaeger.Spec.Agent.PriorityClassName != "" {
+		priorityClassName = a.jaeger.Spec.Agent.PriorityClassName
+	}
+
+	livenessProbe := &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Path: "/",
+				Port: intstr.FromInt(int(adminPort)),
+			},
+		},
+		InitialDelaySeconds: 5,
+		PeriodSeconds:       15,
+		FailureThreshold:    5,
+	}
+	if a.jaeger.Spec.Agent.LivenessProbe != nil {
+		livenessProbe = a.jaeger.Spec.Agent.LivenessProbe
+	}
+
+	return &appsv1.DaemonSet{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "DaemonSet",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-agent-daemonset", a.jaeger.Name),
+			Namespace: a.jaeger.Namespace,
+			Labels:    commonSpec.Labels,
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: a.jaeger.APIVersion,
+				Kind:       a.jaeger.Kind,
+				Name:       a.jaeger.Name,
+				UID:        a.jaeger.UID,
+				Controller: &trueVar,
+			}},
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: commonSpec.Labels,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels:      commonSpec.Labels,
+					Annotations: commonSpec.Annotations,
+				},
+				Spec: corev1.PodSpec{
+					ImagePullSecrets: a.jaeger.Spec.Agent.ImagePullSecrets,
+					Containers: []corev1.Container{{
+						Image: util.ImageName(a.jaeger.Spec.Agent.Image, "jaeger-agent-image"),
+						Name:  "jaeger-agent-daemonset",
+						Args:  args,
+						Env:   proxy.ReadProxyVarsFromEnv(),
+						Ports: []corev1.ContainerPort{
+							{
+								ContainerPort: zkCompactTrft,
+								HostPort:      zkCompactTrft,
+								Name:          "zk-compact-trft",
+								Protocol:      corev1.ProtocolUDP,
+							},
+							{
+								ContainerPort: configRest,
+								HostPort:      configRest,
+								Name:          "config-rest",
+							},
+							{
+								ContainerPort: jgCompactTrft,
+								HostPort:      jgCompactTrft,
+								Name:          "jg-compact-trft",
+								Protocol:      corev1.ProtocolUDP,
+							},
+							{
+								ContainerPort: jgBinaryTrft,
+								HostPort:      jgBinaryTrft,
+								Name:          "jg-binary-trft",
+								Protocol:      corev1.ProtocolUDP,
+							},
+							{
+								ContainerPort: adminPort,
+								HostPort:      adminPort,
+								Name:          "admin-http",
+							},
+						},
+						LivenessProbe: livenessProbe,
+						ReadinessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								HTTPGet: &corev1.HTTPGetAction{
+									Path: "/",
+									Port: intstr.FromInt(int(adminPort)),
+								},
+							},
+							InitialDelaySeconds: 1,
+						},
+						Resources:       commonSpec.Resources,
+						VolumeMounts:    commonSpec.VolumeMounts,
+						ImagePullPolicy: commonSpec.ImagePullPolicy,
+						SecurityContext: commonSpec.ContainerSecurityContext,
+					}},
+					DNSPolicy:          dnsPolicy,
+					HostNetwork:        hostNetwork,
+					PriorityClassName:  priorityClassName,
+					Volumes:            commonSpec.Volumes,
+					Affinity:           commonSpec.Affinity,
+					Tolerations:        commonSpec.Tolerations,
+					SecurityContext:    commonSpec.SecurityContext,
+					ServiceAccountName: account.JaegerServiceAccountFor(a.jaeger, account.AgentComponent),
+					EnableServiceLinks: &falseVar,
+				},
+			},
+		},
+	}
+}
+
+func (a *Agent) name() string {
+	return fmt.Sprintf("%s-agent", a.jaeger.Name)
+}

--- a/pkg/deployment/agent_test.go
+++ b/pkg/deployment/agent_test.go
@@ -1,0 +1,435 @@
+package deployment
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	v1 "github.com/jaegertracing/jaeger-operator/apis/v1"
+	"github.com/jaegertracing/jaeger-operator/pkg/autodetect"
+	"github.com/jaegertracing/jaeger-operator/pkg/config/ca"
+	"github.com/jaegertracing/jaeger-operator/pkg/util"
+	"github.com/jaegertracing/jaeger-operator/pkg/version"
+)
+
+func setDefaults() {
+	viper.SetDefault("jaeger-agent-image", "jaegertracing/jaeger-agent")
+}
+
+func init() {
+	setDefaults()
+}
+
+func reset() {
+	viper.Reset()
+	setDefaults()
+}
+
+func TestNewAgent(t *testing.T) {
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
+	jaeger.Spec.Agent.Strategy = "daemonset"
+
+	d := NewAgent(jaeger).Get()
+	assert.Empty(t, jaeger.Spec.Agent.Image)
+	assert.Contains(t, d.Spec.Template.Spec.Containers[0].Image, "jaeger-agent")
+}
+
+func TestDefaultAgentImage(t *testing.T) {
+	viper.Set("jaeger-agent-image", "org/custom-agent-image")
+	defer reset()
+
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
+	jaeger.Spec.Agent.Strategy = "daemonset"
+
+	d := NewAgent(jaeger).Get()
+	assert.Empty(t, jaeger.Spec.Agent.Image)
+	assert.Equal(t, "org/custom-agent-image:"+version.Get().Jaeger, d.Spec.Template.Spec.Containers[0].Image)
+}
+
+func TestGetDefaultAgentDeployment(t *testing.T) {
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
+	agent := NewAgent(jaeger)
+	assert.Nil(t, agent.Get()) // it's not implemented yet
+}
+
+func TestGetSidecarDeployment(t *testing.T) {
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
+	jaeger.Spec.Agent.Strategy = "sidecar"
+	agent := NewAgent(jaeger)
+	assert.Nil(t, agent.Get()) // it's not implemented yet
+}
+
+func TestGetDaemonSetDeployment(t *testing.T) {
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
+	jaeger.Spec.Agent.Strategy = "daemonset"
+	agent := NewAgent(jaeger)
+
+	ds := agent.Get()
+	assert.NotNil(t, ds)
+}
+
+func TestDaemonSetAgentAnnotations(t *testing.T) {
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
+	jaeger.Spec.Agent.Strategy = "daemonset"
+	jaeger.Spec.Annotations = map[string]string{
+		"name":  "operator",
+		"hello": "jaeger",
+	}
+	jaeger.Spec.Agent.Annotations = map[string]string{
+		"hello":                "world", // Override top level annotation
+		"prometheus.io/scrape": "false", // Override implicit value
+	}
+
+	agent := NewAgent(jaeger)
+	dep := agent.Get()
+
+	assert.Equal(t, "operator", dep.Spec.Template.Annotations["name"])
+	assert.Equal(t, "false", dep.Spec.Template.Annotations["sidecar.istio.io/inject"])
+	assert.Equal(t, "world", dep.Spec.Template.Annotations["hello"])
+	assert.Equal(t, "false", dep.Spec.Template.Annotations["prometheus.io/scrape"])
+	assert.Equal(t, "disabled", dep.Spec.Template.Annotations["linkerd.io/inject"])
+}
+
+func TestDaemonSetAgentLabels(t *testing.T) {
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
+	jaeger.Spec.Agent.Strategy = "daemonset"
+	jaeger.Spec.Labels = map[string]string{
+		"name":  "operator",
+		"hello": "jaeger",
+	}
+	jaeger.Spec.Agent.Labels = map[string]string{
+		"hello":   "world", // Override top level label
+		"another": "false",
+	}
+
+	agent := NewAgent(jaeger)
+	dep := agent.Get()
+
+	assert.Equal(t, "operator", dep.Spec.Template.Labels["name"])
+	assert.Equal(t, "world", dep.Spec.Template.Labels["hello"])
+	assert.Equal(t, "false", dep.Spec.Template.Labels["another"])
+	assert.Equal(t, "operator", dep.Spec.Selector.MatchLabels["name"])
+	assert.Equal(t, "world", dep.Spec.Selector.MatchLabels["hello"])
+	assert.Equal(t, "false", dep.Spec.Selector.MatchLabels["another"])
+}
+
+func TestDaemonSetAgentResources(t *testing.T) {
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
+	jaeger.Spec.Agent.Strategy = "daemonset"
+	jaeger.Spec.Resources = corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceLimitsCPU:              *resource.NewQuantity(1024, resource.BinarySI),
+			corev1.ResourceLimitsEphemeralStorage: *resource.NewQuantity(512, resource.DecimalSI),
+		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceRequestsCPU:              *resource.NewQuantity(1024, resource.BinarySI),
+			corev1.ResourceRequestsEphemeralStorage: *resource.NewQuantity(512, resource.DecimalSI),
+		},
+	}
+	jaeger.Spec.Agent.Resources = corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceLimitsCPU:    *resource.NewQuantity(2048, resource.BinarySI),
+			corev1.ResourceLimitsMemory: *resource.NewQuantity(123, resource.DecimalSI),
+		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceRequestsCPU:    *resource.NewQuantity(2048, resource.BinarySI),
+			corev1.ResourceRequestsMemory: *resource.NewQuantity(123, resource.DecimalSI),
+		},
+	}
+
+	agent := NewAgent(jaeger)
+	dep := agent.Get()
+
+	assert.Equal(t, *resource.NewQuantity(2048, resource.BinarySI), dep.Spec.Template.Spec.Containers[0].Resources.Limits[corev1.ResourceLimitsCPU])
+	assert.Equal(t, *resource.NewQuantity(2048, resource.BinarySI), dep.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceRequestsCPU])
+	assert.Equal(t, *resource.NewQuantity(123, resource.DecimalSI), dep.Spec.Template.Spec.Containers[0].Resources.Limits[corev1.ResourceLimitsMemory])
+	assert.Equal(t, *resource.NewQuantity(123, resource.DecimalSI), dep.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceRequestsMemory])
+	assert.Equal(t, *resource.NewQuantity(512, resource.DecimalSI), dep.Spec.Template.Spec.Containers[0].Resources.Limits[corev1.ResourceLimitsEphemeralStorage])
+	assert.Equal(t, *resource.NewQuantity(512, resource.DecimalSI), dep.Spec.Template.Spec.Containers[0].Resources.Requests[corev1.ResourceRequestsEphemeralStorage])
+}
+
+func TestAgentLabels(t *testing.T) {
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
+	jaeger.Spec.Agent.Strategy = "daemonset"
+	a := NewAgent(jaeger)
+	dep := a.Get()
+	assert.Equal(t, "jaeger-operator", dep.Spec.Template.Labels["app.kubernetes.io/managed-by"])
+	assert.Equal(t, "agent", dep.Spec.Template.Labels["app.kubernetes.io/component"])
+	assert.Equal(t, a.jaeger.Name, dep.Spec.Template.Labels["app.kubernetes.io/instance"])
+	assert.Equal(t, fmt.Sprintf("%s-agent", a.jaeger.Name), dep.Spec.Template.Labels["app.kubernetes.io/name"])
+}
+
+func TestAgentOrderOfArguments(t *testing.T) {
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
+	jaeger.Spec.Agent.Strategy = "daemonset"
+	jaeger.Spec.Agent.Options = v1.NewOptions(map[string]interface{}{
+		"b-option": "b-value",
+		"a-option": "a-value",
+		"c-option": "c-value",
+	})
+
+	a := NewAgent(jaeger)
+	dep := a.Get()
+
+	assert.Len(t, dep.Spec.Template.Spec.Containers, 1)
+	assert.Len(t, dep.Spec.Template.Spec.Containers[0].Args, 4)
+	assert.True(t, strings.HasPrefix(dep.Spec.Template.Spec.Containers[0].Args[0], "--a-option"))
+	assert.True(t, strings.HasPrefix(dep.Spec.Template.Spec.Containers[0].Args[1], "--b-option"))
+	assert.True(t, strings.HasPrefix(dep.Spec.Template.Spec.Containers[0].Args[2], "--c-option"))
+
+	// the following are added automatically
+	assert.True(t, strings.HasPrefix(dep.Spec.Template.Spec.Containers[0].Args[3], "--reporter.grpc.host-port"))
+}
+
+func TestAgentCustomReporterPort(t *testing.T) {
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
+	jaeger.Spec.Agent.Strategy = "daemonset"
+	jaeger.Spec.Agent.Options = v1.NewOptions(map[string]interface{}{
+		"reporter.grpc.host-port": "collector:5000",
+	})
+
+	a := NewAgent(jaeger)
+	dep := a.Get()
+
+	assert.Equal(t, "--reporter.grpc.host-port=collector:5000", dep.Spec.Template.Spec.Containers[0].Args[0])
+}
+
+func TestAgentArgumentsOpenshiftTLS(t *testing.T) {
+	autodetect.OperatorConfiguration.SetPlatform(autodetect.OpenShiftPlatform)
+	defer viper.Reset()
+
+	for _, tt := range []struct {
+		name            string
+		options         v1.Options
+		expectedArgs    []string
+		nonExpectedArgs []string
+	}{
+		{
+			name: "Openshift CA",
+			options: v1.NewOptions(map[string]interface{}{
+				"a-option": "a-value",
+			}),
+			expectedArgs: []string{
+				"--a-option=a-value",
+				"--reporter.grpc.host-port=dns:///my-instance-collector-headless.test:14250",
+				"--reporter.grpc.tls.enabled=true",
+				"--reporter.grpc.tls.ca=" + ca.ServiceCAPath,
+				"--reporter.grpc.tls.server-name=my-instance-collector-headless.test.svc.cluster.local",
+			},
+		},
+		{
+			name: "Custom CA",
+			options: v1.NewOptions(map[string]interface{}{
+				"a-option":                  "a-value",
+				"reporter.grpc.tls.enabled": "true",
+				"reporter.grpc.tls.ca":      "/my/custom/ca",
+			}),
+			expectedArgs: []string{
+				"--a-option=a-value",
+				"--reporter.grpc.host-port=dns:///my-instance-collector-headless.test:14250",
+				"--reporter.grpc.tls.enabled=true",
+				"--reporter.grpc.tls.ca=/my/custom/ca",
+			},
+		},
+		{
+			name: "Explicit disable TLS",
+			options: v1.NewOptions(map[string]interface{}{
+				"a-option":                  "a-value",
+				"reporter.grpc.tls.enabled": "false",
+			}),
+			expectedArgs: []string{
+				"--a-option=a-value",
+				"--reporter.grpc.host-port=dns:///my-instance-collector-headless.test:14250",
+				"--reporter.grpc.tls.enabled=false",
+			},
+			nonExpectedArgs: []string{
+				"--reporter.grpc.tls.enabled=true",
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			jaeger := v1.NewJaeger(types.NamespacedName{
+				Name:      "my-instance",
+				Namespace: "test",
+			})
+			jaeger.Spec.Agent.Strategy = "daemonset"
+			jaeger.Spec.Agent.Options = tt.options
+
+			a := NewAgent(jaeger)
+			dep := a.Get()
+
+			assert.Len(t, dep.Spec.Template.Spec.Containers, 1)
+			assert.Len(t, dep.Spec.Template.Spec.Containers[0].Args, len(tt.expectedArgs))
+
+			for _, arg := range tt.expectedArgs {
+				assert.NotEmpty(t, util.FindItem(arg, dep.Spec.Template.Spec.Containers[0].Args))
+			}
+
+			if tt.nonExpectedArgs != nil {
+				for _, arg := range tt.nonExpectedArgs {
+					assert.Empty(t, util.FindItem(arg, dep.Spec.Template.Spec.Containers[0].Args))
+				}
+			}
+
+			assert.Len(t, dep.Spec.Template.Spec.Volumes, 2)
+			assert.Len(t, dep.Spec.Template.Spec.Containers[0].VolumeMounts, 2)
+		})
+	}
+}
+
+func TestAgentImagePullSecrets(t *testing.T) {
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestAllInOneImagePullSecrets"})
+	const pullSecret = "mysecret"
+	jaeger.Spec.Agent.Strategy = "daemonset"
+	jaeger.Spec.Agent.ImagePullSecrets = []corev1.LocalObjectReference{
+		{
+			Name: pullSecret,
+		},
+	}
+
+	agent := NewAgent(jaeger)
+	dep := agent.Get()
+
+	assert.Equal(t, pullSecret, dep.Spec.Template.Spec.ImagePullSecrets[0].Name)
+}
+
+func TestAgentImagePullPolicy(t *testing.T) {
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestAgentImagePullPolicy"})
+	const pullPolicy = corev1.PullPolicy("Always")
+	jaeger.Spec.Agent.Strategy = "daemonset"
+	jaeger.Spec.ImagePullPolicy = corev1.PullPolicy("Always")
+
+	agent := NewAgent(jaeger)
+	dep := agent.Get()
+
+	assert.Equal(t, pullPolicy, dep.Spec.Template.Spec.Containers[0].ImagePullPolicy)
+}
+
+func TestAgentServiceLinks(t *testing.T) {
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
+	jaeger.Spec.Agent.Strategy = "daemonset"
+	a := NewAgent(jaeger)
+	dep := a.Get()
+	falseVar := false
+	assert.Equal(t, &falseVar, dep.Spec.Template.Spec.EnableServiceLinks)
+	assert.Equal(t, falseVar, dep.Spec.Template.Spec.HostNetwork)
+}
+
+func TestAgentHostNetwork(t *testing.T) {
+	trueVar := true
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
+	jaeger.Spec.Agent.Strategy = "daemonset"
+	jaeger.Spec.Agent.HostNetwork = &trueVar
+	a := NewAgent(jaeger)
+	dep := a.Get()
+	assert.Equal(t, trueVar, dep.Spec.Template.Spec.HostNetwork)
+}
+
+func TestAgentDNSPolicyWithHostNetwork(t *testing.T) {
+	trueVar := true
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
+	jaeger.Spec.Agent.Strategy = "daemonset"
+	jaeger.Spec.Agent.HostNetwork = &trueVar
+	a := NewAgent(jaeger)
+	dep := a.Get()
+	assert.Equal(t, trueVar, dep.Spec.Template.Spec.HostNetwork)
+	assert.Equal(t, corev1.DNSClusterFirstWithHostNet, dep.Spec.Template.Spec.DNSPolicy)
+}
+
+func TestAgentPriorityClassName(t *testing.T) {
+	priorityClassName := "test-class"
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
+	jaeger.Spec.Agent.Strategy = "daemonset"
+	jaeger.Spec.Agent.PriorityClassName = priorityClassName
+	a := NewAgent(jaeger)
+	dep := a.Get()
+	assert.Equal(t, priorityClassName, dep.Spec.Template.Spec.PriorityClassName)
+}
+
+func TestAgentLivenessProbe(t *testing.T) {
+	livenessProbe := &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Path: "/",
+				Port: intstr.FromInt(int(14271)),
+			},
+		},
+		InitialDelaySeconds: 60,
+		PeriodSeconds:       60,
+		FailureThreshold:    60,
+	}
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
+	jaeger.Spec.Agent.Strategy = "daemonset"
+	jaeger.Spec.Agent.LivenessProbe = livenessProbe
+	a := NewAgent(jaeger)
+	dep := a.Get()
+	assert.Equal(t, livenessProbe, dep.Spec.Template.Spec.Containers[0].LivenessProbe)
+}
+
+func TestAgentEmptyEmptyLivenessProbe(t *testing.T) {
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
+	jaeger.Spec.Agent.Strategy = "daemonset"
+	a := NewAgent(jaeger)
+	dep := a.Get()
+	assert.Equal(t, &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{
+				Path: "/",
+				Port: intstr.FromInt(int(14271)),
+			},
+		},
+		InitialDelaySeconds: 5,
+		PeriodSeconds:       15,
+		FailureThreshold:    5,
+	}, dep.Spec.Template.Spec.Containers[0].LivenessProbe)
+}
+
+func TestAgentContainerSecurityContext(t *testing.T) {
+	trueVar := true
+	idVar := int64(1234)
+	securityContextVar := corev1.SecurityContext{
+		RunAsNonRoot: &trueVar,
+		RunAsGroup:   &idVar,
+		RunAsUser:    &idVar,
+	}
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
+	jaeger.Spec.Agent.Strategy = "daemonset"
+	jaeger.Spec.Agent.ContainerSecurityContext = &securityContextVar
+
+	a := NewAgent(jaeger)
+	dep := a.Get()
+
+	assert.Equal(t, securityContextVar, *dep.Spec.Template.Spec.Containers[0].SecurityContext)
+}
+
+func TestAgentContainerSecurityContextOverride(t *testing.T) {
+	trueVar := true
+	idVar1 := int64(1234)
+	idVar2 := int64(4321)
+	securityContextVar := corev1.SecurityContext{
+		RunAsNonRoot: &trueVar,
+		RunAsGroup:   &idVar1,
+		RunAsUser:    &idVar1,
+	}
+	overrideSecurityContextVar := corev1.SecurityContext{
+		RunAsNonRoot: &trueVar,
+		RunAsGroup:   &idVar2,
+		RunAsUser:    &idVar2,
+	}
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
+	jaeger.Spec.Agent.Strategy = "daemonset"
+	jaeger.Spec.ContainerSecurityContext = &securityContextVar
+	jaeger.Spec.Agent.ContainerSecurityContext = &overrideSecurityContextVar
+
+	a := NewAgent(jaeger)
+	dep := a.Get()
+
+	assert.Equal(t, overrideSecurityContextVar, *dep.Spec.Template.Spec.Containers[0].SecurityContext)
+}

--- a/pkg/inject/oauth_proxy_test.go
+++ b/pkg/inject/oauth_proxy_test.go
@@ -152,6 +152,7 @@ func TestOAuthProxyWithCustomDelegateURLsWithoutProperClusterRole(t *testing.T) 
 	autodetect.OperatorConfiguration.SetAuthDelegatorAvailability(autodetect.AuthDelegatorAvailabilityNo)
 	defer func() {
 		viper.Reset()
+		setDefaults()
 	}()
 
 	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
@@ -240,6 +241,7 @@ func TestTrustedCAVolumeIsUsed(t *testing.T) {
 	autodetect.OperatorConfiguration.SetPlatform(autodetect.OpenShiftPlatform)
 	defer func() {
 		viper.Reset()
+		setDefaults()
 	}()
 
 	// prepare

--- a/pkg/inject/sidecar.go
+++ b/pkg/inject/sidecar.go
@@ -1,10 +1,24 @@
 package inject
 
 import (
-	appsv1 "k8s.io/api/apps/v1"
+	"fmt"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
 
+	"github.com/operator-framework/operator-lib/proxy"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	v1 "github.com/jaegertracing/jaeger-operator/apis/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/autodetect"
 	"github.com/jaegertracing/jaeger-operator/pkg/config/ca"
+	"github.com/jaegertracing/jaeger-operator/pkg/deployment"
+	"github.com/jaegertracing/jaeger-operator/pkg/service"
+	"github.com/jaegertracing/jaeger-operator/pkg/util"
 )
 
 var (
@@ -22,6 +36,394 @@ var (
 		"prometheus.io/port":   "14271",
 	}
 )
+
+const (
+	envVarServiceName = "JAEGER_SERVICE_NAME"
+	envVarPropagation = "JAEGER_PROPAGATION"
+	envVarPodName     = "POD_NAME"
+	envVarHostIP      = "HOST_IP"
+)
+
+type SidecarOptions struct {
+	EnvConfigMaps []corev1.ConfigMap
+}
+
+type Options func(f *SidecarOptions)
+
+func WithEnvFromConfigMaps(configMaps []corev1.ConfigMap) Options {
+	return func(s *SidecarOptions) {
+		s.EnvConfigMaps = configMaps
+	}
+}
+
+// Sidecar adds a new container to the deployment, connecting to the given jaeger instance
+func Sidecar(jaeger *v1.Jaeger, dep *appsv1.Deployment, opts ...Options) *appsv1.Deployment {
+	deployment.NewAgent(jaeger) // we need some initialization from that, but we don't actually need the agent's instance here
+	logFields := jaeger.Logger().WithValues("deployment", dep.Name)
+
+	if jaeger == nil {
+		logFields.V(-2).Info("no Jaeger instance found, skipping sidecar injection")
+		return dep
+	}
+
+	if val, ok := dep.Labels[Label]; ok && val != jaeger.Name {
+		logFields.V(-2).Info("deployment is assigned to a different Jaeger instance, skipping sidecar injection")
+		return dep
+	}
+	decorate(dep, opts...)
+	hasAgent, agentContainerIndex := HasJaegerAgent(dep)
+	logFields.V(-1).Info("injecting sidecar")
+	if hasAgent { // This is an update
+		dep.Spec.Template.Spec.Containers[agentContainerIndex] = container(jaeger, dep, agentContainerIndex)
+	} else {
+		dep.Spec.Template.Spec.Containers = append(dep.Spec.Template.Spec.Containers, container(jaeger, dep, -1))
+	}
+
+	jaegerName := util.Truncate(jaeger.Name, 63)
+
+	if dep.Labels == nil {
+		dep.Labels = map[string]string{Label: jaegerName}
+	} else {
+		dep.Labels[Label] = jaegerName
+	}
+
+	return dep
+}
+
+// Desired determines whether a sidecar is desired, based on the annotation from both the deployment and the namespace
+func desired(dep *appsv1.Deployment, ns *corev1.Namespace) bool {
+	logger := log.Log.WithValues(
+		"namespace", dep.Namespace,
+		"deployment", dep.Name,
+	)
+	depAnnotationValue, depExist := dep.Annotations[Annotation]
+	nsAnnotationValue, nsExist := ns.Annotations[Annotation]
+
+	if depExist && !strings.EqualFold(depAnnotationValue, "false") {
+		logger.V(-1).Info("annotation present on deployment")
+		return true
+	}
+
+	if nsExist && !strings.EqualFold(nsAnnotationValue, "false") {
+		logger.V(-1).Info("annotation present on namespace")
+		return true
+	}
+
+	return false
+}
+
+// IncreaseRevision increases the revision counter if a inject annoation exists.
+func IncreaseRevision(annotations map[string]string) {
+	if annotations == nil {
+		return
+	}
+	revStr := "0"
+	v := annotations[AnnotationRev]
+	if rev, err := strconv.Atoi(v); err == nil {
+		revStr = strconv.Itoa(rev + 1)
+	}
+	annotations[AnnotationRev] = revStr
+}
+
+// Needed determines whether a pod needs to get a sidecar injected or not
+func Needed(dep *appsv1.Deployment, ns *corev1.Namespace) bool {
+	if !desired(dep, ns) {
+		return false
+	}
+
+	// do not inject jaeger due to port collision
+	// do not inject if deployment's Annotation value is false
+	if dep.Labels["app"] == "jaeger" && dep.Labels["app.kubernetes.io/component"] != "query" {
+		return false
+	}
+
+	hasAgent, _ := HasJaegerAgent(dep)
+
+	if hasAgent {
+		// has already a sidecar injected and managed by the operator
+		// return true because could require an update.
+		_, hasLabel := dep.Labels[Label]
+		return hasLabel
+	}
+	// If no agent but has annotations
+	return true
+}
+
+// Select a suitable Jaeger from the JaegerList for the given Pod, or nil of none is suitable
+func Select(target *appsv1.Deployment, ns *corev1.Namespace, availableJaegerPods *v1.JaegerList) *v1.Jaeger {
+	jaegerNameDep := target.Annotations[Annotation]
+	jaegerNameNs := ns.Annotations[Annotation]
+
+	if jaegerNameDep != "" && !strings.EqualFold(jaegerNameDep, "true") {
+		// name on the deployment has precedence
+		if jaeger := getJaeger(target.Namespace, jaegerNameDep, availableJaegerPods); jaeger != nil {
+			return jaeger
+		}
+		return nil
+	}
+	if jaeger := getJaeger(target.Namespace, jaegerNameNs, availableJaegerPods); jaeger != nil {
+		return jaeger
+	}
+
+	if strings.EqualFold(jaegerNameDep, "true") || strings.EqualFold(jaegerNameNs, "true") {
+		// If there is only *one* available instance in all watched namespaces
+		// then that's what we'll use
+		if len(availableJaegerPods.Items) == 1 {
+			jaeger := &availableJaegerPods.Items[0]
+			return jaeger
+		}
+		// If there is more than one available instance in all watched namespaces
+		// then we should find if there is only *one* on the same namespace
+		// if that is the case. we should use it.
+		instancesInNamespace := getJaegerFromNamespace(target.Namespace, availableJaegerPods)
+		if len(instancesInNamespace) == 1 {
+			jaeger := instancesInNamespace[0]
+			return jaeger
+		}
+		// At this point, we have more than one instance that could be used to inject
+		// we should just not inject, as it's not clear which one should be used.
+	}
+	return nil
+}
+
+func getJaegerFromNamespace(namespace string, jaegers *v1.JaegerList) []*v1.Jaeger {
+	var instances []*v1.Jaeger
+	for _, p := range jaegers.Items {
+		if p.Namespace == namespace {
+			// matched the namespace!
+			j := p
+			instances = append(instances, &j)
+		}
+	}
+	return instances
+}
+
+// The implementation is non-deterministic. It selects first jaeger instance that matches inject name.
+// However, the implementation at least prefers to inject the jaeger that is in the same namespace as workload.
+// In effect this solves the non-deterministic issue injection issue for jaeger-query that sets
+// the inject annotation to the Jaeger name.
+func getJaeger(deploymentNamespace string, name string, jaegers *v1.JaegerList) *v1.Jaeger {
+	var bestCaseCandidate *v1.Jaeger
+	for i := range jaegers.Items {
+		if jaegers.Items[i].Name == name {
+			if bestCaseCandidate == nil {
+				bestCaseCandidate = &jaegers.Items[i]
+			}
+			if deploymentNamespace == jaegers.Items[i].Namespace {
+				return &jaegers.Items[i]
+			}
+		}
+	}
+	return bestCaseCandidate
+}
+
+func container(jaeger *v1.Jaeger, dep *appsv1.Deployment, agentIdx int) corev1.Container {
+	args := jaeger.Spec.Agent.Options.ToArgs()
+	envs := []corev1.EnvVar{
+		{
+			Name: envVarPodName,
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "metadata.name",
+				},
+			},
+		},
+		{
+			Name: envVarHostIP,
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "status.hostIP",
+				},
+			},
+		},
+	}
+	envs = append(envs, proxy.ReadProxyVarsFromEnv()...)
+
+	// we only add the grpc host if we are adding the reporter type and there's no explicit value yet
+	if len(util.FindItem("--reporter.grpc.host-port=", args)) == 0 {
+		args = append(args, fmt.Sprintf("--reporter.grpc.host-port=dns:///%s.%s.svc:14250", service.GetNameForHeadlessCollectorService(jaeger), jaeger.Namespace))
+	}
+
+	// Enable tls by default for openshift platform
+	if autodetect.OperatorConfiguration.GetPlatform() == autodetect.OpenShiftPlatform {
+		if len(util.FindItem("--reporter.grpc.tls.enabled=", args)) == 0 {
+			args = append(args, "--reporter.grpc.tls.enabled=true")
+			args = append(args, fmt.Sprintf("--reporter.grpc.tls.ca=%s", ca.ServiceCAPath))
+		}
+	}
+
+	zkCompactTrft := util.GetPort("--processor.zipkin-compact.server-host-port=", args, 5775)
+	configRest := util.GetPort("--http-server.host-port=", args, 5778)
+	jgCompactTrft := util.GetPort("--processor.jaeger-compact.server-host-port=", args, 6831)
+	jgBinaryTrft := util.GetPort("--processor.jaeger-binary.server-host-port=", args, 6832)
+	adminPort := util.GetAdminPort(args, 14271)
+
+	if len(util.FindItem("--agent.tags=", args)) == 0 {
+		defaultAgentTagsMap := make(map[string]string)
+		defaultAgentTagsMap["cluster"] = "undefined" // this value isn't currently available
+		defaultAgentTagsMap["deployment.name"] = dep.Name
+		defaultAgentTagsMap["pod.namespace"] = dep.Namespace
+		defaultAgentTagsMap["pod.name"] = fmt.Sprintf("${%s:}", envVarPodName)
+		defaultAgentTagsMap["host.ip"] = fmt.Sprintf("${%s:}", envVarHostIP)
+
+		defaultContainerName := getContainerName(dep.Spec.Template.Spec.Containers, agentIdx)
+
+		// if we can deduce the container name from the PodSpec
+		if defaultContainerName != "" {
+			defaultAgentTagsMap["container.name"] = defaultContainerName
+		}
+
+		if agentIdx > -1 {
+			existingAgentTags := parseAgentTags(dep.Spec.Template.Spec.Containers[agentIdx].Args)
+			// merge two maps
+			for key, value := range defaultAgentTagsMap {
+				existingAgentTags[key] = value
+			}
+			args = append(args, fmt.Sprintf(`--agent.tags=%s`, joinTags(existingAgentTags)))
+		} else {
+			args = append(args, fmt.Sprintf(`--agent.tags=%s`, joinTags(defaultAgentTagsMap)))
+		}
+
+	}
+
+	commonSpec := util.Merge([]v1.JaegerCommonSpec{jaeger.Spec.Agent.JaegerCommonSpec, jaeger.Spec.JaegerCommonSpec})
+
+	// Use only the agent common spec for volumes and mounts.
+	// We don't want to mount all Jaeger internal volumes into user's deployments
+	volumesAndMountsSpec := jaeger.Spec.Agent.JaegerCommonSpec
+	ca.Update(jaeger, &volumesAndMountsSpec)
+	ca.AddServiceCA(jaeger, &volumesAndMountsSpec)
+
+	// ensure we have a consistent order of the arguments
+	// see https://github.com/jaegertracing/jaeger-operator/issues/334
+	sort.Strings(args)
+
+	dep.Spec.Template.Spec.ImagePullSecrets = util.RemoveDuplicatedImagePullSecrets(append(dep.Spec.Template.Spec.ImagePullSecrets, jaeger.Spec.Agent.ImagePullSecrets...))
+	dep.Spec.Template.Spec.Volumes = util.RemoveDuplicatedVolumes(append(dep.Spec.Template.Spec.Volumes, volumesAndMountsSpec.Volumes...))
+	containerDefinition := corev1.Container{
+		Image: util.ImageName(jaeger.Spec.Agent.Image, "jaeger-agent-image"),
+		Name:  "jaeger-agent",
+		Args:  args,
+		Env:   envs,
+		Ports: []corev1.ContainerPort{
+			{
+				ContainerPort: zkCompactTrft,
+				Name:          "zk-compact-trft",
+				Protocol:      corev1.ProtocolUDP,
+			},
+			{
+				ContainerPort: configRest,
+				Name:          "config-rest",
+			},
+			{
+				ContainerPort: jgCompactTrft,
+				Name:          "jg-compact-trft",
+				Protocol:      corev1.ProtocolUDP,
+			},
+			{
+				ContainerPort: jgBinaryTrft,
+				Name:          "jg-binary-trft",
+				Protocol:      corev1.ProtocolUDP,
+			},
+			{
+				ContainerPort: adminPort,
+				Name:          "admin-http",
+			},
+		},
+		Resources:       commonSpec.Resources,
+		SecurityContext: jaeger.Spec.Agent.SidecarSecurityContext,
+		VolumeMounts:    volumesAndMountsSpec.VolumeMounts,
+	}
+
+	if isContainerPortAvailable(adminPort, dep) {
+		containerDefinition.LivenessProbe = &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/",
+					Port: intstr.FromInt(int(adminPort)),
+				},
+			},
+			InitialDelaySeconds: 5,
+			PeriodSeconds:       15,
+			FailureThreshold:    5,
+		}
+		containerDefinition.ReadinessProbe = &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/",
+					Port: intstr.FromInt(int(adminPort)),
+				},
+			},
+			InitialDelaySeconds: 1,
+		}
+	}
+
+	return containerDefinition
+}
+
+func decorate(dep *appsv1.Deployment, opts ...Options) {
+	app, found := dep.Spec.Template.Labels["app.kubernetes.io/instance"]
+	if !found {
+		app, found = dep.Spec.Template.Labels["app.kubernetes.io/name"]
+	}
+	if !found {
+		app, found = dep.Spec.Template.Labels["app"]
+	}
+	if found {
+		// Append the namespace to the app name. Using the DNS style "<app>.<namespace>""
+		// which also matches with the style used in Istio.
+		if len(dep.Namespace) > 0 {
+			app += "." + dep.Namespace
+		} else {
+			app += ".default"
+		}
+
+		sideCarOpt := &SidecarOptions{}
+		for _, opt := range opts {
+			opt(sideCarOpt)
+		}
+
+		for i := 0; i < len(dep.Spec.Template.Spec.Containers); i++ {
+			if !hasEnv(envVarServiceName, dep.Spec.Template.Spec.Containers[i].Env) && !haskeyInEnvFromConfigMaps(envVarServiceName, sideCarOpt.EnvConfigMaps) {
+				dep.Spec.Template.Spec.Containers[i].Env = append(dep.Spec.Template.Spec.Containers[i].Env, corev1.EnvVar{
+					Name:  envVarServiceName,
+					Value: app,
+				})
+			}
+			if !hasEnv(envVarPropagation, dep.Spec.Template.Spec.Containers[i].Env) && !haskeyInEnvFromConfigMaps(envVarPropagation, sideCarOpt.EnvConfigMaps) {
+				dep.Spec.Template.Spec.Containers[i].Env = append(dep.Spec.Template.Spec.Containers[i].Env, corev1.EnvVar{
+					Name:  envVarPropagation,
+					Value: "jaeger,b3,w3c",
+				})
+			}
+		}
+	}
+	for key, value := range PrometheusDefaultAnnotations {
+		_, ok := dep.Annotations[key]
+		if !ok {
+			dep.Annotations[key] = value
+		}
+	}
+}
+
+func haskeyInEnvFromConfigMaps(key string, configMaps []corev1.ConfigMap) bool {
+	found := false
+	for _, cm := range configMaps {
+		if _, ok := cm.Data[key]; ok {
+			found = true
+		}
+	}
+	return found
+}
+
+func hasEnv(name string, vars []corev1.EnvVar) bool {
+	for i := 0; i < len(vars); i++ {
+		if vars[i].Name == name {
+			return true
+		}
+	}
+	return false
+}
 
 // CleanSidecar of  deployments  associated with the jaeger instance.
 func CleanSidecar(instanceName string, deployment *appsv1.Deployment) {
@@ -47,4 +449,100 @@ func CleanSidecar(instanceName string, deployment *appsv1.Deployment) {
 			}
 		}
 	}
+}
+
+// HasJaegerAgent checks whether deployment has Jaeger Agent container
+func HasJaegerAgent(dep *appsv1.Deployment) (bool, int) {
+	// this pod is annotated, it should have a sidecar
+	// but does it already have one?
+	for i, container := range dep.Spec.Template.Spec.Containers {
+		if container.Name == "jaeger-agent" { // we don't labels/annotations on containers, so, we rely on its name
+			return true, i
+		}
+	}
+	return false, -1
+}
+
+// EqualSidecar check if two deployments sidecar are equal
+func EqualSidecar(dep, oldDep *appsv1.Deployment) bool {
+	depHasAgent, depAgentIndex := HasJaegerAgent(dep)
+	oldDepHasAgent, oldDepIndex := HasJaegerAgent(oldDep)
+	if depHasAgent != oldDepHasAgent {
+		return false
+	}
+	depContainer := dep.Spec.Template.Spec.Containers[depAgentIndex]
+	oldDepContainer := oldDep.Spec.Template.Spec.Containers[oldDepIndex]
+	return reflect.DeepEqual(depContainer, oldDepContainer)
+}
+
+func parseAgentTags(args []string) map[string]string {
+	tagsArg := util.FindItem("--agent.tags=", args)
+	if tagsArg == "" {
+		return map[string]string{}
+	}
+	tagsParam := strings.SplitN(tagsArg, "=", 2)[1]
+	tagsMap := make(map[string]string)
+	tagsArr := strings.Split(tagsParam, ",")
+	for _, tagsPairStr := range tagsArr {
+		tagsPair := strings.SplitN(tagsPairStr, "=", 2)
+		tagsMap[tagsPair[0]] = tagsPair[1]
+	}
+	return tagsMap
+}
+
+func joinTags(tags map[string]string) string {
+	tagsSlice := make([]string, 0)
+	for key, value := range tags {
+		tagsSlice = append(tagsSlice, fmt.Sprintf("%s=%s", key, value))
+	}
+	sort.Strings(tagsSlice)
+	return strings.Join(tagsSlice, ",")
+}
+
+func getContainerName(containers []corev1.Container, agentIdx int) string {
+	if agentIdx == -1 && len(containers) == 1 { // we only have one single container and it is not the agent
+		return containers[0].Name
+	} else if agentIdx > -1 && len(containers)-1 == 1 { // we have one single container besides the agent
+		// agent: 0, app: 1
+		// agent: 1, app: 0
+		return containers[1-agentIdx].Name
+	} else {
+		// otherwise, we cannot determine `container.name`
+		return ""
+	}
+}
+
+// isContainerPortAvailable checks whether deployment is already using some port
+func isContainerPortAvailable(port int32, dep *appsv1.Deployment) bool {
+	for _, container := range dep.Spec.Template.Spec.Containers {
+		if container.Name != "jaeger-agent" {
+			for _, containerPort := range container.Ports {
+				if port == containerPort.ContainerPort {
+					return false
+				}
+			}
+		}
+	}
+	return true
+}
+
+// GetConfigMapsMatchedEnvFromInDeployment returns configMap which matches with configMapRef
+func GetConfigMapsMatchedEnvFromInDeployment(dep appsv1.Deployment, configMaps []corev1.ConfigMap) []corev1.ConfigMap {
+	configMapSearchMap := make(map[string]corev1.ConfigMap)
+	for _, cm := range configMaps {
+		configMapSearchMap[cm.Name] = cm
+	}
+
+	matchedConfigMaps := []corev1.ConfigMap{}
+	for _, container := range dep.Spec.Template.Spec.Containers {
+		for _, envConfigMap := range container.EnvFrom {
+			if envConfigMap.ConfigMapRef == nil {
+				continue
+			}
+			if matchedCM, ok := configMapSearchMap[envConfigMap.ConfigMapRef.Name]; ok {
+				matchedConfigMaps = append(matchedConfigMaps, matchedCM)
+			}
+		}
+	}
+	return matchedConfigMaps
 }

--- a/pkg/inject/sidecar_test.go
+++ b/pkg/inject/sidecar_test.go
@@ -1,0 +1,1172 @@
+package inject
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	v1 "github.com/jaegertracing/jaeger-operator/apis/v1"
+	"github.com/jaegertracing/jaeger-operator/pkg/autodetect"
+	"github.com/jaegertracing/jaeger-operator/pkg/config/ca"
+	"github.com/jaegertracing/jaeger-operator/pkg/util"
+)
+
+func setDefaults() {
+	viper.SetDefault("jaeger-agent-image", "jaegertracing/jaeger-agent")
+}
+
+func init() {
+	setDefaults()
+}
+
+func reset() {
+	viper.Reset()
+	setDefaults()
+}
+
+func TestIncreaseRevision(t *testing.T) {
+	IncreaseRevision(nil)
+	in := map[string]string{
+		Annotation: "true",
+	}
+	IncreaseRevision(in)
+	assert.Equal(t, "0", in[AnnotationRev])
+	IncreaseRevision(in)
+	IncreaseRevision(in)
+	assert.Equal(t, "2", in[AnnotationRev])
+}
+
+func TestInjectSidecar(t *testing.T) {
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
+	dep := dep(map[string]string{}, map[string]string{})
+	dep = Sidecar(jaeger, dep)
+	assert.Equal(t, dep.Labels[Label], jaeger.Name)
+	assert.Len(t, dep.Spec.Template.Spec.Containers, 2)
+	assert.Contains(t, dep.Spec.Template.Spec.Containers[1].Image, "jaeger-agent")
+	assert.Empty(t, dep.Spec.Template.Spec.Containers[0].Env)
+	assert.Empty(t, dep.Spec.Template.Spec.Containers[1].VolumeMounts)
+	assert.Empty(t, dep.Spec.Template.Spec.Volumes)
+}
+
+func TestInjectSidecarOpenShift(t *testing.T) {
+	autodetect.OperatorConfiguration.SetPlatform(autodetect.OpenShiftPlatform)
+	defer reset()
+
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
+	assert.Empty(t, jaeger.Spec.Agent.VolumeMounts)
+	assert.Empty(t, jaeger.Spec.Agent.Volumes)
+
+	dep := dep(map[string]string{}, map[string]string{})
+	dep = Sidecar(jaeger, dep)
+	assert.Equal(t, dep.Labels[Label], jaeger.Name)
+	assert.Len(t, dep.Spec.Template.Spec.Containers, 2)
+	assert.Contains(t, dep.Spec.Template.Spec.Containers[1].Image, "jaeger-agent")
+	assert.Empty(t, dep.Spec.Template.Spec.Containers[0].Env)
+	assert.Len(t, dep.Spec.Template.Spec.Containers[1].VolumeMounts, 2)
+	assert.Len(t, dep.Spec.Template.Spec.Volumes, 2)
+
+	// CR should not be touched.
+	assert.Empty(t, jaeger.Spec.Agent.VolumeMounts)
+	assert.Empty(t, jaeger.Spec.Agent.Volumes)
+}
+
+func TestInjectSidecarWithEnvVars(t *testing.T) {
+	// prepare
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
+	dep := dep(map[string]string{Annotation: jaeger.Name}, map[string]string{"app": "testapp"})
+
+	// test
+	dep = Sidecar(jaeger, dep)
+
+	// verify
+	assert.Len(t, dep.Spec.Template.Spec.Containers, 2)
+	assert.Contains(t, dep.Spec.Template.Spec.Containers[1].Image, "jaeger-agent")
+	containsEnvVarNamed(t, dep.Spec.Template.Spec.Containers[1].Env, envVarPodName)
+	containsEnvVarNamed(t, dep.Spec.Template.Spec.Containers[1].Env, envVarHostIP)
+
+	assert.Len(t, dep.Spec.Template.Spec.Containers[0].Env, 2)
+	assert.Contains(t, dep.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: envVarPropagation, Value: "jaeger,b3,w3c"})
+	assert.Contains(t, dep.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: envVarServiceName, Value: "testapp.default"})
+}
+
+func TestInjectSidecarWithEnvVarsK8sAppName(t *testing.T) {
+	// prepare
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
+	dep := dep(map[string]string{}, map[string]string{
+		"app":                    "noapp",
+		"app.kubernetes.io/name": "testapp",
+	})
+
+	// test
+	dep = Sidecar(jaeger, dep)
+
+	// verify
+	assert.Len(t, dep.Spec.Template.Spec.Containers, 2)
+	assert.Len(t, dep.Spec.Template.Spec.Containers[0].Env, 2)
+	assert.Contains(t, dep.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: envVarServiceName, Value: "testapp.default"})
+}
+
+func TestInjectSidecarWithEnvVarsK8sAppInstance(t *testing.T) {
+	// prepare
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
+	dep := dep(map[string]string{}, map[string]string{
+		"app":                        "noapp",
+		"app.kubernetes.io/name":     "noname",
+		"app.kubernetes.io/instance": "testapp",
+	})
+
+	// test
+	dep = Sidecar(jaeger, dep)
+
+	// verify
+	assert.Len(t, dep.Spec.Template.Spec.Containers, 2)
+	assert.Len(t, dep.Spec.Template.Spec.Containers[0].Env, 2)
+	assert.Contains(t, dep.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: envVarServiceName, Value: "testapp.default"})
+}
+
+func TestInjectSidecarWithEnvVarsWithNamespace(t *testing.T) {
+	// prepare
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
+	dep := dep(map[string]string{}, map[string]string{"app": "testapp"})
+	dep.Namespace = "mynamespace"
+
+	// test
+	dep = Sidecar(jaeger, dep)
+
+	// verify
+	assert.Len(t, dep.Spec.Template.Spec.Containers, 2)
+	assert.Contains(t, dep.Spec.Template.Spec.Containers[1].Image, "jaeger-agent")
+
+	assert.Len(t, dep.Spec.Template.Spec.Containers[0].Env, 2)
+	assert.Contains(t, dep.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: envVarServiceName, Value: "testapp.mynamespace"})
+	assert.Contains(t, dep.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: envVarPropagation, Value: "jaeger,b3,w3c"})
+}
+
+func TestInjectSidecarWithEnvVarsOverrideName(t *testing.T) {
+	// prepare
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
+	dep := dep(map[string]string{}, map[string]string{"app": "testapp"})
+	envVar := corev1.EnvVar{
+		Name:  envVarServiceName,
+		Value: "otherapp",
+	}
+	dep.Spec.Template.Spec.Containers[0].Env = append(dep.Spec.Template.Spec.Containers[0].Env, envVar)
+
+	// test
+	dep = Sidecar(jaeger, dep)
+
+	// verify
+	assert.Len(t, dep.Spec.Template.Spec.Containers, 2)
+	assert.Contains(t, dep.Spec.Template.Spec.Containers[1].Image, "jaeger-agent")
+
+	assert.Len(t, dep.Spec.Template.Spec.Containers[0].Env, 2)
+	assert.Contains(t, dep.Spec.Template.Spec.Containers[0].Env, envVar)
+	assert.Contains(t, dep.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: envVarPropagation, Value: "jaeger,b3,w3c"})
+}
+
+func TestInjectSidecarWithEnvVarsOverridePropagation(t *testing.T) {
+	// prepare
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
+	traceContextEnvVar := corev1.EnvVar{
+		Name:  envVarPropagation,
+		Value: "tracecontext",
+	}
+	dep := dep(map[string]string{}, map[string]string{"app": "testapp"})
+	dep.Spec.Template.Spec.Containers[0].Env = append(dep.Spec.Template.Spec.Containers[0].Env, traceContextEnvVar)
+
+	// test
+	dep = Sidecar(jaeger, dep)
+
+	// verify
+	assert.Len(t, dep.Spec.Template.Spec.Containers, 2)
+	assert.Contains(t, dep.Spec.Template.Spec.Containers[1].Image, "jaeger-agent")
+
+	assert.Len(t, dep.Spec.Template.Spec.Containers[0].Env, 2)
+	assert.Contains(t, dep.Spec.Template.Spec.Containers[0].Env, traceContextEnvVar)
+	assert.Contains(t, dep.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: envVarServiceName, Value: "testapp.default"})
+}
+
+func TestInjectSidecarWithEnvFromK8sAppName(t *testing.T) {
+	// prepare
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
+	envFromconfigMaps := []corev1.ConfigMap{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-config",
+			Namespace: "default",
+		},
+		Data: map[string]string{
+			envVarServiceName: "jaeger,b3,w3c",
+			envVarPropagation: "test-service",
+		},
+	}}
+	dep := depEnvFrom(map[string]string{}, map[string]string{
+		"app":                    "noapp",
+		"app.kubernetes.io/name": "testapp",
+	}, []corev1.EnvFromSource{{ConfigMapRef: &corev1.ConfigMapEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "test-config"}}}})
+
+	// test
+	dep = Sidecar(jaeger, dep, WithEnvFromConfigMaps(envFromconfigMaps))
+
+	// verify
+	assert.Len(t, dep.Spec.Template.Spec.Containers, 2)
+	assert.Empty(t, dep.Spec.Template.Spec.Containers[0].Env)
+	assert.Len(t, dep.Spec.Template.Spec.Containers[0].EnvFrom, 1)
+	actualConfigName := dep.Spec.Template.Spec.Containers[0].EnvFrom[0].ConfigMapRef.Name
+	assert.Contains(t, "test-config", actualConfigName)
+}
+
+func TestInjectSidecarWithoutEnvFromK8sAppName(t *testing.T) {
+	// prepare
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
+	envFromconfigMaps := []corev1.ConfigMap{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-config",
+			Namespace: "default",
+		},
+		Data: map[string]string{
+			"USRNAME":  "=XUSUDA",
+			"PASSWORD": "+S=KDKS",
+		},
+	}}
+	dep := depEnvFrom(map[string]string{}, map[string]string{
+		"app":                    "noapp",
+		"app.kubernetes.io/name": "testapp",
+	}, []corev1.EnvFromSource{{ConfigMapRef: &corev1.ConfigMapEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "test-config"}}}})
+
+	// test
+	dep = Sidecar(jaeger, dep, WithEnvFromConfigMaps(envFromconfigMaps))
+
+	// verify
+	assert.Len(t, dep.Spec.Template.Spec.Containers, 2)
+	assert.Len(t, dep.Spec.Template.Spec.Containers[0].Env, 2)
+	assert.Len(t, dep.Spec.Template.Spec.Containers[0].EnvFrom, 1)
+	assert.Contains(t, dep.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: envVarServiceName, Value: "testapp.default"})
+}
+
+func TestInjectSidecarWithVolumeMounts(t *testing.T) {
+	// prepare
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
+	dep := dep(map[string]string{}, map[string]string{})
+
+	agentVolume := corev1.Volume{
+		Name: "test-volume1",
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: "test-secret1",
+			},
+		},
+	}
+	agentVolumeMount := corev1.VolumeMount{
+		Name:      "test-volume1",
+		MountPath: "/test-volume1",
+		ReadOnly:  true,
+	}
+
+	commonVolume := corev1.Volume{
+		Name: "test-volume2",
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: "test-secret2",
+			},
+		},
+	}
+	commonVolumeMount := corev1.VolumeMount{
+		Name:      "test-volume2",
+		MountPath: "/test-volume2",
+		ReadOnly:  true,
+	}
+
+	jaeger.Spec.Agent.Volumes = append(jaeger.Spec.Agent.Volumes, agentVolume)
+	jaeger.Spec.Agent.VolumeMounts = append(jaeger.Spec.Agent.VolumeMounts, agentVolumeMount)
+	jaeger.Spec.Volumes = append(jaeger.Spec.Volumes, commonVolume)
+	jaeger.Spec.VolumeMounts = append(jaeger.Spec.VolumeMounts, commonVolumeMount)
+
+	// test
+	dep = Sidecar(jaeger, dep)
+
+	// verify
+	assert.Contains(t, dep.Spec.Template.Spec.Volumes, agentVolume)
+	assert.NotContains(t, dep.Spec.Template.Spec.Volumes, commonVolume)
+	assert.Contains(t, dep.Spec.Template.Spec.Containers[1].Image, "jaeger-agent")
+	assert.Contains(t, dep.Spec.Template.Spec.Containers[1].VolumeMounts, agentVolumeMount)
+	assert.NotContains(t, dep.Spec.Template.Spec.Containers[1].VolumeMounts, commonVolumeMount)
+}
+
+func TestSidecarImagePullSecrets(t *testing.T) {
+	deploymentImagePullSecrets := []corev1.LocalObjectReference{{
+		Name: "deploymentImagePullSecret",
+	}}
+
+	agentImagePullSecrets := []corev1.LocalObjectReference{{
+		Name: "agentImagePullSecret",
+	}}
+
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
+	jaeger.Spec.Agent.ImagePullSecrets = agentImagePullSecrets
+
+	dep := dep(map[string]string{}, map[string]string{})
+	dep.Spec.Template.Spec.ImagePullSecrets = deploymentImagePullSecrets
+	dep = Sidecar(jaeger, dep)
+
+	assert.Len(t, dep.Spec.Template.Spec.ImagePullSecrets, 2)
+	assert.Equal(t, "deploymentImagePullSecret", dep.Spec.Template.Spec.ImagePullSecrets[0].Name)
+	assert.Equal(t, "agentImagePullSecret", dep.Spec.Template.Spec.ImagePullSecrets[1].Name)
+}
+
+func TestSidecarDefaultPorts(t *testing.T) {
+	// prepare
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
+	dep := dep(map[string]string{}, map[string]string{"app": "testapp"})
+
+	// test
+	dep = Sidecar(jaeger, dep)
+
+	// verify
+	assert.Len(t, dep.Spec.Template.Spec.Containers, 2)
+	assert.Contains(t, dep.Spec.Template.Spec.Containers[1].Image, "jaeger-agent")
+
+	assert.Len(t, dep.Spec.Template.Spec.Containers[1].Ports, 5)
+	assert.Contains(t, dep.Spec.Template.Spec.Containers[1].Ports, corev1.ContainerPort{ContainerPort: 5775, Name: "zk-compact-trft", Protocol: corev1.ProtocolUDP})
+	assert.Contains(t, dep.Spec.Template.Spec.Containers[1].Ports, corev1.ContainerPort{ContainerPort: 5778, Name: "config-rest"})
+	assert.Contains(t, dep.Spec.Template.Spec.Containers[1].Ports, corev1.ContainerPort{ContainerPort: 6831, Name: "jg-compact-trft", Protocol: corev1.ProtocolUDP})
+	assert.Contains(t, dep.Spec.Template.Spec.Containers[1].Ports, corev1.ContainerPort{ContainerPort: 6832, Name: "jg-binary-trft", Protocol: corev1.ProtocolUDP})
+	assert.Contains(t, dep.Spec.Template.Spec.Containers[1].Ports, corev1.ContainerPort{ContainerPort: 14271, Name: "admin-http"})
+}
+
+func TestSidecarProbes(t *testing.T) {
+	// prepare
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
+	dep := dep(map[string]string{}, map[string]string{"app": "testapp"})
+
+	// test
+	dep = Sidecar(jaeger, dep)
+
+	// verify
+	assert.Len(t, dep.Spec.Template.Spec.Containers, 2)
+	assert.Contains(t, dep.Spec.Template.Spec.Containers[1].Image, "jaeger-agent")
+
+	assert.Len(t, dep.Spec.Template.Spec.Containers[1].Ports, 5)
+	assert.NotNil(t, dep.Spec.Template.Spec.Containers[1].LivenessProbe)
+	assert.NotNil(t, dep.Spec.Template.Spec.Containers[1].ReadinessProbe)
+}
+
+func TestSkipInjectSidecar(t *testing.T) {
+	// prepare
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
+	dep := dep(map[string]string{}, map[string]string{Label: "non-existing-operator"})
+
+	// test
+	dep = Sidecar(jaeger, dep)
+
+	// verify
+	assert.Len(t, dep.Spec.Template.Spec.Containers, 1)
+	assert.NotContains(t, dep.Spec.Template.Spec.Containers[0].Image, "jaeger-agent")
+}
+
+func TestSidecarNeeded(t *testing.T) {
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "some-jaeger-instance"})
+
+	depWithAgent := dep(map[string]string{
+		Annotation: "some-jaeger-instance",
+	}, map[string]string{})
+
+	depWithAgent = Sidecar(jaeger, depWithAgent)
+
+	explicitInjected := dep(map[string]string{}, map[string]string{})
+	explicitInjected.Spec.Template.Spec.Containers = append(explicitInjected.Spec.Template.Spec.Containers, corev1.Container{
+		Name: "jaeger-agent",
+	})
+
+	tests := []struct {
+		dep    *appsv1.Deployment
+		ns     *corev1.Namespace
+		needed bool
+	}{
+		{
+			dep:    &appsv1.Deployment{},
+			ns:     &corev1.Namespace{},
+			needed: false,
+		},
+		{
+			dep:    dep(map[string]string{Annotation: "some-jaeger-instance"}, map[string]string{}),
+			ns:     ns(map[string]string{}),
+			needed: true,
+		},
+		{
+			dep:    dep(map[string]string{Annotation: "some-jaeger-instance"}, map[string]string{}),
+			ns:     ns(map[string]string{Annotation: "some-jaeger-instance"}),
+			needed: true,
+		},
+		{
+			dep:    dep(map[string]string{}, map[string]string{}),
+			ns:     ns(map[string]string{Annotation: "some-jaeger-instance"}),
+			needed: true,
+		},
+		{
+			dep:    depWithAgent,
+			ns:     ns(map[string]string{}),
+			needed: true,
+		},
+		{
+			dep:    dep(map[string]string{}, map[string]string{"app": "jaeger"}),
+			ns:     ns(map[string]string{Annotation: "true"}),
+			needed: false,
+		},
+		{
+			dep:    explicitInjected,
+			ns:     ns(map[string]string{}),
+			needed: false,
+		},
+		{
+			dep:    explicitInjected,
+			ns:     ns(map[string]string{Annotation: "true"}),
+			needed: false,
+		},
+		{
+			dep:    dep(map[string]string{Annotation: "false"}, map[string]string{}),
+			ns:     ns(map[string]string{}),
+			needed: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("dep:%s, ns: %s", test.dep.Annotations, test.ns.Annotations), func(t *testing.T) {
+			assert.Equal(t, test.needed, Needed(test.dep, test.ns))
+			assert.LessOrEqual(t, len(test.dep.Spec.Template.Spec.Containers), 2)
+		})
+	}
+}
+
+func TestSelect(t *testing.T) {
+	jTest := v1.NewJaeger(types.NamespacedName{Name: "test"})
+	jProd := v1.NewJaeger(types.NamespacedName{Name: "prod"})
+
+	depNsProd := dep(map[string]string{Annotation: "true"}, map[string]string{})
+	depNsProd.Namespace = "nsprod"
+
+	jTestNsTest := v1.NewJaeger(types.NamespacedName{Name: "test", Namespace: "nstest"})
+	jProdNsProd := v1.NewJaeger(types.NamespacedName{Name: "prod", Namespace: "nsprod"})
+
+	tests := []struct {
+		dep      *appsv1.Deployment
+		ns       *corev1.Namespace
+		jaegers  *v1.JaegerList
+		expected *v1.Jaeger
+		cap      string
+	}{
+		{
+			dep:      dep(map[string]string{Annotation: "prod"}, map[string]string{}),
+			ns:       ns(map[string]string{}),
+			jaegers:  &v1.JaegerList{Items: []v1.Jaeger{*jProd}},
+			expected: jProd,
+			cap:      "dep explicit, ns empty",
+		},
+		{
+			dep:      dep(map[string]string{Annotation: "prod"}, map[string]string{}),
+			ns:       ns(map[string]string{Annotation: "true"}),
+			jaegers:  &v1.JaegerList{Items: []v1.Jaeger{*jProd}},
+			expected: jProd,
+			cap:      "dep explicit, ns true",
+		},
+		{
+			dep:      dep(map[string]string{Annotation: "prod"}, map[string]string{}),
+			ns:       ns(map[string]string{Annotation: "test"}),
+			jaegers:  &v1.JaegerList{Items: []v1.Jaeger{*jProd, *jTest}},
+			expected: jProd,
+			cap:      "dep explicit, ns explicit",
+		},
+		{
+			dep:      dep(map[string]string{Annotation: "doesNotExist"}, map[string]string{}),
+			ns:       ns(map[string]string{Annotation: "test"}),
+			jaegers:  &v1.JaegerList{Items: []v1.Jaeger{*jProd, *jTest}},
+			expected: nil,
+			cap:      "dep explicit does not exist, ns explicit",
+		},
+		{
+			dep:      dep(map[string]string{Annotation: "true"}, map[string]string{}),
+			ns:       ns(map[string]string{Annotation: "true"}),
+			jaegers:  &v1.JaegerList{Items: []v1.Jaeger{*jProd}},
+			expected: jProd,
+			cap:      "dep true, ns true",
+		},
+		{
+			dep:      dep(map[string]string{Annotation: "true"}, map[string]string{}),
+			ns:       ns(map[string]string{Annotation: "true"}),
+			jaegers:  &v1.JaegerList{Items: []v1.Jaeger{*jTest, *jProd}},
+			expected: nil,
+			cap:      "dep true, ns true, ambiguous",
+		},
+		{
+			dep:      dep(map[string]string{Annotation: "true"}, map[string]string{}),
+			ns:       ns(map[string]string{Annotation: "prod"}),
+			jaegers:  &v1.JaegerList{Items: []v1.Jaeger{*jTest, *jProd}},
+			expected: jProd,
+			cap:      "dep true, ns explicit",
+		},
+		{
+			dep:      dep(map[string]string{Annotation: "true"}, map[string]string{}),
+			ns:       ns(map[string]string{}),
+			jaegers:  &v1.JaegerList{Items: []v1.Jaeger{*jTest}},
+			expected: jTest,
+			cap:      "dep true, ns missing",
+		},
+		{
+			dep:      dep(map[string]string{}, map[string]string{}),
+			ns:       ns(map[string]string{Annotation: "prod"}),
+			jaegers:  &v1.JaegerList{Items: []v1.Jaeger{*jTest, *jProd}},
+			expected: jProd,
+			cap:      "dep none, ns explicit",
+		},
+		{
+			dep:      dep(map[string]string{}, map[string]string{}),
+			ns:       ns(map[string]string{Annotation: "true"}),
+			jaegers:  &v1.JaegerList{Items: []v1.Jaeger{*jProd}},
+			expected: jProd,
+			cap:      "dep none, ns true",
+		},
+		{
+			dep:      dep(map[string]string{}, map[string]string{}),
+			ns:       ns(map[string]string{Annotation: "true"}),
+			jaegers:  &v1.JaegerList{Items: []v1.Jaeger{}},
+			expected: nil,
+			cap:      "dep none, ns true, no jaegers",
+		},
+		{
+			dep:      depNsProd,
+			ns:       ns(map[string]string{}),
+			jaegers:  &v1.JaegerList{Items: []v1.Jaeger{*jTestNsTest, *jProdNsProd}},
+			expected: jProdNsProd,
+			cap:      "dep true, two jaeger instances one in the same ns",
+		},
+		{
+			dep:      depNsProd,
+			ns:       ns(map[string]string{Annotation: "true"}),
+			jaegers:  &v1.JaegerList{Items: []v1.Jaeger{*jTestNsTest, *jProdNsProd}},
+			expected: jProdNsProd,
+			cap:      "dep none, ns true, two jaeger instances one in the same ns",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.cap, func(t *testing.T) {
+			jaeger := Select(test.dep, test.ns, test.jaegers)
+			assert.Equal(t, test.expected, jaeger)
+		})
+	}
+}
+
+func TestSelectBasedOnName(t *testing.T) {
+	dep := dep(map[string]string{Annotation: "the-second-jaeger-instance-available"}, map[string]string{})
+
+	jaegerPods := &v1.JaegerList{
+		Items: []v1.Jaeger{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "the-first-jaeger-instance-available",
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "the-second-jaeger-instance-available",
+				},
+			},
+		},
+	}
+
+	jaeger := Select(dep, &corev1.Namespace{}, jaegerPods)
+	assert.NotNil(t, jaeger)
+	assert.Equal(t, "the-second-jaeger-instance-available", jaeger.Name)
+	assert.Equal(t, "the-second-jaeger-instance-available", dep.Annotations[Annotation])
+}
+
+func TestSidecarOrderOfArguments(t *testing.T) {
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
+	jaeger.Spec.Agent.Options = v1.NewOptions(map[string]interface{}{
+		"b-option": "b-value",
+		"a-option": "a-value",
+		"c-option": "c-value",
+	})
+
+	dep := dep(map[string]string{}, map[string]string{})
+	dep = Sidecar(jaeger, dep)
+
+	assert.Len(t, dep.Spec.Template.Spec.Containers, 2)
+	assert.Len(t, dep.Spec.Template.Spec.Containers[1].Args, 5)
+	containsOptionWithPrefix(t, dep.Spec.Template.Spec.Containers[1].Args, "--a-option")
+	containsOptionWithPrefix(t, dep.Spec.Template.Spec.Containers[1].Args, "--b-option")
+	containsOptionWithPrefix(t, dep.Spec.Template.Spec.Containers[1].Args, "--c-option")
+	containsOptionWithPrefix(t, dep.Spec.Template.Spec.Containers[1].Args, "--agent.tags")
+	containsOptionWithPrefix(t, dep.Spec.Template.Spec.Containers[1].Args, "--reporter.grpc.host-port")
+	agentTagsMap := parseAgentTags(dep.Spec.Template.Spec.Containers[1].Args)
+	assert.Equal(t, "only_container", agentTagsMap["container.name"])
+}
+
+func TestSidecarExplicitTags(t *testing.T) {
+	// prepare
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
+	jaeger.Spec.Agent.Options = v1.NewOptions(map[string]interface{}{"agent.tags": "key=val"})
+	dep := dep(map[string]string{}, map[string]string{})
+
+	// test
+	dep = Sidecar(jaeger, dep)
+
+	// verify
+	assert.Len(t, dep.Spec.Template.Spec.Containers, 2)
+	agentTags := parseAgentTags(dep.Spec.Template.Spec.Containers[1].Args)
+	assert.Equal(t, map[string]string{"key": "val"}, agentTags)
+}
+
+func TestSidecarCustomReporterPort(t *testing.T) {
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
+	jaeger.Spec.Agent.Options = v1.NewOptions(map[string]interface{}{
+		"reporter.grpc.host-port": "collector:5000",
+	})
+
+	dep := dep(map[string]string{}, map[string]string{})
+	dep = Sidecar(jaeger, dep)
+
+	assert.Len(t, dep.Spec.Template.Spec.Containers, 2)
+	assert.Len(t, dep.Spec.Template.Spec.Containers[1].Args, 2)
+	assert.Contains(t, dep.Spec.Template.Spec.Containers[1].Args, "--reporter.grpc.host-port=collector:5000")
+}
+
+func TestSidecarAgentResources(t *testing.T) {
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
+	jaeger.Spec.Resources = corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceLimitsCPU:              *resource.NewQuantity(1024, resource.BinarySI),
+			corev1.ResourceLimitsEphemeralStorage: *resource.NewQuantity(512, resource.DecimalSI),
+		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceRequestsCPU:              *resource.NewQuantity(1024, resource.BinarySI),
+			corev1.ResourceRequestsEphemeralStorage: *resource.NewQuantity(512, resource.DecimalSI),
+		},
+	}
+	jaeger.Spec.Agent.Resources = corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceLimitsCPU:    *resource.NewQuantity(2048, resource.BinarySI),
+			corev1.ResourceLimitsMemory: *resource.NewQuantity(123, resource.DecimalSI),
+		},
+		Requests: corev1.ResourceList{
+			corev1.ResourceRequestsCPU:    *resource.NewQuantity(2048, resource.BinarySI),
+			corev1.ResourceRequestsMemory: *resource.NewQuantity(123, resource.DecimalSI),
+		},
+	}
+
+	dep := dep(map[string]string{}, map[string]string{})
+	dep = Sidecar(jaeger, dep)
+
+	assert.Len(t, dep.Spec.Template.Spec.Containers, 2, "Expected 2 containers")
+	assert.Equal(t, "jaeger-agent", dep.Spec.Template.Spec.Containers[1].Name)
+	assert.Equal(t, *resource.NewQuantity(2048, resource.BinarySI), dep.Spec.Template.Spec.Containers[1].Resources.Limits[corev1.ResourceLimitsCPU])
+	assert.Equal(t, *resource.NewQuantity(2048, resource.BinarySI), dep.Spec.Template.Spec.Containers[1].Resources.Requests[corev1.ResourceRequestsCPU])
+	assert.Equal(t, *resource.NewQuantity(123, resource.DecimalSI), dep.Spec.Template.Spec.Containers[1].Resources.Limits[corev1.ResourceLimitsMemory])
+	assert.Equal(t, *resource.NewQuantity(123, resource.DecimalSI), dep.Spec.Template.Spec.Containers[1].Resources.Requests[corev1.ResourceRequestsMemory])
+	assert.Equal(t, *resource.NewQuantity(512, resource.DecimalSI), dep.Spec.Template.Spec.Containers[1].Resources.Limits[corev1.ResourceLimitsEphemeralStorage])
+	assert.Equal(t, *resource.NewQuantity(512, resource.DecimalSI), dep.Spec.Template.Spec.Containers[1].Resources.Requests[corev1.ResourceRequestsEphemeralStorage])
+}
+
+func TestCleanSidecars(t *testing.T) {
+	instanceName := "my-instance"
+	nsn := types.NamespacedName{
+		Name:      instanceName,
+		Namespace: "Test",
+	}
+	jaeger := v1.NewJaeger(nsn)
+	dep1 := Sidecar(jaeger, dep(map[string]string{}, map[string]string{}))
+	assert.Len(t, dep1.Spec.Template.Spec.Containers, 2)
+	assert.Empty(t, dep1.Spec.Template.Spec.Volumes)
+	CleanSidecar(instanceName, dep1)
+	assert.Len(t, dep1.Spec.Template.Spec.Containers, 1)
+	assert.Empty(t, dep1.Spec.Template.Spec.Volumes)
+}
+
+func TestCleanSidecarsOpenShift(t *testing.T) {
+	// prepare
+	autodetect.OperatorConfiguration.SetPlatform(autodetect.OpenShiftPlatform)
+	defer viper.Reset()
+
+	instanceName := "my-instance"
+	nsn := types.NamespacedName{
+		Name:      instanceName,
+		Namespace: "Test",
+	}
+	jaeger := v1.NewJaeger(nsn)
+	dep1 := Sidecar(jaeger, dep(map[string]string{}, map[string]string{}))
+
+	// sanity check
+	require.Len(t, dep1.Spec.Template.Spec.Containers, 2)
+	require.Len(t, dep1.Spec.Template.Spec.Volumes, 2)
+
+	// test
+	CleanSidecar(instanceName, dep1)
+
+	// verify
+	assert.Len(t, dep1.Spec.Template.Spec.Containers, 1)
+	assert.Empty(t, dep1.Spec.Template.Spec.Volumes)
+}
+
+func TestSidecarWithLabel(t *testing.T) {
+	nsn := types.NamespacedName{
+		Name:      "my-instance",
+		Namespace: "Test",
+	}
+	jaeger := v1.NewJaeger(nsn)
+	dep1 := dep(map[string]string{}, map[string]string{})
+	dep1 = Sidecar(jaeger, dep1)
+	assert.Equal(t, "my-instance", dep1.Labels[Label])
+	dep2 := dep(map[string]string{}, map[string]string{})
+	dep2.Labels = map[string]string{"anotherLabel": "anotherValue"}
+	dep2 = Sidecar(jaeger, dep2)
+	assert.Len(t, dep2.Labels, 2)
+	assert.Equal(t, "anotherValue", dep2.Labels["anotherLabel"])
+	assert.Equal(t, dep2.Labels[Label], jaeger.Name)
+}
+
+func TestSidecarWithoutPrometheusAnnotations(t *testing.T) {
+	// prepare
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
+	dep := Sidecar(jaeger, dep(map[string]string{}, map[string]string{}))
+
+	// test
+	dep = Sidecar(jaeger, dep)
+
+	// verify
+	assert.Contains(t, dep.Annotations, "prometheus.io/scrape")
+	assert.Contains(t, dep.Annotations, "prometheus.io/port")
+}
+
+func TestSidecarWithPrometheusAnnotations(t *testing.T) {
+	// prepare
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
+	dep := dep(map[string]string{
+		"prometheus.io/scrape": "false",
+		"prometheus.io/port":   "9090",
+	}, map[string]string{})
+
+	// test
+	dep = Sidecar(jaeger, dep)
+
+	// verify
+	assert.Equal(t, "false", dep.Annotations["prometheus.io/scrape"])
+	assert.Equal(t, "9090", dep.Annotations["prometheus.io/port"])
+}
+
+func TestSidecarAgentTagsWithMultipleContainers(t *testing.T) {
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
+	dep := Sidecar(jaeger, depWithTwoContainers(map[string]string{}, map[string]string{}))
+
+	assert.Equal(t, dep.Labels[Label], jaeger.Name)
+	assert.Len(t, dep.Spec.Template.Spec.Containers, 3, "Expected 3 containers")
+	assert.Equal(t, "jaeger-agent", dep.Spec.Template.Spec.Containers[2].Name)
+	containsOptionWithPrefix(t, dep.Spec.Template.Spec.Containers[2].Args, "--agent.tags")
+	agentTagsMap := parseAgentTags(dep.Spec.Template.Spec.Containers[2].Args)
+	assert.NotContains(t, agentTagsMap, "container.name")
+}
+
+func TestSidecarAgentContainerNameTagWithDoubleInjectedContainer(t *testing.T) {
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
+	dep := Sidecar(jaeger, dep(map[string]string{}, map[string]string{}))
+
+	// inject - 1st time
+	assert.Equal(t, dep.Labels[Label], jaeger.Name)
+	assert.Len(t, dep.Spec.Template.Spec.Containers, 2, "Expected 2 containers")
+	assert.Equal(t, "jaeger-agent", dep.Spec.Template.Spec.Containers[1].Name)
+	containsOptionWithPrefix(t, dep.Spec.Template.Spec.Containers[1].Args, "--agent.tags")
+	agentTagsMap := parseAgentTags(dep.Spec.Template.Spec.Containers[1].Args)
+	assert.Equal(t, "only_container", agentTagsMap["container.name"])
+
+	// inject - 2nd time due to deployment/namespace reconciliation
+	dep = Sidecar(jaeger, dep)
+	assert.Len(t, dep.Spec.Template.Spec.Containers, 2, "Expected 2 containers")
+	assert.Equal(t, "jaeger-agent", dep.Spec.Template.Spec.Containers[1].Name)
+	containsOptionWithPrefix(t, dep.Spec.Template.Spec.Containers[1].Args, "--agent.tags")
+	agentTagsMap = parseAgentTags(dep.Spec.Template.Spec.Containers[1].Args)
+	assert.Equal(t, "only_container", agentTagsMap["container.name"])
+}
+
+func ns(annotations map[string]string) *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: annotations,
+		},
+		Spec: corev1.NamespaceSpec{},
+	}
+}
+
+func dep(annotations map[string]string, labels map[string]string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: annotations,
+			Labels:      labels,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labels,
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "only_container",
+					}},
+				},
+			},
+		},
+	}
+}
+
+func depEnvFrom(annotations map[string]string, labels map[string]string, envFrom []corev1.EnvFromSource) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: annotations,
+			Labels:      labels,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labels,
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:    "only_container",
+						EnvFrom: envFrom,
+					}},
+				},
+			},
+		},
+	}
+}
+
+func depWithTwoContainers(annotations map[string]string, labels map[string]string) *appsv1.Deployment {
+	dep := dep(annotations, labels)
+	dep.Spec.Template.Spec.Containers[0].Name = "container_0"
+	dep.Spec.Template.Spec.Containers = append(dep.Spec.Template.Spec.Containers, corev1.Container{
+		Name: "container_1",
+	})
+	return dep
+}
+
+func containsEnvVarNamed(t *testing.T, envVars []corev1.EnvVar, key string) bool {
+	for _, envVar := range envVars {
+		if envVar.Name == key {
+			return true
+		}
+	}
+	assert.Fail(t, "element with key '%s' not found", key)
+	return false
+}
+
+func containsOptionWithPrefix(t *testing.T, args []string, prefix string) bool {
+	for _, arg := range args {
+		if strings.HasPrefix(arg, prefix) {
+			return true
+		}
+	}
+	assert.Fail(t, "list of arguments didn't have an option starting with '%s'", prefix)
+	return false
+}
+
+func TestSidecarArgumentsOpenshiftTLS(t *testing.T) {
+	autodetect.OperatorConfiguration.SetPlatform(autodetect.OpenShiftPlatform)
+	defer viper.Reset()
+
+	for _, tt := range []struct {
+		name            string
+		options         v1.Options
+		expectedArgs    []string
+		nonExpectedArgs []string
+	}{
+		{
+			name: "Openshift CA",
+			options: v1.NewOptions(map[string]interface{}{
+				"a-option": "a-value",
+			}),
+			expectedArgs: []string{
+				"--a-option=a-value",
+				"--reporter.grpc.tls.enabled=true",
+				"--reporter.grpc.tls.ca=" + ca.ServiceCAPath,
+				"--reporter.grpc.host-port=dns:///my-instance-collector-headless.test.svc:14250",
+				"--agent.tags=",
+			},
+		},
+		{
+			name: "Custom CA",
+			options: v1.NewOptions(map[string]interface{}{
+				"a-option":                  "a-value",
+				"reporter.grpc.tls.enabled": "true",
+				"reporter.grpc.tls.ca":      "/my/custom/ca",
+			}),
+			expectedArgs: []string{
+				"--a-option=a-value",
+				"--reporter.grpc.host-port=dns:///my-instance-collector-headless.test.svc:14250",
+				"--reporter.grpc.tls.enabled=true",
+				"--reporter.grpc.tls.ca=/my/custom/ca",
+				"--agent.tags=",
+			},
+		},
+		{
+			name: "Explicit disable TLS",
+			options: v1.NewOptions(map[string]interface{}{
+				"a-option":                  "a-value",
+				"reporter.grpc.tls.enabled": "false",
+			}),
+			expectedArgs: []string{
+				"--a-option=a-value",
+				"--reporter.grpc.host-port=dns:///my-instance-collector-headless.test.svc:14250",
+				"--reporter.grpc.tls.enabled=false",
+				"--agent.tags=",
+			},
+			nonExpectedArgs: []string{
+				"--reporter.grpc.tls.enabled=true",
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			jaeger := v1.NewJaeger(types.NamespacedName{
+				Name:      "my-instance",
+				Namespace: "test",
+			})
+			jaeger.Spec.Agent.Options = tt.options
+			dep := dep(map[string]string{Annotation: jaeger.Name}, map[string]string{})
+			dep = Sidecar(jaeger, dep)
+
+			assert.Len(t, dep.Spec.Template.Spec.Containers, 2)
+			assert.Len(t, dep.Spec.Template.Spec.Containers[1].Args, len(tt.expectedArgs))
+
+			for _, arg := range tt.expectedArgs {
+				assert.NotEmpty(t, util.FindItem(arg, dep.Spec.Template.Spec.Containers[1].Args))
+			}
+
+			if tt.nonExpectedArgs != nil {
+				for _, arg := range tt.nonExpectedArgs {
+					assert.Empty(t, util.FindItem(arg, dep.Spec.Template.Spec.Containers[1].Args))
+				}
+			}
+
+			assert.Len(t, dep.Spec.Template.Spec.Volumes, 2)
+			assert.Len(t, dep.Spec.Template.Spec.Containers[1].VolumeMounts, 2)
+		})
+	}
+}
+
+func TestEqualSidecar(t *testing.T) {
+	jaeger := v1.NewJaeger(types.NamespacedName{
+		Name:      "my-instance",
+		Namespace: "test",
+	})
+
+	dep1 := dep(map[string]string{Annotation: jaeger.Name}, map[string]string{})
+	dep1 = Sidecar(jaeger, dep1)
+
+	dep1Equal := dep(map[string]string{Annotation: jaeger.Name}, map[string]string{})
+	dep1Equal = Sidecar(jaeger, dep1Equal)
+	assert.True(t, EqualSidecar(dep1, dep1Equal))
+
+	// Change flags.
+	jaeger.Spec.Agent.Options = v1.NewOptions(map[string]interface{}{
+		"--agent.tags": "changed-tag=newvalue",
+	})
+
+	dep2 := dep(map[string]string{Annotation: jaeger.Name}, map[string]string{})
+	dep2 = Sidecar(jaeger, dep2)
+	assert.False(t, EqualSidecar(dep1, dep2))
+
+	// When no agent is present on the deploy
+	dep3 := dep(map[string]string{Annotation: jaeger.Name}, map[string]string{})
+	assert.False(t, EqualSidecar(dep1, dep3))
+}
+
+func TestInjectSidecarOnOpenShift(t *testing.T) {
+	autodetect.OperatorConfiguration.SetPlatform(autodetect.OpenShiftPlatform)
+	defer viper.Reset()
+
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "my-instance"})
+	dep := dep(map[string]string{}, map[string]string{})
+	dep = Sidecar(jaeger, dep)
+	assert.Equal(t, dep.Labels[Label], jaeger.Name)
+	assert.Len(t, dep.Spec.Template.Spec.Containers, 2)
+	assert.Len(t, dep.Spec.Template.Spec.Containers[1].VolumeMounts, 2)
+	assert.Len(t, dep.Spec.Template.Spec.Volumes, 2)
+}
+
+func TestSidecarWithSecurityContext(t *testing.T) {
+	var user, group int64 = 111, 222
+	expectedSecurityContext := &corev1.SecurityContext{RunAsUser: &user, RunAsGroup: &group}
+
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestSidecarWithSecurityContext"})
+	jaeger.Spec.Agent.SidecarSecurityContext = expectedSecurityContext
+
+	dep := dep(map[string]string{}, map[string]string{})
+	dep = Sidecar(jaeger, dep)
+	assert.Len(t, dep.Spec.Template.Spec.Containers, 2)
+	assert.Equal(t, expectedSecurityContext, dep.Spec.Template.Spec.Containers[1].SecurityContext)
+}
+
+func TestSortedTags(t *testing.T) {
+	defaultAgentTagsMap := make(map[string]string)
+	defaultAgentTagsMap["cluster"] = "undefined" // this value isn't currently available
+	defaultAgentTagsMap["deployment.name"] = "deploy"
+	defaultAgentTagsMap["pod.namespace"] = "ns"
+	defaultAgentTagsMap["pod.name"] = "pod_name"
+	defaultAgentTagsMap["host.ip"] = "0.0.0.0"
+	assert.Equal(t, joinTags(defaultAgentTagsMap), fmt.Sprintf("%s=%s,%s=%s,%s=%s,%s=%s,%s=%s",
+		"cluster", "undefined", // this value isn't currently available
+		"deployment.name", "deploy",
+		"host.ip", "0.0.0.0",
+		"pod.name", "pod_name",
+		"pod.namespace", "ns",
+	))
+}
+
+func TestSortedTagsWithContainer(t *testing.T) {
+	defaultAgentTagsMap := make(map[string]string)
+	defaultAgentTagsMap["cluster"] = "undefined" // this value isn't currently available
+	defaultAgentTagsMap["deployment.name"] = "deploy"
+	defaultAgentTagsMap["pod.namespace"] = "ns"
+	defaultAgentTagsMap["pod.name"] = "pod_name"
+	defaultAgentTagsMap["host.ip"] = "0.0.0.0"
+	defaultAgentTagsMap["container.name"] = "only_container"
+	assert.Equal(t, joinTags(defaultAgentTagsMap), fmt.Sprintf("%s=%s,%s=%s,%s=%s,%s=%s,%s=%s,%s=%s",
+		"cluster", "undefined", // this value isn't currently available
+		"container.name", "only_container",
+		"deployment.name", "deploy",
+		"host.ip", "0.0.0.0",
+		"pod.name", "pod_name",
+		"pod.namespace", "ns",
+	))
+}
+
+func TestParseEmptyAgentTags(t *testing.T) {
+	tags := parseAgentTags([]string{})
+	assert.Equal(t, map[string]string{}, tags)
+}
+
+func TestGetContainerNameWithOneAppContainer(t *testing.T) {
+	deploy := dep(map[string]string{}, map[string]string{})
+	containerName := getContainerName(deploy.Spec.Template.Spec.Containers, -1)
+	assert.Equal(t, "only_container", containerName)
+}
+
+func TestGetContainerNameWithTwoAppContainers(t *testing.T) {
+	deploy := depWithTwoContainers(map[string]string{}, map[string]string{})
+	containerName := getContainerName(deploy.Spec.Template.Spec.Containers, -1)
+	assert.Equal(t, "", containerName)
+}
+
+func TestGetContainerNameWithAppContainerAndJaegerAgent(t *testing.T) {
+	nsn := types.NamespacedName{
+		Name:      "my-instance",
+		Namespace: "Test",
+	}
+	jaeger := v1.NewJaeger(nsn)
+	deploy := dep(map[string]string{}, map[string]string{})
+	deploy = Sidecar(jaeger, deploy)
+
+	assert.Len(t, deploy.Spec.Template.Spec.Containers, 2)
+	hasAgent, agentIdx := HasJaegerAgent(deploy)
+	assert.True(t, hasAgent)
+	assert.Greater(t, agentIdx, -1)
+	containerName := getContainerName(deploy.Spec.Template.Spec.Containers, agentIdx)
+	assert.Equal(t, "only_container", containerName)
+}
+
+func TestGetConfigMapsMatchedEnvFromInDeploymentWithEnvFromSecretRef(t *testing.T) {
+	deploy := depEnvFrom(map[string]string{}, map[string]string{},
+		[]corev1.EnvFromSource{{SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "test-secret"}}}})
+	configMaps := []corev1.ConfigMap{}
+
+	matchedConfigMaps := GetConfigMapsMatchedEnvFromInDeployment(*deploy, configMaps)
+
+	assert.Empty(t, matchedConfigMaps)
+}
+
+func TestGetConfigMapsMatchedEnvFromInDeploymentWithEnvFromConfigMapRef(t *testing.T) {
+	deploy := depEnvFrom(map[string]string{}, map[string]string{},
+		[]corev1.EnvFromSource{{ConfigMapRef: &corev1.ConfigMapEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "test-config"}}}})
+	configMaps := []corev1.ConfigMap{{ObjectMeta: metav1.ObjectMeta{Name: "test-config"}}}
+
+	matchedConfigMaps := GetConfigMapsMatchedEnvFromInDeployment(*deploy, configMaps)
+
+	assert.Len(t, matchedConfigMaps, 1)
+	assert.Equal(t, "test-config", matchedConfigMaps[0].Name)
+}
+
+func TestGetConfigMapsMatchedEnvFromInDeploymentWithEnvFromConfigAndSecret(t *testing.T) {
+	deploy := depEnvFrom(map[string]string{}, map[string]string{},
+		[]corev1.EnvFromSource{
+			{ConfigMapRef: &corev1.ConfigMapEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "test-config"}}},
+			{SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "test-secret"}}},
+		},
+	)
+	configMaps := []corev1.ConfigMap{{ObjectMeta: metav1.ObjectMeta{Name: "test-config"}}}
+
+	matchedConfigMaps := GetConfigMapsMatchedEnvFromInDeployment(*deploy, configMaps)
+
+	assert.Len(t, matchedConfigMaps, 1)
+	assert.Equal(t, "test-config", matchedConfigMaps[0].Name)
+}
+
+func TestGetJaeger(t *testing.T) {
+	jaegers := v1.JaegerList{
+		Items: []v1.Jaeger{
+			*v1.NewJaeger(types.NamespacedName{
+				Namespace: "project1",
+				Name:      "jaeger",
+			}),
+			*v1.NewJaeger(types.NamespacedName{
+				Namespace: "project1",
+				Name:      "jaeger2",
+			}),
+			*v1.NewJaeger(types.NamespacedName{
+				Namespace: "project2",
+				Name:      "jaeger",
+			}),
+		},
+	}
+
+	tests := []struct {
+		testName     string
+		deploymentNs string
+		jaegerName   string
+		jaeger       *v1.Jaeger
+	}{
+		{
+			testName:     "deployment matches jaeger namespace",
+			deploymentNs: "project1",
+			jaegerName:   "jaeger",
+			jaeger: v1.NewJaeger(types.NamespacedName{
+				Namespace: "project1",
+				Name:      "jaeger",
+			}),
+		},
+		{
+			testName:     "deployment in other namespace",
+			deploymentNs: "app",
+			jaegerName:   "jaeger",
+			jaeger: v1.NewJaeger(types.NamespacedName{
+				Namespace: "project1",
+				Name:      "jaeger",
+			}),
+		},
+		{
+			testName:     "jaeger name does not match",
+			deploymentNs: "app",
+			jaegerName:   "does-not-exist",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			selectedJaeger := getJaeger(tt.deploymentNs, tt.jaegerName, &jaegers)
+			assert.Equal(t, tt.jaeger, selectedJaeger)
+		})
+	}
+}

--- a/pkg/strategy/all_in_one.go
+++ b/pkg/strategy/all_in_one.go
@@ -63,6 +63,11 @@ func newAllInOneStrategy(ctx context.Context, jaeger *v1.Jaeger) S {
 	// add the deployments
 	c.deployments = []appsv1.Deployment{*inject.OAuthProxy(jaeger, dep.Get())}
 
+	// add the daemonsets
+	if ds := deployment.NewAgent(jaeger).Get(); ds != nil {
+		c.daemonSets = []appsv1.DaemonSet{*ds}
+	}
+
 	// add the services
 	for _, svc := range dep.Services() {
 		c.services = append(c.services, *svc)

--- a/pkg/strategy/all_in_one_test.go
+++ b/pkg/strategy/all_in_one_test.go
@@ -18,6 +18,10 @@ import (
 	"github.com/jaegertracing/jaeger-operator/pkg/util"
 )
 
+func init() {
+	viper.SetDefault("jaeger-agent-image", "jaegertracing/jaeger-agent")
+}
+
 func TestCreateAllInOneDeployment(t *testing.T) {
 	name := "TestCreateAllInOneDeployment"
 	jaeger := v1.NewJaeger(types.NamespacedName{Name: name})
@@ -37,14 +41,14 @@ func TestCreateAllInOneDeploymentOnOpenShift(t *testing.T) {
 	assertDeploymentsAndServicesForAllInOne(t, jaeger, c, false, true, false)
 }
 
-func TestCreateAllInOneDeploymentWithNoDaemonSetAgent(t *testing.T) {
+func TestCreateAllInOneDeploymentWithDaemonSetAgent(t *testing.T) {
 	name := "TestCreateAllInOneDeploymentWithDaemonSetAgent"
 
 	j := v1.NewJaeger(types.NamespacedName{Name: name})
 	j.Spec.Agent.Strategy = "DaemonSet"
 
 	c := newAllInOneStrategy(context.Background(), j)
-	assertDeploymentsAndServicesForAllInOne(t, j, c, false, false, false)
+	assertDeploymentsAndServicesForAllInOne(t, j, c, true, false, false)
 }
 
 func TestCreateAllInOneDeploymentWithUIConfigMap(t *testing.T) {

--- a/pkg/strategy/production.go
+++ b/pkg/strategy/production.go
@@ -37,6 +37,7 @@ func newProductionStrategy(ctx context.Context, jaeger *v1.Jaeger) S {
 	c := S{typ: v1.DeploymentStrategyProduction}
 	collector := deployment.NewCollector(jaeger)
 	query := deployment.NewQuery(jaeger)
+	agent := deployment.NewAgent(jaeger)
 
 	// add all service accounts
 	for _, acc := range account.Get(jaeger) {
@@ -64,6 +65,11 @@ func newProductionStrategy(ctx context.Context, jaeger *v1.Jaeger) S {
 	// add the service CA config map
 	if cm := ca.GetServiceCABundle(jaeger); cm != nil {
 		c.configMaps = append(c.configMaps, *cm)
+	}
+
+	// add the daemonsets
+	if ds := agent.Get(); ds != nil {
+		c.daemonSets = []appsv1.DaemonSet{*ds}
 	}
 
 	// add the services

--- a/pkg/strategy/production_test.go
+++ b/pkg/strategy/production_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func init() {
+	viper.SetDefault("jaeger-agent-image", "jaegertracing/jaeger-agent")
 	viper.SetDefault(v1.FlagCronJobsVersion, v1.FlagCronJobsVersionBatchV1)
 }
 
@@ -45,14 +46,14 @@ func TestCreateProductionDeploymentOnOpenShift(t *testing.T) {
 	assertDeploymentsAndServicesForProduction(t, jaeger, c, false, true, false)
 }
 
-func TestCreateProductionDeploymentWithNoDaemonSetAgent(t *testing.T) {
+func TestCreateProductionDeploymentWithDaemonSetAgent(t *testing.T) {
 	name := "TestCreateProductionDeploymentWithDaemonSetAgent"
 
 	j := v1.NewJaeger(types.NamespacedName{Name: name})
 	j.Spec.Agent.Strategy = "DaemonSet"
 
 	c := newProductionStrategy(context.Background(), j)
-	assertDeploymentsAndServicesForProduction(t, j, c, false, false, false)
+	assertDeploymentsAndServicesForProduction(t, j, c, true, false, false)
 }
 
 func TestCreateProductionDeploymentWithUIConfigMap(t *testing.T) {

--- a/pkg/strategy/streaming_test.go
+++ b/pkg/strategy/streaming_test.go
@@ -21,6 +21,10 @@ import (
 	"github.com/jaegertracing/jaeger-operator/pkg/storage"
 )
 
+func init() {
+	viper.SetDefault("jaeger-agent-image", "jaegertracing/jaeger-agent")
+}
+
 func TestCreateStreamingDeployment(t *testing.T) {
 	name := "my-instance"
 	jaeger := v1.NewJaeger(types.NamespacedName{Name: name})
@@ -73,14 +77,14 @@ func TestCreateStreamingDeploymentOnOpenShift(t *testing.T) {
 	assertDeploymentsAndServicesForStreaming(t, jaeger, c, false, true, false)
 }
 
-func TestCreateStreamingDeploymentWithNoDaemonSetAgent(t *testing.T) {
+func TestCreateStreamingDeploymentWithDaemonSetAgent(t *testing.T) {
 	name := "my-instance"
 
 	j := v1.NewJaeger(types.NamespacedName{Name: name})
 	j.Spec.Agent.Strategy = "DaemonSet"
 
 	c := newStreamingStrategy(context.Background(), j)
-	assertDeploymentsAndServicesForStreaming(t, j, c, false, false, false)
+	assertDeploymentsAndServicesForStreaming(t, j, c, true, false, false)
 }
 
 func TestCreateStreamingDeploymentWithUIConfigMap(t *testing.T) {
@@ -229,7 +233,8 @@ func TestAgentSidecarIsInjectedIntoQueryForStreaming(t *testing.T) {
 	c := newStreamingStrategy(context.Background(), j)
 	for _, dep := range c.Deployments() {
 		if strings.HasSuffix(dep.Name, "-query") {
-			assert.Len(t, dep.Spec.Template.Spec.Containers, 1)
+			assert.Len(t, dep.Spec.Template.Spec.Containers, 2)
+			assert.Equal(t, "jaeger-agent", dep.Spec.Template.Spec.Containers[1].Name)
 		}
 	}
 }

--- a/tests/e2e/examples/examples-agent-as-daemonset/01-add-policy.yaml
+++ b/tests/e2e/examples/examples-agent-as-daemonset/01-add-policy.yaml
@@ -1,0 +1,10 @@
+# Add service account to user
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: "oc adm  policy --namespace $NAMESPACE add-scc-to-user daemonset-with-hostport -z jaeger-agent-daemonset"
+  # Sometimes, the previous command needs some time to take effect. If we create
+  # the Jaeger deployment before the command takes effect, the Jaeger instance
+  # is not deployed. There is not a way to verify it is there except wait some
+  # seconds
+  - script: "sleep 5"

--- a/tests/e2e/examples/examples-agent-as-daemonset/03-assert.yaml
+++ b/tests/e2e/examples/examples-agent-as-daemonset/03-assert.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata: 
+  name: agent-as-daemonset-agent-daemonset
+status:
+  numberReady: 1

--- a/tests/e2e/examples/examples-agent-with-priority-class/01-add-policy.yaml
+++ b/tests/e2e/examples/examples-agent-with-priority-class/01-add-policy.yaml
@@ -1,0 +1,10 @@
+# Add service account to user
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: "oc adm  policy --namespace $NAMESPACE add-scc-to-user daemonset-with-hostport -z jaeger-agent-daemonset"
+  # Sometimes, the previous command needs some time to take effect. If we create
+  # the Jaeger deployment before the command takes effect, the Jaeger instance
+  # is not deployed. There is not a way to verify it is there except wait some
+  # seconds
+  - script: "sleep 5"

--- a/tests/e2e/examples/examples-business-application-injected-sidecar/00-assert.yaml
+++ b/tests/e2e/examples/examples-business-application-injected-sidecar/00-assert.yaml
@@ -1,0 +1,7 @@
+# Assert the bussiness application deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myapp
+spec:
+  replicas: 1

--- a/tests/e2e/examples/render.sh
+++ b/tests/e2e/examples/render.sh
@@ -3,6 +3,19 @@
 source $(dirname "$0")/../render-utils.sh
 
 ###############################################################################
+# TEST NAME: examples-agent-with-priority-class
+###############################################################################
+start_test "examples-agent-with-priority-class"
+example_name="agent-with-priority-class"
+prepare_daemonset "00"
+if [ $IS_OPENSHIFT != true ]; then
+    rm ./01-add-policy.yaml # This is just for OpenShift
+fi
+render_install_example "$example_name" "02"
+render_smoke_test_example "$example_name" "02"
+
+
+###############################################################################
 # TEST NAME: examples-all-in-one-with-options
 ###############################################################################
 start_test "examples-all-in-one-with-options"
@@ -16,6 +29,25 @@ if [ $IS_OPENSHIFT = true ]; then
 else
     sed -i "s~my-jaeger-query:16686~my-jaeger-query:16686/jaeger~gi" ./01-smoke-test.yaml
 fi
+
+
+###############################################################################
+# TEST NAME: examples-business-application-injected-sidecar
+###############################################################################
+start_test "examples-business-application-injected-sidecar"
+example_name="simplest"
+cp $EXAMPLES_DIR/business-application-injected-sidecar.yaml ./00-install.yaml
+$YQ e -i '.spec.template.spec.containers[0].image=strenv(VERTX_IMG)' ./00-install.yaml
+$YQ e -i '.spec.template.spec.containers[0].livenessProbe.httpGet.path="/"' ./00-install.yaml
+$YQ e -i '.spec.template.spec.containers[0].livenessProbe.httpGet.port=8080' ./00-install.yaml
+$YQ e -i '.spec.template.spec.containers[0].livenessProbe.initialDelaySeconds=1' ./00-install.yaml
+$YQ e -i '.spec.template.spec.containers[0].livenessProbe.failureThreshold=3' ./00-install.yaml
+$YQ e -i '.spec.template.spec.containers[0].livenessProbe.periodSeconds=10' ./00-install.yaml
+$YQ e -i '.spec.template.spec.containers[0].livenessProbe.successThreshold=1' ./00-install.yaml
+$YQ e -i '.spec.template.spec.containers[0].livenessProbe.timeoutSeconds=1' ./00-install.yaml
+render_install_example "$example_name" "01"
+render_smoke_test_example "$example_name" "02"
+
 
 ###############################################################################
 # TEST NAME: examples-collector-with-priority-class
@@ -111,6 +143,18 @@ export example_name="with-sampling"
 render_install_cassandra "00"
 render_install_example "$example_name" "01"
 render_smoke_test_example "$example_name" "02"
+
+###############################################################################
+# TEST NAME: examples-agent-as-daemonset
+###############################################################################
+start_test "examples-agent-as-daemonset"
+if [ $IS_OPENSHIFT = true ]; then
+    prepare_daemonset "00"
+    $GOMPLATE -f $EXAMPLES_DIR/openshift/agent-as-daemonset.yaml -o 02-install.yaml
+else
+    rm ./01-add-policy.yaml # This is just for OpenShift
+    render_install_example "agent-as-daemonset" "02"
+fi
 
 
 ###############################################################################

--- a/tests/e2e/miscellaneous/istio/00-assert.yaml
+++ b/tests/e2e/miscellaneous/istio/00-assert.yaml
@@ -1,0 +1,10 @@
+# Assert the Istio is up and running
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: istiod
+  namespace: istio-system
+spec:
+  replicas: 1
+status:
+  readyReplicas: 1

--- a/tests/e2e/miscellaneous/istio/00-install.yaml
+++ b/tests/e2e/miscellaneous/istio/00-install.yaml
@@ -1,0 +1,5 @@
+# Start Istio
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: "cd ../../../../.. && make istio"

--- a/tests/e2e/miscellaneous/istio/01-assert.yaml
+++ b/tests/e2e/miscellaneous/istio/01-assert.yaml
@@ -1,0 +1,6 @@
+# Assert the namespace was labeled properly
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    istio-injection: enabled

--- a/tests/e2e/miscellaneous/istio/01-install.yaml
+++ b/tests/e2e/miscellaneous/istio/01-install.yaml
@@ -1,0 +1,5 @@
+# Label the namespace to enable Istio
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: "kubectl label namespaces $NAMESPACE istio-injection=enabled"

--- a/tests/e2e/miscellaneous/istio/02-assert.yaml
+++ b/tests/e2e/miscellaneous/istio/02-assert.yaml
@@ -1,0 +1,7 @@
+# Assert the Jaeger deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simplest
+spec:
+  replicas: 1

--- a/tests/e2e/miscellaneous/istio/02-install.yaml
+++ b/tests/e2e/miscellaneous/istio/02-install.yaml
@@ -1,0 +1,5 @@
+# Start Jaeger deployment
+apiVersion: jaegertracing.io/v1
+kind: Jaeger
+metadata:
+  name: simplest

--- a/tests/e2e/miscellaneous/istio/03-assert.yaml
+++ b/tests/e2e/miscellaneous/istio/03-assert.yaml
@@ -1,0 +1,79 @@
+# Assert there is a pod with these three container names
+apiVersion: v1
+kind: Pod
+spec:
+  # Note: if the order of the container names is changed, the test will fail
+  containers:
+    - name: myapp
+    - name: jaeger-agent
+    - name: istio-proxy
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: simplest-collector-headless
+spec:
+  ports:
+  - name: http-zipkin
+    port: 9411
+    protocol: TCP
+    targetPort: 9411
+  - name: grpc-jaeger
+    port: 14250
+    protocol: TCP
+    targetPort: 14250
+  - name: http-c-tchan-trft
+    port: 14267
+    protocol: TCP
+    targetPort: 14267
+  - name: http-c-binary-trft
+    port: 14268
+    protocol: TCP
+    targetPort: 14268
+  - name: admin-http
+    port: 14269
+    protocol: TCP
+    targetPort: 14269
+  - name: grpc-otlp
+    port: 4317
+    protocol: TCP
+    targetPort: 4317
+  - name: http-otlp
+    port: 4318
+    protocol: TCP
+    targetPort: 4318
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: simplest-collector
+spec:
+  ports:
+  - name: http-zipkin
+    port: 9411
+    protocol: TCP
+    targetPort: 9411
+  - name: grpc-jaeger
+    port: 14250
+    protocol: TCP
+    targetPort: 14250
+  - name: http-c-tchan-trft
+    port: 14267
+    protocol: TCP
+    targetPort: 14267
+  - name: http-c-binary-trft
+    port: 14268
+    protocol: TCP
+    targetPort: 14268
+  - name: admin-http
+    port: 14269
+    protocol: TCP
+    targetPort: 14269
+  - name: grpc-otlp
+    port: 4317
+    protocol: TCP
+    targetPort: 4317
+  - name: http-otlp
+    port: 4318
+    protocol: TCP
+    targetPort: 4318

--- a/tests/e2e/miscellaneous/istio/README.md
+++ b/tests/e2e/miscellaneous/istio/README.md
@@ -1,0 +1,4 @@
+# Istio
+## What is this test case testing?
+
+Smoke test for integration with [Istio](https://istio.io/).

--- a/tests/e2e/miscellaneous/istio/livelinessprobe.template
+++ b/tests/e2e/miscellaneous/istio/livelinessprobe.template
@@ -1,0 +1,9 @@
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 10
+          failureThreshold: 5
+          periodSeconds: 1
+          successThreshold: 1
+          timeoutSeconds: 10

--- a/tests/e2e/miscellaneous/istio/patch-04-find-service.yaml.template
+++ b/tests/e2e/miscellaneous/istio/patch-04-find-service.yaml.template
@@ -1,0 +1,12 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: 00-find-service
+spec:
+  template:
+    spec:
+      containers:
+        - name: asserts-container
+          image: {{ .Env.ASSERT_IMG }}
+          command: ["/bin/sh","-c"]
+          args: ["./query && curl -sf -XPOST http://localhost:15000/quitquitquit"]

--- a/tests/e2e/miscellaneous/render.sh
+++ b/tests/e2e/miscellaneous/render.sh
@@ -91,6 +91,33 @@ function generate_otlp_e2e_tests() {
 generate_otlp_e2e_tests "http"
 generate_otlp_e2e_tests "grpc"
 
+
+###############################################################################
+# TEST NAME: istio
+###############################################################################
+if [ $IS_OPENSHIFT = true ]; then
+    skip_test "istio" "Test not supported in OpenShift"
+else
+    start_test "istio"
+    export jaeger_name="simplest"
+    cat $EXAMPLES_DIR/business-application-injected-sidecar.yaml ./livelinessprobe.template > ./03-install.yaml
+    render_find_service "$jaeger_name" "allInOne" "order" "00" "04"
+
+    # One of the first steps of this test is enabling the Istio sidecar injection
+    # for the namespace. That means, each pod is started will have an Istio sidecar.
+    # A Job is not considered complete until all containers have stopped running.
+    # Istio Sidecars run indefinitely. So, when a job is started, the sidecar will
+    # stay forever there and the test will be marked as failed. Also, since the
+    # container job starts and finish, the pod status will be `NotReady`.
+    # Stopping Istio from the pod doing a POST HTTP query to
+    # http://localhost:15000/quitquitquit (endpoint available since Istio 1.3),
+    # solves the issue
+    patched_file="./04-find-service.yaml"
+    $YQ e -i '.spec.template.spec.containers[0].command = ["/bin/sh","-c"]' $patched_file
+    $YQ e -i '.spec.template.spec.containers[0].args= ["./query && curl -sf -XPOST http://localhost:15000/quitquitquit"]' $patched_file
+fi
+
+
 ###############################################################################
 # TEST NAME: outside-cluster
 ###############################################################################

--- a/tests/e2e/sidecar/Makefile
+++ b/tests/e2e/sidecar/Makefile
@@ -1,0 +1,5 @@
+render-e2e-tests-sidecar: load-assert-job
+	$(VECHO)./tests/e2e/sidecar/render.sh
+
+run-e2e-tests-sidecar:
+	$(VECHO)KAFKA_OLM=$(KAFKA_OLM) ./hack/run-e2e-test-suite.sh sidecar $(USE_KIND_CLUSTER) $(JAEGER_OLM)

--- a/tests/e2e/sidecar/render.sh
+++ b/tests/e2e/sidecar/render.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+source $(dirname "$0")/../render-utils.sh
+
+# This Jaeger service name is the one used by vertx
+jaeger_service_name="order"
+
+###############################################################################
+# TEST NAME: sidecar-deployment
+###############################################################################
+start_test "sidecar-deployment"
+render_install_vertx "01"
+# Check Jaeger is receiving spans
+render_find_service "agent-as-sidecar" "allInOne" "$jaeger_service_name" "00" "03"
+# After removing the first Jaeger instance, we should be able to continue
+# receiving spans in the second one
+render_find_service "agent-as-sidecar2" "allInOne" "$jaeger_service_name" "01" "06"
+
+
+###############################################################################
+# TEST NAME: sidecar-namespace
+###############################################################################
+start_test "sidecar-namespace"
+render_install_vertx "01"
+# After removing the first Jaeger instance, we should be able to continue
+# receiving spans in the second one
+render_find_service "agent-as-sidecar" "allInOne" "$jaeger_service_name" "00" "03"
+# Check Jaeger is receiving spans
+render_find_service "agent-as-sidecar2" "allInOne" "$jaeger_service_name" "01" "06"
+
+
+###############################################################################
+# TEST NAME: sidecar-skip-webhook
+###############################################################################
+start_test "sidecar-skip-webhook"
+render_install_vertx "01"

--- a/tests/e2e/sidecar/sidecar-deployment/00-assert.yaml
+++ b/tests/e2e/sidecar/sidecar-deployment/00-assert.yaml
@@ -1,0 +1,8 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agent-as-sidecar
+spec:
+  replicas: 1
+status:
+  readyReplicas: 1

--- a/tests/e2e/sidecar/sidecar-deployment/00-install.yaml
+++ b/tests/e2e/sidecar/sidecar-deployment/00-install.yaml
@@ -1,0 +1,13 @@
+apiVersion: jaegertracing.io/v1
+kind: Jaeger
+metadata:
+  name: agent-as-sidecar
+spec:
+  strategy: allinone
+  allInOne:
+    options:
+      log-level:  "debug"
+      memory.max-traces: 10000
+  ingress:
+    enabled: true
+    security: "none"

--- a/tests/e2e/sidecar/sidecar-deployment/02-assert.yaml
+++ b/tests/e2e/sidecar/sidecar-deployment/02-assert.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: vertx-create-span-sidecar
+spec:
+  containers:
+    - name: vertx-create-span-sidecar
+    # Assert the Jaeger agent is there
+    - name: jaeger-agent
+status:
+  phase: Running

--- a/tests/e2e/sidecar/sidecar-deployment/02-enable-injection.yaml
+++ b/tests/e2e/sidecar/sidecar-deployment/02-enable-injection.yaml
@@ -1,0 +1,6 @@
+# Add annotation to the deployment
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl annotate --overwrite deployment vertx-create-span-sidecar "sidecar.jaegertracing.io/inject"="true"
+    namespaced: true

--- a/tests/e2e/sidecar/sidecar-deployment/04-assert.yaml
+++ b/tests/e2e/sidecar/sidecar-deployment/04-assert.yaml
@@ -1,0 +1,8 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agent-as-sidecar2
+spec:
+  replicas: 1
+status:
+  readyReplicas: 1

--- a/tests/e2e/sidecar/sidecar-deployment/04-other-instance.yaml
+++ b/tests/e2e/sidecar/sidecar-deployment/04-other-instance.yaml
@@ -1,0 +1,14 @@
+# Create another Jaeger instance
+apiVersion: jaegertracing.io/v1
+kind: Jaeger
+metadata:
+  name: agent-as-sidecar2
+spec:
+  strategy: allinone
+  allInOne:
+    options:
+      log-level:  "debug"
+      memory.max-traces: 10000
+  ingress:
+    enabled: true
+    security: "none"

--- a/tests/e2e/sidecar/sidecar-deployment/05-delete-first-instance.yaml
+++ b/tests/e2e/sidecar/sidecar-deployment/05-delete-first-instance.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: jaegertracing.io/v1
+    kind: Jaeger
+    name: agent-as-sidecar

--- a/tests/e2e/sidecar/sidecar-deployment/05-errors.yaml
+++ b/tests/e2e/sidecar/sidecar-deployment/05-errors.yaml
@@ -1,0 +1,5 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agent-as-sidecar
+

--- a/tests/e2e/sidecar/sidecar-deployment/07-assert.yaml
+++ b/tests/e2e/sidecar/sidecar-deployment/07-assert.yaml
@@ -1,0 +1,11 @@
+# Ensure the sidecar is not there anymore
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: vertx-create-span-sidecar
+spec:
+  containers:
+    - name: vertx-create-span-sidecar
+status:
+  phase: Running

--- a/tests/e2e/sidecar/sidecar-deployment/07-disable-injection.yaml
+++ b/tests/e2e/sidecar/sidecar-deployment/07-disable-injection.yaml
@@ -1,0 +1,6 @@
+# Add annotation to the deployment
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl annotate --overwrite deployment vertx-create-span-sidecar "sidecar.jaegertracing.io/inject"="false"
+    namespaced: true

--- a/tests/e2e/sidecar/sidecar-deployment/README.md
+++ b/tests/e2e/sidecar/sidecar-deployment/README.md
@@ -1,0 +1,22 @@
+# Sidecar - Deployment
+## What is this test case testing?
+
+Test the deployment of the Jaeger agent as as sidecar annotating a deployment.
+
+[From the Jaeger documentation](https://www.jaegertracing.io/docs/latest/operator/#auto-injecting-jaeger-agent-sidecars):
+> The operator can inject Jaeger Agent sidecars in Deployment workloads,
+provided that the deployment or its namespace has the annotation
+`sidecar.jaegertracing.io/inject` with a suitable value. The values can be either
+"true" (as string), or the Jaeger instance name, as returned by `kubectl get
+jaegers`. When "true" is used, there should be exactly one Jaeger instance for
+the same namespace as the deployment, otherwise, the operator can’t figure out
+automatically which Jaeger instance to use. A specific Jaeger instance name on
+a deployment has a higher precedence than true applied on its namespace.
+
+This test works in the following way:
+* Create a Jaeger instance
+* Inject the Jaeger agent as a sidecard for a deployment
+* Create a second Jaeger instance
+* Remove the first Jaeger instance (now, the deployment will use the second Jaeger instance)
+* Check there were no errors
+* Check the sidecar is removed when the annotation is removed

--- a/tests/e2e/sidecar/sidecar-namespace/00-assert.yaml
+++ b/tests/e2e/sidecar/sidecar-namespace/00-assert.yaml
@@ -1,0 +1,8 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agent-as-sidecar
+spec:
+  replicas: 1
+status:
+  readyReplicas: 1

--- a/tests/e2e/sidecar/sidecar-namespace/00-install.yaml
+++ b/tests/e2e/sidecar/sidecar-namespace/00-install.yaml
@@ -1,0 +1,13 @@
+apiVersion: jaegertracing.io/v1
+kind: Jaeger
+metadata:
+  name: agent-as-sidecar
+spec:
+  strategy: allinone
+  allInOne:
+    options:
+      log-level:  "debug"
+      memory.max-traces: 10000
+  ingress:
+    enabled: true
+    security: "none"

--- a/tests/e2e/sidecar/sidecar-namespace/02-assert.yaml
+++ b/tests/e2e/sidecar/sidecar-namespace/02-assert.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: vertx-create-span-sidecar
+spec:
+  containers:
+    - name: vertx-create-span-sidecar
+    # Assert the Jaeger agent is there
+    - name: jaeger-agent
+status:
+  phase: Running

--- a/tests/e2e/sidecar/sidecar-namespace/02-enable-injection.yaml
+++ b/tests/e2e/sidecar/sidecar-namespace/02-enable-injection.yaml
@@ -1,0 +1,4 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl annotate --overwrite namespaces $NAMESPACE "sidecar.jaegertracing.io/inject"="true"

--- a/tests/e2e/sidecar/sidecar-namespace/04-assert.yaml
+++ b/tests/e2e/sidecar/sidecar-namespace/04-assert.yaml
@@ -1,0 +1,8 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agent-as-sidecar2
+spec:
+  replicas: 1
+status:
+  readyReplicas: 1

--- a/tests/e2e/sidecar/sidecar-namespace/04-other-instance.yaml
+++ b/tests/e2e/sidecar/sidecar-namespace/04-other-instance.yaml
@@ -1,0 +1,13 @@
+apiVersion: jaegertracing.io/v1
+kind: Jaeger
+metadata:
+  name: agent-as-sidecar2
+spec:
+  strategy: allinone
+  allInOne:
+    options:
+      log-level:  "debug"
+      memory.max-traces: 10000
+  ingress:
+    enabled: true
+    security: "none"

--- a/tests/e2e/sidecar/sidecar-namespace/05-delete-first-instance.yaml
+++ b/tests/e2e/sidecar/sidecar-namespace/05-delete-first-instance.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: jaegertracing.io/v1
+    kind: Jaeger
+    name: agent-as-sidecar

--- a/tests/e2e/sidecar/sidecar-namespace/05-errors.yaml
+++ b/tests/e2e/sidecar/sidecar-namespace/05-errors.yaml
@@ -1,0 +1,5 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agent-as-sidecar
+

--- a/tests/e2e/sidecar/sidecar-namespace/07-assert.yaml
+++ b/tests/e2e/sidecar/sidecar-namespace/07-assert.yaml
@@ -1,0 +1,11 @@
+# Ensure the sidecar is not there anymore
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: vertx-create-span-sidecar
+spec:
+  containers:
+    - name: vertx-create-span-sidecar
+status:
+  phase: Running

--- a/tests/e2e/sidecar/sidecar-namespace/07-disable-injection.yaml
+++ b/tests/e2e/sidecar/sidecar-namespace/07-disable-injection.yaml
@@ -1,0 +1,4 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl annotate --overwrite namespaces $NAMESPACE "sidecar.jaegertracing.io/inject"="false"

--- a/tests/e2e/sidecar/sidecar-namespace/README.md
+++ b/tests/e2e/sidecar/sidecar-namespace/README.md
@@ -1,0 +1,22 @@
+# Sidecar - Namespace
+## What is this test case testing?
+
+Test the deployment of the Jaeger agent as as sidecar annotating a namespace.
+
+[From the Jaeger documentation](https://www.jaegertracing.io/docs/latest/operator/#auto-injecting-jaeger-agent-sidecars):
+> The operator can inject Jaeger Agent sidecars in Deployment workloads,
+provided that the deployment or its namespace has the annotation
+`sidecar.jaegertracing.io/inject` with a suitable value. The values can be either
+"true" (as string), or the Jaeger instance name, as returned by `kubectl get
+jaegers`. When "true" is used, there should be exactly one Jaeger instance for
+the same namespace as the deployment, otherwise, the operator can’t figure out
+automatically which Jaeger instance to use. A specific Jaeger instance name on
+a deployment has a higher precedence than true applied on its namespace.
+
+This test works in the following way:
+* Create a Jaeger instance
+* Inject the Jaeger agent as a sidecard for a deployment
+* Create a second Jaeger instance
+* Remove the first Jaeger instance (now, the deployment will use the second Jaeger instance)
+* Check there were no errors
+* Check the sidecar is removed when the annotation is removed

--- a/tests/e2e/sidecar/sidecar-skip-webhook/00-assert.yaml
+++ b/tests/e2e/sidecar/sidecar-skip-webhook/00-assert.yaml
@@ -1,0 +1,8 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agent-as-sidecar
+spec:
+  replicas: 1
+status:
+  readyReplicas: 1

--- a/tests/e2e/sidecar/sidecar-skip-webhook/00-install.yaml
+++ b/tests/e2e/sidecar/sidecar-skip-webhook/00-install.yaml
@@ -1,0 +1,13 @@
+apiVersion: jaegertracing.io/v1
+kind: Jaeger
+metadata:
+  name: agent-as-sidecar
+spec:
+  strategy: allinone
+  allInOne:
+    options:
+      log-level:  "debug"
+      memory.max-traces: 10000
+  ingress:
+    enabled: true
+    security: "none"

--- a/tests/e2e/sidecar/sidecar-skip-webhook/02-add-anotation-and-label.yaml
+++ b/tests/e2e/sidecar/sidecar-skip-webhook/02-add-anotation-and-label.yaml
@@ -1,0 +1,7 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl label deployment vertx-create-span-sidecar "app.kubernetes.io/name"="jaeger-operator"
+    namespaced: true
+  - command: kubectl annotate --overwrite deployment vertx-create-span-sidecar "sidecar.jaegertracing.io/inject"="true"
+    namespaced: true

--- a/tests/e2e/sidecar/sidecar-skip-webhook/02-assert.yaml
+++ b/tests/e2e/sidecar/sidecar-skip-webhook/02-assert.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: vertx-create-span-sidecar
+spec:
+  containers:
+    # Ensure the Jaeger agent is not there
+    - name: vertx-create-span-sidecar
+status:
+  phase: Running

--- a/tests/e2e/sidecar/sidecar-skip-webhook/03-assert.yaml
+++ b/tests/e2e/sidecar/sidecar-skip-webhook/03-assert.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: vertx-create-span-sidecar
+spec:
+  containers:
+    - name: vertx-create-span-sidecar
+    - name: jaeger-agent
+status:
+  phase: Running

--- a/tests/e2e/sidecar/sidecar-skip-webhook/03-remove-label.yaml
+++ b/tests/e2e/sidecar/sidecar-skip-webhook/03-remove-label.yaml
@@ -1,0 +1,5 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: kubectl label deployment vertx-create-span-sidecar app.kubernetes.io/name-
+    namespaced: true

--- a/tests/e2e/sidecar/sidecar-skip-webhook/README.md
+++ b/tests/e2e/sidecar/sidecar-skip-webhook/README.md
@@ -1,0 +1,11 @@
+# Sidecar - Skip webhook
+## What is this test case testing?
+
+When the `"app.kubernetes.io/name"="jaeger-operator"` label is added to a deployment,
+the Jaeger agent is not added as a sidecar.
+
+This test works in the following way:
+* Create a Jaeger instance
+* Enables the autoinjection of the Jaeger agent as a sidecar in a deployment but since the
+label `"app.kubernetes.io/name"="jaeger-operator"` is set, the sidecar is not created
+* Remove the label and check if the sidecar is created


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- <!-- Example: Resolves #123 -->

## Description of the changes
Revert jaeger agent deprecation to be able to release 1.58 first.
- https://github.com/jaegertracing/jaeger-operator/pull/2608
- 
**Commits/PRs**
- https://github.com/jaegertracing/jaeger-operator/pull/2609
- https://github.com/jaegertracing/jaeger-operator/pull/2497

## How was this change tested?
- 

## Checklist
- [ ] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [ ] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
