### PR TITLE
fix: set SPAN_STORAGE_TYPE=grpc for grpc-plugin storage

### DIFF
--- a/apis/v1/jaeger_types.go
+++ b/apis/v1/jaeger_types.go
@@ -126,6 +126,16 @@ func (storageType JaegerStorageType) OptionsPrefix() string {
 	return string(storageType)
 }
 
+// SpanStorageType returns the value to use for the SPAN_STORAGE_TYPE environment variable
+// passed to the Jaeger components. The operator identifies the gRPC storage plugin as
+// "grpc-plugin", but Jaeger's storage factory only recognizes "grpc".
+func (storageType JaegerStorageType) SpanStorageType() string {
+	if storageType == JaegerGRPCPluginStorage {
+		return "grpc"
+	}
+	return string(storageType)
+}
+
 // JaegerSpec defines the desired state of Jaeger
 type JaegerSpec struct {
 	// +optional

--- a/apis/v1/jaeger_types_test.go
+++ b/apis/v1/jaeger_types_test.go
@@ -14,6 +14,12 @@ func TestElasticsearchPrefix(t *testing.T) {
 	assert.Equal(t, "es", JaegerESStorage.OptionsPrefix())
 }
 
+func TestSpanStorageType(t *testing.T) {
+	assert.Equal(t, "grpc", JaegerGRPCPluginStorage.SpanStorageType())
+	assert.Equal(t, "cassandra", JaegerCassandraStorage.SpanStorageType())
+	assert.Equal(t, "anystorage", JaegerStorageType("anystorage").SpanStorageType())
+}
+
 func TestValidTypes(t *testing.T) {
 	assert.ElementsMatch(t, ValidStorageTypes(),
 		[]JaegerStorageType{

--- a/pkg/deployment/all_in_one.go
+++ b/pkg/deployment/all_in_one.go
@@ -123,7 +123,7 @@ func (a *AllInOne) Get() *appsv1.Deployment {
 	envVars := []corev1.EnvVar{
 		{
 			Name:  "SPAN_STORAGE_TYPE",
-			Value: string(a.jaeger.Spec.Storage.Type),
+			Value: a.jaeger.Spec.Storage.Type.SpanStorageType(),
 		},
 		{
 			Name:  "METRICS_STORAGE_TYPE",

--- a/pkg/deployment/collector.go
+++ b/pkg/deployment/collector.go
@@ -131,7 +131,7 @@ func (c *Collector) Get() *appsv1.Deployment {
 	envVars := []corev1.EnvVar{
 		{
 			Name:  "SPAN_STORAGE_TYPE",
-			Value: string(storageType),
+			Value: storageType.SpanStorageType(),
 		},
 		{
 			Name:  "COLLECTOR_ZIPKIN_HOST_PORT",

--- a/pkg/deployment/collector_test.go
+++ b/pkg/deployment/collector_test.go
@@ -808,6 +808,9 @@ func TestCollectorGRPCPlugin(t *testing.T) {
 	}, dep.Spec.Template.Spec.InitContainers)
 	require.Len(t, dep.Spec.Template.Spec.Containers, 1)
 	assert.Equal(t, []string{"--grpc-storage-plugin.binary=/plugin/plugin", "--sampling.strategies-file=/etc/jaeger/sampling/sampling.json"}, dep.Spec.Template.Spec.Containers[0].Args)
+
+	envVars := dep.Spec.Template.Spec.Containers[0].Env
+	assert.Contains(t, envVars, corev1.EnvVar{Name: "SPAN_STORAGE_TYPE", Value: "grpc"})
 }
 
 func TestCollectorContainerSecurityContext(t *testing.T) {

--- a/pkg/deployment/ingester.go
+++ b/pkg/deployment/ingester.go
@@ -128,7 +128,7 @@ func (i *Ingester) Get() *appsv1.Deployment {
 	envVars := []corev1.EnvVar{
 		{
 			Name:  "SPAN_STORAGE_TYPE",
-			Value: string(i.jaeger.Spec.Storage.Type),
+			Value: i.jaeger.Spec.Storage.Type.SpanStorageType(),
 		},
 	}
 	envVars = append(envVars, proxy.ReadProxyVarsFromEnv()...)

--- a/pkg/deployment/query.go
+++ b/pkg/deployment/query.go
@@ -124,7 +124,7 @@ func (q *Query) Get() *appsv1.Deployment {
 	envVars := []corev1.EnvVar{
 		{
 			Name:  "SPAN_STORAGE_TYPE",
-			Value: string(q.jaeger.Spec.Storage.Type),
+			Value: q.jaeger.Spec.Storage.Type.SpanStorageType(),
 		},
 		{
 			Name:  "METRICS_STORAGE_TYPE",


### PR DESCRIPTION
Motivation

When a Jaeger CR sets storage.type: grpc-plugin (the documented way to
connect a gRPC storage plugin such as jaeger-clickhouse), the collector,
query, ingester and all-in-one containers set the SPAN_STORAGE_TYPE
environment variable to the literal string "grpc-plugin". Jaeger's own
storage factory does not recognize "grpc-plugin" as a valid storage
type, only "grpc", so the container fails at startup with:

    Cannot initialize storage factory: unknown storage type grpc-plugin.
    Valid types are [cassandra opensearch elasticsearch memory kafka
    badger blackhole grpc]

"grpc-plugin" is the operator's own CRD-facing identifier for this
storage type (used e.g. for the "grpc-storage-plugin" options prefix
and for wiring the plugin binary init container/volume); it was never
meant to be forwarded verbatim to Jaeger's SPAN_STORAGE_TYPE, which
only understands "grpc".

Approach

Add JaegerStorageType.SpanStorageType() in apis/v1/jaeger_types.go,
mirroring the existing OptionsPrefix() method: it returns "grpc" for
JaegerGRPCPluginStorage and the type unchanged otherwise. Use it at
the four places SPAN_STORAGE_TYPE is set (pkg/deployment/collector.go,
all_in_one.go, query.go, ingester.go) instead of a raw string
conversion. All other uses of the "grpc-plugin" identifier (options
prefix, plugin init-container/volume wiring, CR validation) are
untouched, since only the value forwarded to Jaeger itself was wrong.

Validation

Ran `go build ./...` (passes) and
`go test ./apis/v1/... ./pkg/deployment/...` (passes), including a new
TestSpanStorageType unit test and an extended TestCollectorGRPCPlugin
assertion that the collector container's env includes
SPAN_STORAGE_TYPE=grpc. Confirmed this is a targeted repro: reverting
only the collector.go change and re-running TestCollectorGRPCPlugin
fails with SPAN_STORAGE_TYPE=grpc-plugin (the exact value reported in
the issue), and passes again once the fix is restored. No live cluster
or e2e run was performed; this repo's CONTRIBUTING.md calls unit tests
sufficient for small changes, reserving e2e for new features.

Report: https://github.com/jaegertracing/jaeger-operator/issues/2727
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>

Fixes #2727