### PR TITLE
feat: added unit test for namespace reconciler

### DIFF
--- a/controllers/appsv1/namespace_controller_test.go
+++ b/controllers/appsv1/namespace_controller_test.go
@@ -1,12 +1,16 @@
 package appsv1_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
 	k8sconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	k8sreconcile "sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	v1 "github.com/jaegertracing/jaeger-operator/apis/v1"
 	"github.com/jaegertracing/jaeger-operator/controllers/appsv1"
 )
 
@@ -26,5 +30,26 @@ func TestNamespaceControllerRegisterWithManager(t *testing.T) {
 	err = reconciler.SetupWithManager(mgr)
 
 	// verify
+	require.NoError(t, err)
+}
+
+func TestNewNamespaceInstance(t *testing.T) {
+	// prepare
+	nsn := types.NamespacedName{Name: "my-instance", Namespace: "default"}
+	reconciler := appsv1.NewNamespaceReconciler(
+		k8sClient,
+		k8sClient,
+		testScheme,
+	)
+
+	instance := v1.NewJaeger(nsn)
+	err := k8sClient.Create(context.Background(), instance)
+	require.NoError(t, err)
+
+	req := k8sreconcile.Request{
+		NamespacedName: nsn,
+	}
+
+	_, err = reconciler.Reconcile(context.Background(), req)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- Missing unit test for `NamespaceReconciler`

## Description of the changes
- Adds a missing unit-test for reconciling the `NamespaceReconciler`.

## How was this change tested?
- Ran the unit test locally

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
