### PR TITLE
refactor: move webhook interface validation to test file

### DIFF
--- a/apis/v1/jaeger_webhook.go
+++ b/apis/v1/jaeger_webhook.go
@@ -12,7 +12,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -35,8 +34,6 @@ func (j *Jaeger) SetupWebhookWithManager(mgr ctrl.Manager) error {
 }
 
 //+kubebuilder:webhook:path=/mutate-jaegertracing-io-v1-jaeger,mutating=true,failurePolicy=fail,sideEffects=None,groups=jaegertracing.io,resources=jaegers,verbs=create;update,versions=v1,name=mjaeger.kb.io,admissionReviewVersions={v1}
-
-var _ webhook.Defaulter = &Jaeger{}
 
 func (j *Jaeger) objsWithOptions() []*Options {
 	return []*Options{
@@ -84,8 +81,6 @@ func (j *Jaeger) Default() {
 
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
 //+kubebuilder:webhook:path=/validate-jaegertracing-io-v1-jaeger,mutating=false,failurePolicy=fail,sideEffects=None,groups=jaegertracing.io,resources=jaegers,verbs=create;update,versions=v1,name=vjaeger.kb.io,admissionReviewVersions={v1}
-
-var _ webhook.Validator = &Jaeger{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (j *Jaeger) ValidateCreate() (admission.Warnings, error) {

--- a/apis/v1/jaeger_webhook_test.go
+++ b/apis/v1/jaeger_webhook_test.go
@@ -4,16 +4,21 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	esv1 "github.com/openshift/elasticsearch-operator/apis/logging/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+var (
+	_ webhook.Defaulter = &Jaeger{}
+	_ webhook.Validator = &Jaeger{}
 )
 
 func TestDefault(t *testing.T) {
@@ -166,8 +171,8 @@ func TestDefault(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			esv1.AddToScheme(scheme.Scheme)
-			AddToScheme(scheme.Scheme)
+			require.NoError(t, esv1.AddToScheme(scheme.Scheme))
+			require.NoError(t, AddToScheme(scheme.Scheme))
 			fakeCl := fake.NewClientBuilder().WithRuntimeObjects(test.objs...).Build()
 			cl = fakeCl
 
@@ -273,8 +278,8 @@ func TestValidate(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			esv1.AddToScheme(scheme.Scheme)
-			AddToScheme(scheme.Scheme)
+			require.NoError(t, esv1.AddToScheme(scheme.Scheme))
+			require.NoError(t, AddToScheme(scheme.Scheme))
 			fakeCl := fake.NewClientBuilder().WithRuntimeObjects(test.objsToCreate...).Build()
 			cl = fakeCl
 


### PR DESCRIPTION
## Which problem is this PR solving?
Resolves #2794

## Description of the changes
Moved the webhook interface validation code from `jaeger_webhook.go` to `jaeger_webhook_test.go` to ensure the Jaeger structure still fulfills the webhook interfaces. This change allows external projects to import the `jaeger-operator/apis/v1` package with `sigs.k8s.io/controller-runtime` library version [v0.20.0](https://github.com/kubernetes-sigs/controller-runtime/releases/tag/v0.20.0), as the deprecated webhook interfaces were removed in this version. 

## How was this change tested?
- I created a tag over this MR (on my forked repo) and I was able to build and run succesfully the `jaeger-operator/apis/v1` package with the `sigs.k8s.io/controller-runtime` library version [v0.20.0](https://github.com/kubernetes-sigs/controller-runtime/releases/tag/v0.20.0) over an external Go Kubernetes operator project.

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] ~I have added unit tests for the new functionality~
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
