### PR TITLE
Remove duplicate watch on Jaeger type in SetupWithManager

### DIFF
--- a/controllers/jaegertracing/jaeger_controller.go
+++ b/controllers/jaegertracing/jaeger_controller.go
@@ -23,8 +23,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/operator-framework/operator-lib/handler"
-
 	v1 "github.com/jaegertracing/jaeger-operator/apis/v1"
 	"github.com/jaegertracing/jaeger-operator/pkg/controller/jaeger"
 )
@@ -69,10 +67,6 @@ func (r *JaegerReconciler) Reconcile(ctx context.Context, request ctrl.Request) 
 func (r *JaegerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	err := ctrl.NewControllerManagedBy(mgr).
 		For(&v1.Jaeger{}).
-		Watches(
-			&v1.Jaeger{},
-			&handler.InstrumentedEnqueueRequestForObject{},
-		).
 		Complete(r)
 	return err
 }


### PR DESCRIPTION
Fixes #2915

## Description

In `controllers/jaegertracing/jaeger_controller.go:67-72`, the `SetupWithManager` method registers **two watches** on the same `Jaeger` type:

```go
func (r *JaegerReconciler) SetupWithManager(mgr ctrl.Manager) error {
    err := ctrl.NewControllerManagedBy(mgr).
        For(&v1.Jaeger{}).                                          // watch #1
        Watches(&v1.Jaeger{}, &handler.InstrumentedEnqueueRequestForObject{}). // watch #2
        Complete(r)
    return err
}
```

- `For(&v1.Jaeger{})` internally creates a watch using `handler.EnqueueRequestForObject`
- `Watches(&v1.Jaeger{}, &handler.InstrumentedEnqueueRequestForObject{})` creates a **second** watch on the exact same type with an instrumented wrapper

Every create/update/delete event on a `Jaeger` object enqueues **two** reconcile requests (though the work queue deduplicates by key, this is still wasteful and indicates a bug).

## Fix

Remove the redundant `Watches` call and the unused `"github.com/operator-framework/operator-lib/handler"` import. `For()` already handles primary resource watching — the other controllers (`namespace_controller.go`, `elasticsearch_controller.go`) follow this pattern correctly.

## Impact

- Duplicate reconcile requests per event
- Unnecessary CPU/memory overhead
- Confusing code that suggests the primary resource needs an explicit watch

## Additional context

Other controllers in this repo use only `For()` without explicit `Watches()`:
- `controllers/appsv1/namespace_controller.go:38-42`
- `controllers/elasticsearch/elasticsearch_controller.go:41-43`
