### PR TITLE
Set `sidecar.istio.io/inject` as pod label instead of annotation

### DIFF
--- a/examples/business-application-injected-sidecar.yaml
+++ b/examples/business-application-injected-sidecar.yaml
@@ -12,7 +12,6 @@ spec:
     metadata:
       labels:
         app: myapp
-      annotations:
         sidecar.istio.io/inject: "true"
     spec:
       containers:

--- a/pkg/cronjob/es_index_cleaner.go
+++ b/pkg/cronjob/es_index_cleaner.go
@@ -39,11 +39,11 @@ func CreateEsIndexCleaner(jaeger *v1.Jaeger) runtime.Object {
 	baseCommonSpec := v1.JaegerCommonSpec{
 		Annotations: map[string]string{
 			"prometheus.io/scrape":    "false",
-			"sidecar.istio.io/inject": "false",
 			"linkerd.io/inject":       "disabled",
 		},
 		Labels: util.Labels(name, "cronjob-es-index-cleaner", *jaeger),
 	}
+	baseCommonSpec.Labels["sidecar.istio.io/inject"] = "false"
 
 	commonSpec := util.Merge([]v1.JaegerCommonSpec{jaeger.Spec.Storage.EsIndexCleaner.JaegerCommonSpec, jaeger.Spec.JaegerCommonSpec, baseCommonSpec})
 

--- a/pkg/cronjob/es_index_cleaner_test.go
+++ b/pkg/cronjob/es_index_cleaner_test.go
@@ -139,7 +139,7 @@ func TestEsIndexCleanerAnnotations(t *testing.T) {
 
 	cjob := CreateEsIndexCleaner(jaeger).(*batchv1.CronJob)
 	assert.Equal(t, "operator", cjob.Spec.JobTemplate.Spec.Template.Annotations["name"])
-	assert.Equal(t, "false", cjob.Spec.JobTemplate.Spec.Template.Annotations["sidecar.istio.io/inject"])
+	assert.Equal(t, "false", cjob.Spec.JobTemplate.Spec.Template.Labels["sidecar.istio.io/inject"])
 	assert.Equal(t, "world", cjob.Spec.JobTemplate.Spec.Template.Annotations["hello"])
 	assert.Equal(t, "false", cjob.Spec.JobTemplate.Spec.Template.Annotations["prometheus.io/scrape"])
 	assert.Equal(t, "disabled", cjob.Spec.JobTemplate.Spec.Template.Annotations["linkerd.io/inject"])

--- a/pkg/cronjob/es_rollover.go
+++ b/pkg/cronjob/es_rollover.go
@@ -100,9 +100,11 @@ func createTemplate(name, action string, jaeger *v1.Jaeger, envs []corev1.EnvVar
 	envs = append(envs, proxy.ReadProxyVarsFromEnv()...)
 	baseCommonSpec := v1.JaegerCommonSpec{
 		Annotations: map[string]string{
-			"prometheus.io/scrape":    "false",
+			"prometheus.io/scrape": "false",
+			"linkerd.io/inject":    "disabled",
+		},
+		Labels: map[string]string{
 			"sidecar.istio.io/inject": "false",
-			"linkerd.io/inject":       "disabled",
 		},
 	}
 

--- a/pkg/cronjob/es_rollover_test.go
+++ b/pkg/cronjob/es_rollover_test.go
@@ -199,7 +199,7 @@ func TestEsRolloverAnnotations(t *testing.T) {
 	cjob := rollover(jaeger).(*batchv1.CronJob)
 
 	assert.Equal(t, "operator", cjob.Spec.JobTemplate.Spec.Template.Annotations["name"])
-	assert.Equal(t, "false", cjob.Spec.JobTemplate.Spec.Template.Annotations["sidecar.istio.io/inject"])
+	assert.Equal(t, "false", cjob.Spec.JobTemplate.Spec.Template.Labels["sidecar.istio.io/inject"])
 	assert.Equal(t, "world", cjob.Spec.JobTemplate.Spec.Template.Annotations["hello"])
 	assert.Equal(t, "false", cjob.Spec.JobTemplate.Spec.Template.Annotations["prometheus.io/scrape"])
 	assert.Equal(t, "disabled", cjob.Spec.JobTemplate.Spec.Template.Annotations["linkerd.io/inject"])
@@ -311,7 +311,7 @@ func TestEsRolloverLookbackAnnotations(t *testing.T) {
 	cjob := lookback(jaeger).(*batchv1.CronJob)
 
 	assert.Equal(t, "operator", cjob.Spec.JobTemplate.Spec.Template.Annotations["name"])
-	assert.Equal(t, "false", cjob.Spec.JobTemplate.Spec.Template.Annotations["sidecar.istio.io/inject"])
+	assert.Equal(t, "false", cjob.Spec.JobTemplate.Spec.Template.Labels["sidecar.istio.io/inject"])
 	assert.Equal(t, "world", cjob.Spec.JobTemplate.Spec.Template.Annotations["hello"])
 	assert.Equal(t, "false", cjob.Spec.JobTemplate.Spec.Template.Annotations["prometheus.io/scrape"])
 	assert.Equal(t, "disabled", cjob.Spec.JobTemplate.Spec.Template.Annotations["linkerd.io/inject"])

--- a/pkg/cronjob/spark_dependencies.go
+++ b/pkg/cronjob/spark_dependencies.go
@@ -47,11 +47,11 @@ func CreateSparkDependencies(jaeger *v1.Jaeger) runtime.Object {
 	baseCommonSpec := v1.JaegerCommonSpec{
 		Annotations: map[string]string{
 			"prometheus.io/scrape":    "false",
-			"sidecar.istio.io/inject": "false",
 			"linkerd.io/inject":       "disabled",
 		},
 		Labels: util.Labels(name, "spark-dependencies", *jaeger),
 	}
+	baseCommonSpec.Labels["sidecar.istio.io/inject"] = "false"
 
 	commonSpec := util.Merge([]v1.JaegerCommonSpec{jaeger.Spec.Storage.Dependencies.JaegerCommonSpec, jaeger.Spec.JaegerCommonSpec, baseCommonSpec})
 

--- a/pkg/cronjob/spark_dependencies_test.go
+++ b/pkg/cronjob/spark_dependencies_test.go
@@ -197,7 +197,7 @@ func TestDependenciesAnnotations(t *testing.T) {
 	cjob := CreateSparkDependencies(jaeger).(*batchv1.CronJob)
 
 	assert.Equal(t, "operator", cjob.Spec.JobTemplate.Spec.Template.Annotations["name"])
-	assert.Equal(t, "false", cjob.Spec.JobTemplate.Spec.Template.Annotations["sidecar.istio.io/inject"])
+	assert.Equal(t, "false", cjob.Spec.JobTemplate.Spec.Template.Labels["sidecar.istio.io/inject"])
 	assert.Equal(t, "world", cjob.Spec.JobTemplate.Spec.Template.Annotations["hello"])
 	assert.Equal(t, "false", cjob.Spec.JobTemplate.Spec.Template.Annotations["prometheus.io/scrape"])
 	assert.Equal(t, "disabled", cjob.Spec.JobTemplate.Spec.Template.Annotations["linkerd.io/inject"])

--- a/pkg/deployment/agent.go
+++ b/pkg/deployment/agent.go
@@ -85,9 +85,8 @@ func (a *Agent) Get() *appsv1.DaemonSet {
 	}
 
 	commonSpec := util.Merge([]v1.JaegerCommonSpec{a.jaeger.Spec.Agent.JaegerCommonSpec, a.jaeger.Spec.JaegerCommonSpec, baseCommonSpec})
-	_, ok := commonSpec.Annotations["sidecar.istio.io/inject"]
-	if !ok {
-		commonSpec.Annotations["sidecar.istio.io/inject"] = "false"
+	if _, ok := commonSpec.Labels["sidecar.istio.io/inject"]; !ok {
+		commonSpec.Labels["sidecar.istio.io/inject"] = "false"
 	}
 
 	ca.Update(a.jaeger, commonSpec)

--- a/pkg/deployment/agent_test.go
+++ b/pkg/deployment/agent_test.go
@@ -117,7 +117,7 @@ func TestDaemonSetAgentAnnotations(t *testing.T) {
 	dep := agent.Get()
 
 	assert.Equal(t, "operator", dep.Spec.Template.Annotations["name"])
-	assert.Equal(t, "false", dep.Spec.Template.Annotations["sidecar.istio.io/inject"])
+	assert.Equal(t, "false", dep.Spec.Template.Labels["sidecar.istio.io/inject"])
 	assert.Equal(t, "world", dep.Spec.Template.Annotations["hello"])
 	assert.Equal(t, "false", dep.Spec.Template.Annotations["prometheus.io/scrape"])
 	assert.Equal(t, "disabled", dep.Spec.Template.Annotations["linkerd.io/inject"])

--- a/pkg/deployment/all_in_one.go
+++ b/pkg/deployment/all_in_one.go
@@ -56,9 +56,8 @@ func (a *AllInOne) Get() *appsv1.Deployment {
 	}
 
 	commonSpec := util.Merge([]v1.JaegerCommonSpec{a.jaeger.Spec.AllInOne.JaegerCommonSpec, a.jaeger.Spec.JaegerCommonSpec, baseCommonSpec})
-	_, ok := commonSpec.Annotations["sidecar.istio.io/inject"]
-	if !ok {
-		commonSpec.Annotations["sidecar.istio.io/inject"] = "false"
+	if _, ok := commonSpec.Labels["sidecar.istio.io/inject"]; !ok {
+		commonSpec.Labels["sidecar.istio.io/inject"] = "false"
 	}
 
 	options := util.AllArgs(a.jaeger.Spec.AllInOne.Options,

--- a/pkg/deployment/all_in_one_test.go
+++ b/pkg/deployment/all_in_one_test.go
@@ -81,7 +81,7 @@ func TestAllInOneAnnotations(t *testing.T) {
 	dep := allinone.Get()
 
 	assert.Equal(t, "operator", dep.Spec.Template.Annotations["name"])
-	assert.Equal(t, "false", dep.Spec.Template.Annotations["sidecar.istio.io/inject"])
+	assert.Equal(t, "false", dep.Spec.Template.Labels["sidecar.istio.io/inject"])
 	assert.Equal(t, "world", dep.Spec.Template.Annotations["hello"])
 	assert.Equal(t, "false", dep.Spec.Template.Annotations["prometheus.io/scrape"])
 	assert.Equal(t, "disabled", dep.Spec.Template.Annotations["linkerd.io/inject"])

--- a/pkg/deployment/collector.go
+++ b/pkg/deployment/collector.go
@@ -54,9 +54,8 @@ func (c *Collector) Get() *appsv1.Deployment {
 	}
 
 	commonSpec := util.Merge([]v1.JaegerCommonSpec{c.jaeger.Spec.Collector.JaegerCommonSpec, c.jaeger.Spec.JaegerCommonSpec, baseCommonSpec})
-	_, ok := commonSpec.Annotations["sidecar.istio.io/inject"]
-	if !ok {
-		commonSpec.Annotations["sidecar.istio.io/inject"] = "false"
+	if _, ok := commonSpec.Labels["sidecar.istio.io/inject"]; !ok {
+		commonSpec.Labels["sidecar.istio.io/inject"] = "false"
 	}
 
 	var envFromSource []corev1.EnvFromSource

--- a/pkg/deployment/collector_test.go
+++ b/pkg/deployment/collector_test.go
@@ -120,7 +120,7 @@ func TestCollectorAnnotations(t *testing.T) {
 	dep := collector.Get()
 
 	assert.Equal(t, "operator", dep.Spec.Template.Annotations["name"])
-	assert.Equal(t, "false", dep.Spec.Template.Annotations["sidecar.istio.io/inject"])
+	assert.Equal(t, "false", dep.Spec.Template.Labels["sidecar.istio.io/inject"])
 	assert.Equal(t, "world", dep.Spec.Template.Annotations["hello"])
 	assert.Equal(t, "false", dep.Spec.Template.Annotations["prometheus.io/scrape"])
 	assert.Equal(t, "disabled", dep.Spec.Template.Annotations["linkerd.io/inject"])

--- a/pkg/deployment/ingester.go
+++ b/pkg/deployment/ingester.go
@@ -60,9 +60,8 @@ func (i *Ingester) Get() *appsv1.Deployment {
 	}
 
 	commonSpec := util.Merge([]v1.JaegerCommonSpec{i.jaeger.Spec.Ingester.JaegerCommonSpec, i.jaeger.Spec.JaegerCommonSpec, baseCommonSpec})
-	_, ok := commonSpec.Annotations["sidecar.istio.io/inject"]
-	if !ok {
-		commonSpec.Annotations["sidecar.istio.io/inject"] = "false"
+	if _, ok := commonSpec.Labels["sidecar.istio.io/inject"]; !ok {
+		commonSpec.Labels["sidecar.istio.io/inject"] = "false"
 	}
 
 	var envFromSource []corev1.EnvFromSource

--- a/pkg/deployment/ingester_test.go
+++ b/pkg/deployment/ingester_test.go
@@ -103,7 +103,7 @@ func TestIngesterAnnotations(t *testing.T) {
 	dep := ingester.Get()
 
 	assert.Equal(t, "operator", dep.Spec.Template.Annotations["name"])
-	assert.Equal(t, "false", dep.Spec.Template.Annotations["sidecar.istio.io/inject"])
+	assert.Equal(t, "false", dep.Spec.Template.Labels["sidecar.istio.io/inject"])
 	assert.Equal(t, "world", dep.Spec.Template.Annotations["hello"])
 	assert.Equal(t, "false", dep.Spec.Template.Annotations["prometheus.io/scrape"])
 	assert.Equal(t, "disabled", dep.Spec.Template.Annotations["linkerd.io/inject"])

--- a/pkg/deployment/query.go
+++ b/pkg/deployment/query.go
@@ -63,9 +63,8 @@ func (q *Query) Get() *appsv1.Deployment {
 	}
 
 	commonSpec := util.Merge([]v1.JaegerCommonSpec{q.jaeger.Spec.Query.JaegerCommonSpec, q.jaeger.Spec.JaegerCommonSpec, baseCommonSpec})
-	_, ok := commonSpec.Annotations["sidecar.istio.io/inject"]
-	if !ok {
-		commonSpec.Annotations["sidecar.istio.io/inject"] = "false"
+	if _, ok := commonSpec.Labels["sidecar.istio.io/inject"]; !ok {
+		commonSpec.Labels["sidecar.istio.io/inject"] = "false"
 	}
 
 	options := util.AllArgs(q.jaeger.Spec.Query.Options,

--- a/pkg/deployment/query_test.go
+++ b/pkg/deployment/query_test.go
@@ -79,7 +79,7 @@ func TestQueryAnnotations(t *testing.T) {
 	dep := query.Get()
 
 	assert.Equal(t, "operator", dep.Spec.Template.Annotations["name"])
-	assert.Equal(t, "false", dep.Spec.Template.Annotations["sidecar.istio.io/inject"])
+	assert.Equal(t, "false", dep.Spec.Template.Labels["sidecar.istio.io/inject"])
 	assert.Equal(t, "world", dep.Spec.Template.Annotations["hello"])
 	assert.Equal(t, "false", dep.Spec.Template.Annotations["prometheus.io/scrape"])
 	assert.Equal(t, "disabled", dep.Spec.Template.Annotations["linkerd.io/inject"])

--- a/pkg/storage/cassandra_dependencies.go
+++ b/pkg/storage/cassandra_dependencies.go
@@ -96,11 +96,11 @@ func cassandraDeps(jaeger *v1.Jaeger) []batchv1.Job {
 	commonSpec := &v1.JaegerCommonSpec{
 		Annotations: map[string]string{
 			"prometheus.io/scrape":    "false",
-			"sidecar.istio.io/inject": "false",
 			"linkerd.io/inject":       "disabled",
 		},
 		Labels: util.Labels(truncatedName, "cronjob-cassandra-schema", *jaeger),
 	}
+	commonSpec.Labels["sidecar.istio.io/inject"] = "false"
 	commonSpec = util.Merge([]v1.JaegerCommonSpec{jaeger.Spec.Collector.JaegerCommonSpec, jaeger.Spec.JaegerCommonSpec, *commonSpec})
 
 	// Set job deadline to 1 day by default. If the job does not succeed within

--- a/pkg/storage/elasticsearch_dependencies.go
+++ b/pkg/storage/elasticsearch_dependencies.go
@@ -25,11 +25,11 @@ func elasticsearchDependencies(jaeger *v1.Jaeger) []batchv1.Job {
 	commonSpec := &v1.JaegerCommonSpec{
 		Annotations: map[string]string{
 			"prometheus.io/scrape":    "false",
-			"sidecar.istio.io/inject": "false",
 			"linkerd.io/inject":       "disabled",
 		},
 		Labels: util.Labels(name, "job-es-rollover-create-mapping", *jaeger),
 	}
+	commonSpec.Labels["sidecar.istio.io/inject"] = "false"
 	commonSpec = util.Merge([]v1.JaegerCommonSpec{jaeger.Spec.Storage.EsRollover.JaegerCommonSpec, jaeger.Spec.JaegerCommonSpec, *commonSpec})
 	job := batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/storage/elasticsearch_dependencies_test.go
+++ b/pkg/storage/elasticsearch_dependencies_test.go
@@ -58,9 +58,12 @@ func TestElasticsearchDependencies(t *testing.T) {
 	assert.Len(t, deps, 1)
 	job := deps[0]
 
+	jobLabels := util.Labels("eevee-es-rollover-create-mapping", "job-es-rollover-create-mapping", *j)
+	jobLabels["sidecar.istio.io/inject"] = "false"
+
 	assert.Equal(t, j.Namespace, job.Namespace)
 	assert.Equal(t, []metav1.OwnerReference{util.AsOwner(j)}, job.OwnerReferences)
-	assert.Equal(t, util.Labels("eevee-es-rollover-create-mapping", "job-es-rollover-create-mapping", *j), job.Labels)
+	assert.Equal(t, jobLabels, job.Labels)
 	assert.Len(t, job.Spec.Template.Spec.Containers, 1)
 	assert.Equal(t, j.Spec.Storage.EsRollover.Image, job.Spec.Template.Spec.Containers[0].Image)
 	assert.Equal(t, []string{"init", "foo"}, job.Spec.Template.Spec.Containers[0].Args)


### PR DESCRIPTION
## Which problem is this PR solving?

Istio deprecated the use of `sidecar.istio.io/inject` annotation. It should be set as pod label.

Ref: https://istio.io/latest/docs/reference/config/annotations/#SidecarInject

## Description of the changes
- Update references where `sidecar.istio.io/inject` is set as annotation to label
- Update existing test cases to pass with the above changes

## How was this change tested?
- `go test ./pkg/...`

## Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [ ] I have added unit tests for the new functionality
- [ ] I have run lint and test steps successfully: `make lint test`

## AI Usage in this PR (choose one)
See [AI Usage Policy](https://github.com/jaegertracing/jaeger/blob/main/CONTRIBUTING_GUIDELINES.md#ai-usage-policy).
- [x] **None**: No AI tools were used in creating this PR
- [ ] **Light**: AI provided minor assistance (formatting, simple suggestions)
- [ ] **Moderate**: AI helped with code generation or debugging specific parts
- [ ] **Heavy**: AI generated most or all of the code changes
