### PR TITLE
patch: adding ability to pass labels through to the services for query

### DIFF
--- a/pkg/service/query.go
+++ b/pkg/service/query.go
@@ -17,6 +17,14 @@ func NewQueryService(jaeger *v1.Jaeger, selector map[string]string) *corev1.Serv
 	if jaeger.Spec.Query.Annotations != nil {
 		annotations = jaeger.Spec.Query.Annotations
 	}
+
+	labels := util.Labels(GetNameForQueryService(jaeger), "service-query", *jaeger)
+	if jaeger.Spec.Query.Labels != nil {
+		for k, v := range jaeger.Spec.Query.Labels {
+			labels[k] = v
+		}
+
+	}
 	if jaeger.Spec.Ingress.Security == v1.IngressSecurityOAuthProxy {
 		annotations["service.alpha.openshift.io/serving-cert-secret-name"] = GetTLSSecretNameForQueryService(jaeger)
 	}
@@ -56,7 +64,7 @@ func NewQueryService(jaeger *v1.Jaeger, selector map[string]string) *corev1.Serv
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        GetNameForQueryService(jaeger),
 			Namespace:   jaeger.Namespace,
-			Labels:      util.Labels(GetNameForQueryService(jaeger), "service-query", *jaeger),
+			Labels:      labels,
 			Annotations: annotations,
 			OwnerReferences: []metav1.OwnerReference{
 				{

--- a/pkg/service/query_test.go
+++ b/pkg/service/query_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -150,4 +151,34 @@ func TestQueryServiceSpecAnnotations(t *testing.T) {
 	assert.Equal(t, intstr.FromInt(16685), svc.Spec.Ports[1].TargetPort)
 	assert.Equal(t, intstr.FromInt(16687), svc.Spec.Ports[2].TargetPort)
 	assert.Equal(t, map[string]string{"component": "jaeger"}, svc.Annotations)
+}
+
+func TestQueryServiceSpecLabels(t *testing.T) {
+	name := "TestQueryServiceSpecLabels"
+	selector := map[string]string{"app": "myapp", "jaeger": name, "jaeger-component": "query"}
+
+	// Test 1: Without custom labels
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: name})
+	svc := NewQueryService(jaeger, selector)
+	fmt.Println(svc.ObjectMeta.Labels)
+
+	// Verify default labels from util.Labels are present
+	assert.Equal(t, "testqueryservicespeclabels-query", svc.ObjectMeta.Name)
+	assert.Len(t, svc.Spec.Ports, 3)
+	assert.Equal(t, int32(16686), svc.Spec.Ports[0].Port)
+	assert.Equal(t, int32(16685), svc.Spec.Ports[1].Port)
+	assert.Equal(t, int32(16687), svc.Spec.Ports[2].Port)
+	assert.Equal(t, "http-query", svc.Spec.Ports[0].Name)
+	assert.Equal(t, "grpc-query", svc.Spec.Ports[1].Name)
+	assert.Equal(t, "admin-http", svc.Spec.Ports[2].Name)
+	assert.Equal(t, intstr.FromInt(16686), svc.Spec.Ports[0].TargetPort)
+	assert.Equal(t, intstr.FromInt(16685), svc.Spec.Ports[1].TargetPort)
+	assert.Equal(t, intstr.FromInt(16687), svc.Spec.Ports[2].TargetPort)
+
+	assert.Equal(t, "jaeger", svc.ObjectMeta.Labels["app"])
+	assert.Equal(t, fmt.Sprintf("%s", svc.ObjectMeta.Name), svc.ObjectMeta.Labels["app.kubernetes.io/name"])
+	assert.Equal(t, name, svc.ObjectMeta.Labels["app.kubernetes.io/instance"])
+	assert.Equal(t, "service-query", svc.ObjectMeta.Labels["app.kubernetes.io/component"])
+	assert.Equal(t, "jaeger", svc.ObjectMeta.Labels["app.kubernetes.io/part-of"])
+	assert.Equal(t, "jaeger-operator", svc.ObjectMeta.Labels["app.kubernetes.io/managed-by"])
 }


### PR DESCRIPTION
## Which problem is this PR solving?
As it stands, we can pass annotations down to the query service using `spec.query.annotations` but any labels reflected in the `spec.query.labels` field only get passed to the deployment. This feels like it may have just been an oversight and to be honest, it's something I actually need as I'm sure some others do.
For my purposes, I need to be able to filter services based on their labels and the labels need to be custom ones such as environment, service, region and more. A long story short, it's for application discovery when using Teleport. so I can ensure certain people can only see certain services.

## Description of the changes
This change sets a new variable called `labels which gets the original labels values of `util.Labels(GetNameForQueryService(jaeger), "service-query", *jaeger)` set as the default.
It then checsk to see if any additional labels have been passed and merges them into the map.

## How was this change tested?
- I've run make test to ensure my tests work as expected.
- I'm running it in my production server right now. I've built and image and pused it to [my repo here](https://hub.docker.com/repository/docker/drewviles/jaeger-operator/general). I've then used this image to launch the operator with and without custom labels and in both cases it has worked as expected.

### With no custom label
![image](https://github.com/user-attachments/assets/b481ef69-bb28-45b4-baf4-b3e069e709c6)

### With custom label
![image](https://github.com/user-attachments/assets/832466b7-c720-424f-b059-44422bc6a604)

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
  - for `jaeger`: `make lint test`
  - for `jaeger-ui`: `npm run lint` and `npm run test`
