### PR TITLE
Fix golang version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jaegertracing/jaeger-operator
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/Masterminds/semver v1.5.0


### PR DESCRIPTION
The absence of a patch version makes some builders to fail.