### PR TITLE
Added compatibility for Jaeger Operator v1.61.x and v1.62.x

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -2,6 +2,8 @@ The following table shows the compatibility of Jaeger Operator with three differ
 
 | Jaeger Operator | Kubernetes     | Strimzi Operator   | Cert-Manager |
 |-----------------|----------------|--------------------|--------------|
+| v1.62.x         | v1.19 to v1.30 | v0.32              | v1.6.1       |
+| v1.61.x         | v1.19 to v1.30 | v0.32              | v1.6.1       |
 | v1.60.x         | v1.19 to v1.30 | v0.32              | v1.6.1       |
 | v1.59.x         | v1.19 to v1.28 | v0.32              | v1.6.1       |
 | v1.58.x         | skipped        | skipped            | skipped      |


### PR DESCRIPTION
## Which problem is this PR solving?
- resolves https://github.com/jaegertracing/jaeger-operator/issues/2724

## Description of the changes
Updated the Jaeger Operator's compatibility Matrix by following the guidance given here: https://github.com/jaegertracing/jaeger-operator/issues/2219#issuecomment-1610911287

## How was this change tested?
N/A

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `yarn lint` and `yarn test`
