### PR TITLE
feat: added missing test for elasticsearch reconciler

### DIFF
--- a/controllers/elasticsearch/elasticsearch_controller_test.go
+++ b/controllers/elasticsearch/elasticsearch_controller_test.go
@@ -1,0 +1,77 @@
+package elasticsearch_test
+
+import (
+	"context"
+	"testing"
+
+	esv1 "github.com/openshift/elasticsearch-operator/apis/logging/v1"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	k8sconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	k8sreconcile "sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	v1 "github.com/jaegertracing/jaeger-operator/apis/v1"
+	"github.com/jaegertracing/jaeger-operator/controllers/elasticsearch"
+)
+
+func TestElasticSearchSetupWithManager(t *testing.T) {
+	t.Skip("this test requires a real cluster, otherwise the GetConfigOrDie will die")
+
+	// prepare
+	mgr, err := manager.New(k8sconfig.GetConfigOrDie(), manager.Options{})
+	require.NoError(t, err)
+	reconciler := elasticsearch.NewReconciler(
+		k8sClient,
+		k8sClient,
+	)
+
+	// test
+	err = reconciler.SetupWithManager(mgr)
+
+	// verify
+	require.NoError(t, err)
+}
+
+func TestNewElasticSearchInstance(t *testing.T) {
+	// prepare
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-ns",
+		},
+	}
+
+	es := &esv1.Elasticsearch{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-es",
+			Namespace: "test-ns",
+		},
+	}
+
+	jaeger := v1.NewJaeger(types.NamespacedName{
+		Name:      "test-jaeger",
+		Namespace: "test-jaeger",
+	})
+
+	esv1.AddToScheme(testScheme)
+	v1.AddToScheme(testScheme)
+
+	client := fake.NewClientBuilder().WithRuntimeObjects(ns, es, jaeger).Build()
+	reconciler := elasticsearch.NewReconciler(
+		client,
+		client,
+	)
+
+	req := k8sreconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "test-es",
+			Namespace: "test-ns",
+		},
+	}
+
+	_, err := reconciler.Reconcile(context.Background(), req)
+	require.NoError(t, err)
+}

--- a/controllers/elasticsearch/suit_test.go
+++ b/controllers/elasticsearch/suit_test.go
@@ -1,0 +1,57 @@
+package elasticsearch_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	v1 "github.com/jaegertracing/jaeger-operator/apis/v1"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	// +kubebuilder:scaffold:imports
+)
+
+var (
+	k8sClient  client.Client
+	testEnv    *envtest.Environment
+	testScheme *runtime.Scheme = scheme.Scheme
+)
+
+func TestMain(m *testing.M) {
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{filepath.Join("..", "..", "config", "crd", "bases")},
+	}
+
+	cfg, err := testEnv.Start()
+	if err != nil {
+		fmt.Printf("failed to start testEnv: %v", err)
+		os.Exit(1)
+	}
+
+	if err := v1.AddToScheme(scheme.Scheme); err != nil {
+		fmt.Printf("failed to register scheme: %v", err)
+		os.Exit(1)
+	}
+
+	// +kubebuilder:scaffold:scheme
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: testScheme})
+	if err != nil {
+		fmt.Printf("failed to setup a Kubernetes client: %v", err)
+		os.Exit(1)
+	}
+
+	code := m.Run()
+
+	err = testEnv.Stop()
+	if err != nil {
+		fmt.Printf("failed to stop testEnv: %v", err)
+		os.Exit(1)
+	}
+
+	os.Exit(code)
+}


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
- Missing unit test for `controllers/elasticsearch`

## Description of the changes
- Adds missing unit test for `controllers/elasticsearch`

## How was this change tested?
- Tested locally `make test-unit`

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
