### PR TITLE
[fix] Add default apiVersion for CronJob and HPA in generate mode

### DIFF
--- a/pkg/cmd/start/main.go
+++ b/pkg/cmd/start/main.go
@@ -54,6 +54,9 @@ func AddFlags(cmd *cobra.Command) {
 	_ = viper.BindEnv("jaeger-es-rollover-image", "RELATED_IMAGE_JAEGER_ES_ROLLOVER")
 	_ = viper.BindEnv(v1.FlagOpenShiftOauthProxyImage, "RELATED_IMAGE_OPENSHIFT_OAUTH_PROXY")
 
+	cmd.Flags().String(v1.FlagCronJobsVersion, v1.FlagCronJobsVersionBatchV1, "The version of the CronJob API to use, e.g. batch/v1 or batch/v1beta1")
+	cmd.Flags().String(v1.FlagAutoscalingVersion, v1.FlagAutoscalingVersionV2, "The version of the Autoscaling API to use, e.g. autoscaling/v2 or autoscaling/v2beta2")
+
 	docURL := fmt.Sprintf("https://www.jaegertracing.io/docs/%s", version.DefaultJaegerMajorMinor())
 	cmd.Flags().String("documentation-url", docURL, "The URL for the 'Documentation' menu item")
 }

--- a/pkg/cmd/start/main_test.go
+++ b/pkg/cmd/start/main_test.go
@@ -1,0 +1,20 @@
+package start
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+
+	v1 "github.com/jaegertracing/jaeger-operator/apis/v1"
+)
+
+func TestAddFlagsDefaults(t *testing.T) {
+	cmd := &cobra.Command{}
+	AddFlags(cmd)
+	viper.BindPFlags(cmd.Flags())
+
+	assert.Equal(t, v1.FlagCronJobsVersionBatchV1, viper.GetString(v1.FlagCronJobsVersion))
+	assert.Equal(t, v1.FlagAutoscalingVersionV2, viper.GetString(v1.FlagAutoscalingVersion))
+}


### PR DESCRIPTION
Which problem is this PR solving?
Resolves #2767

Description of the changes
Added default values for `--cronjobs-version` (`batch/v1`) and `--autoscaling-version` (`autoscaling/v2`) to the `AddFlags` function in `pkg/cmd/start/main.go`, which is shared by both the `start` and `generate` commands. In `start` mode, auto-detection overrides these defaults with cluster-detected values. In `generate` mode, the defaults ensure the `apiVersion` field is present in the YAML output for CronJob and HorizontalPodAutoscaler resources.

How was this change tested?
- Verified the fix by running `go run . generate --cr examples/simple-prod.yaml --output /tmp/out.yaml` and confirming `apiVersion: batch/v1` and `apiVersion: autoscaling/v2` appear in the output
- Added unit test `TestAddFlagsDefaults` to verify the flag defaults are set correctly
- Ran `go test ./pkg/...` - all tests pass (pre-existing failures in storage and controller packages are unrelated)

Checklist
- [x] I have read https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md
- [x] I have signed all commits
- [x] I have added unit tests for the new functionality
- [x] I have run lint and test steps successfully
