### PR TITLE
Remove reporter (agent) flags from all in one

### DIFF
--- a/pkg/config/tls/tls_test.go
+++ b/pkg/config/tls/tls_test.go
@@ -25,18 +25,3 @@ func TestUpdateWithTLSSecret(t *testing.T) {
 	assert.Equal(t, "--collector.grpc.tls.cert=/etc/tls-config/tls.crt", options[1])
 	assert.Equal(t, "--collector.grpc.tls.key=/etc/tls-config/tls.key", options[2])
 }
-
-func TestIgnoreDefaultTLSSecretWhenGrpcHostPortIsSet(t *testing.T) {
-	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestIgnoreDefaultTLSSecretWhenGrpcHostPortIsSet"})
-	autodetect.OperatorConfiguration.SetPlatform(autodetect.OpenShiftPlatform)
-
-	commonSpec := v1.JaegerCommonSpec{}
-	options := []string{}
-	options = append(options, "--reporter.grpc.host-port=my.host-port.com")
-
-	Update(jaeger, &commonSpec, &options)
-	assert.Empty(t, commonSpec.Volumes)
-	assert.Empty(t, commonSpec.VolumeMounts)
-	assert.Len(t, options, 1)
-	assert.Equal(t, "--reporter.grpc.host-port=my.host-port.com", options[0])
-}

--- a/pkg/deployment/all_in_one.go
+++ b/pkg/deployment/all_in_one.go
@@ -1,7 +1,6 @@
 package deployment
 
 import (
-	"fmt"
 	"sort"
 	"strconv"
 
@@ -13,7 +12,6 @@ import (
 
 	v1 "github.com/jaegertracing/jaeger-operator/apis/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/account"
-	"github.com/jaegertracing/jaeger-operator/pkg/autodetect"
 	"github.com/jaegertracing/jaeger-operator/pkg/config/ca"
 	"github.com/jaegertracing/jaeger-operator/pkg/config/sampling"
 	"github.com/jaegertracing/jaeger-operator/pkg/config/tls"
@@ -77,18 +75,6 @@ func (a *AllInOne) Get() *appsv1.Deployment {
 	ca.Update(a.jaeger, commonSpec)
 	ca.AddServiceCA(a.jaeger, commonSpec)
 	storage.UpdateGRPCPlugin(a.jaeger, commonSpec)
-
-	// Enable tls by default for openshift platform
-	// even though the agent is in the same process as the collector, they communicate via gRPC, and the collector has TLS enabled,
-	// as it might receive connections from external agents
-	if autodetect.OperatorConfiguration.GetPlatform() == autodetect.OpenShiftPlatform {
-		if len(util.FindItem("--reporter.grpc.host-port=", options)) == 0 &&
-			len(util.FindItem("--reporter.grpc.tls.enabled=", options)) == 0 {
-			options = append(options, "--reporter.grpc.tls.enabled=true")
-			options = append(options, fmt.Sprintf("--reporter.grpc.tls.ca=%s", ca.ServiceCAPath))
-			options = append(options, fmt.Sprintf("--reporter.grpc.tls.server-name=%s.%s.svc.cluster.local", service.GetNameForHeadlessCollectorService(a.jaeger), a.jaeger.Namespace))
-		}
-	}
 
 	// ensure we have a consistent order of the arguments
 	// see https://github.com/jaegertracing/jaeger-operator/issues/334

--- a/pkg/deployment/all_in_one_test.go
+++ b/pkg/deployment/all_in_one_test.go
@@ -398,42 +398,20 @@ func TestAllInOneArgumentsOpenshiftTLS(t *testing.T) {
 				"--collector.grpc.tls.cert=/etc/tls-config/tls.crt",
 				"--collector.grpc.tls.key=/etc/tls-config/tls.key",
 				"--sampling.strategies-file",
-				"--reporter.grpc.tls.ca",
-				"--reporter.grpc.tls.enabled",
-				"--reporter.grpc.tls.server-name",
 			},
 		},
 		{
 			name: "Explicit disable TLS",
 			options: v1.NewOptions(map[string]interface{}{
 				"a-option":                   "a-value",
-				"reporter.grpc.tls.enabled":  "false",
 				"collector.grpc.tls.enabled": "false",
 			}),
 			expectedArgs: []string{
 				"--a-option=a-value",
-				"--reporter.grpc.tls.enabled=false",
 				"--collector.grpc.tls.enabled=false",
 				"--sampling.strategies-file",
 			},
 			nonExpectedArgs: []string{
-				"--reporter.grpc.tls.enabled=true",
-				"--collector.grpc.tls.enabled=true",
-			},
-		},
-		{
-			name: "Do not implicitly enable TLS when grpc.host-port is provided",
-			options: v1.NewOptions(map[string]interface{}{
-				"a-option":                "a-value",
-				"reporter.grpc.host-port": "my.host-port.com",
-			}),
-			expectedArgs: []string{
-				"--a-option=a-value",
-				"--reporter.grpc.host-port=my.host-port.com",
-				"--sampling.strategies-file",
-			},
-			nonExpectedArgs: []string{
-				"--reporter.grpc.tls.enabled=true",
 				"--collector.grpc.tls.enabled=true",
 			},
 		},


### PR DESCRIPTION
<!--
!! Please DELETE this comment before posting.
We appreciate your contribution to the Jaeger project! 👋🎉
-->

## Which problem is this PR solving?
-  When agent was removed from jaeger , reporter flags were removed from all in one binary. so those flags are not valid anymore.

## Description of the changes
-  Remove reporter flags, as those are specific flags for report to the agent. which is not anymore present in the all in one.

## How was this change tested?
-  Deployed on kubernetes cluster and did an all in one deployment

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
