### PR TITLE
Scope auto-provisioned kafka TLS volumes to collector and ingester only

### DIFF
--- a/pkg/strategy/streaming.go
+++ b/pkg/strategy/streaming.go
@@ -217,7 +217,7 @@ func autoProvisionKafka(ctx context.Context, jaeger *v1.Jaeger, manifest S) S {
 	clusterCAPath := fmt.Sprintf("/var/run/secrets/%s-cluster-ca", jaeger.Name)
 	clientCertPath := fmt.Sprintf("/var/run/secrets/%s", ku.Name)
 
-	// store the new volumes/volume mounts in a common spec, later to be merged with the instance's common spec
+	// store the new volumes/volume mounts in a common spec, later to be merged into the collector's and ingester's common specs
 	commonSpec := v1.JaegerCommonSpec{}
 
 	// this is the volume containing the client TLS details, like the cert and key
@@ -272,7 +272,13 @@ func autoProvisionKafka(ctx context.Context, jaeger *v1.Jaeger, manifest S) S {
 
 	jaeger.Spec.Collector.Options = v1.NewOptions(collectorOpts)
 	jaeger.Spec.Ingester.Options = v1.NewOptions(ingesterOpts)
-	jaeger.Spec.JaegerCommonSpec = *util.Merge([]v1.JaegerCommonSpec{commonSpec, jaeger.Spec.JaegerCommonSpec})
+
+	// only the collector and the ingester actually talk to kafka, so the volumes/volume mounts
+	// with the TLS material are injected into their specs, instead of the instance's common spec
+	// (which would leak the kafka certs into every other component, like the query service or the
+	// storage cronjobs)
+	jaeger.Spec.Collector.JaegerCommonSpec = *util.Merge([]v1.JaegerCommonSpec{commonSpec, jaeger.Spec.Collector.JaegerCommonSpec})
+	jaeger.Spec.Ingester.JaegerCommonSpec = *util.Merge([]v1.JaegerCommonSpec{commonSpec, jaeger.Spec.Ingester.JaegerCommonSpec})
 
 	return manifest
 }

--- a/pkg/strategy/streaming_test.go
+++ b/pkg/strategy/streaming_test.go
@@ -280,14 +280,21 @@ func TestAutoProvisionedKafkaInjectsIntoInstance(t *testing.T) {
 	assert.Contains(t, jaeger.Spec.Ingester.Options.Map(), "kafka.consumer.tls.ca")
 	assert.NotContains(t, jaeger.Spec.Ingester.Options.Map(), "kafka.producer.brokers")
 
-	assert.Len(t, jaeger.Spec.Volumes, 2)
-	assert.Len(t, jaeger.Spec.VolumeMounts, 2)
+	assert.Len(t, jaeger.Spec.Collector.Volumes, 2)
+	assert.Len(t, jaeger.Spec.Collector.VolumeMounts, 2)
+	assert.Len(t, jaeger.Spec.Ingester.Volumes, 2)
+	assert.Len(t, jaeger.Spec.Ingester.VolumeMounts, 2)
+
+	// the kafka certs are only needed by the collector and the ingester, so they should not
+	// leak into the instance's common spec, which is shared by every other component
+	assert.Empty(t, jaeger.Spec.Volumes)
+	assert.Empty(t, jaeger.Spec.VolumeMounts)
 }
 
 func TestReplaceVolume(t *testing.T) {
 	// prepare
 	instance := v1.NewJaeger(types.NamespacedName{Name: "my-instance", Namespace: "tenant-1"})
-	instance.Spec.Volumes = []corev1.Volume{
+	instance.Spec.Collector.Volumes = []corev1.Volume{
 		{
 			Name: "kafkauser-my-instance",
 			VolumeSource: corev1.VolumeSource{
@@ -317,10 +324,10 @@ func TestReplaceVolume(t *testing.T) {
 	autoProvisionKafka(ctx, instance, newStreamingStrategy(ctx, instance))
 
 	// verify
-	assert.Len(t, instance.Spec.Volumes, 3)
+	assert.Len(t, instance.Spec.Collector.Volumes, 3)
 
 	found := 0
-	for _, v := range instance.Spec.Volumes {
+	for _, v := range instance.Spec.Collector.Volumes {
 		if v.Name == "kafkauser-my-instance-cluster-ca" {
 			found = found + 1
 			assert.Equal(t, "my-instance-cluster-ca-cert", v.VolumeSource.Secret.SecretName)
@@ -336,7 +343,7 @@ func TestReplaceVolume(t *testing.T) {
 func TestReplaceVolumeMount(t *testing.T) {
 	// prepare
 	instance := v1.NewJaeger(types.NamespacedName{Name: "my-instance", Namespace: "tenant-1"})
-	instance.Spec.VolumeMounts = []corev1.VolumeMount{
+	instance.Spec.Collector.VolumeMounts = []corev1.VolumeMount{
 		{
 			Name:      "kafkauser-my-instance-cluster-ca",
 			MountPath: "/var/path",
@@ -354,9 +361,9 @@ func TestReplaceVolumeMount(t *testing.T) {
 	autoProvisionKafka(ctx, instance, newStreamingStrategy(ctx, instance))
 
 	// verify
-	assert.Len(t, instance.Spec.VolumeMounts, 3)
+	assert.Len(t, instance.Spec.Collector.VolumeMounts, 3)
 	found := 0
-	for _, v := range instance.Spec.VolumeMounts {
+	for _, v := range instance.Spec.Collector.VolumeMounts {
 		if v.Name == "kafkauser-my-instance-cluster-ca" || v.Name == "kafkauser-my-instance" {
 			found = found + 1
 			assert.True(t, strings.HasPrefix(v.MountPath, "/var/run/secrets"))
@@ -383,10 +390,11 @@ func TestAutoProvisionedKafkaAndElasticsearch(t *testing.T) {
 }
 
 func assertEsInjectSecretsStreaming(t *testing.T, p corev1.PodSpec) {
-	// first two volumes are from the common spec
-	assert.Len(t, p.Volumes, 3)
-	assert.Equal(t, "certs", p.Volumes[2].Name)
-	assert.Equal(t, "certs", p.Containers[0].VolumeMounts[2].Name)
+	// the auto-provisioned kafka certs are only injected into the collector/ingester,
+	// so cronjobs should only see the elasticsearch "certs" volume
+	assert.Len(t, p.Volumes, 1)
+	assert.Equal(t, "certs", p.Volumes[0].Name)
+	assert.Equal(t, "certs", p.Containers[0].VolumeMounts[0].Name)
 	envs := map[string]corev1.EnvVar{}
 	for _, e := range p.Containers[0].Env {
 		envs[e.Name] = e


### PR DESCRIPTION
Motivation:
When Jaeger auto-provisions a Kafka cluster for the streaming strategy,
the TLS client cert and cluster CA volumes/volume mounts were merged
into the instance-wide JaegerCommonSpec (jaeger.Spec.JaegerCommonSpec).
That common spec is inherited by every component built from it (query
service, agent, all-in-one, and the elasticsearch es-index-cleaner,
es-rollover and spark-dependencies cronjobs), none of which talk to
Kafka. As a result, those pods were unnecessarily mounting the Kafka
TLS secrets alongside their own volumes.

Approach:
autoProvisionKafka already sets the kafka.producer.*/kafka.consumer.*
options directly on Spec.Collector.Options and Spec.Ingester.Options,
since those are the only components using Kafka. This change applies
the same scoping to the generated Volumes/VolumeMounts: they are now
merged into Spec.Collector.JaegerCommonSpec and
Spec.Ingester.JaegerCommonSpec instead of the shared
Spec.JaegerCommonSpec. Both collector and ingester deployments already
give their own JaegerCommonSpec priority over the shared one when
merging (pkg/deployment/collector.go, pkg/deployment/ingester.go), so
the collector/ingester pods still receive the Kafka volumes exactly as
before; every other component no longer does.

This is a behavior fix scoping which pods receive the auto-provisioned
Kafka TLS volumes; it does not change any user-visible behavior for the
collector or ingester (which still work exactly as before), only
removes volumes that were being mounted, unused, into unrelated pods.

Validation:
  go build ./...
  go test ./pkg/strategy/...
Both pass. Updated pkg/strategy/streaming_test.go so
TestAutoProvisionedKafkaInjectsIntoInstance, TestReplaceVolume and
TestReplaceVolumeMount assert the volumes/mounts land on
Spec.Collector/Spec.Ingester (and are absent from the shared
Spec.Volumes/Spec.VolumeMounts), and so
TestAutoProvisionedKafkaAndElasticsearch's cronjob pod-spec assertion
reflects that the ES cronjobs now only carry the elasticsearch "certs"
volume, not the previously-leaked kafka volumes.

Fixes #845

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>
