### PR TITLE
Default Ingress path to "/" for Prefix and Exact path types

### DIFF
--- a/pkg/ingress/query.go
+++ b/pkg/ingress/query.go
@@ -98,6 +98,12 @@ func (i *QueryIngress) addRulesSpec(spec *networkingv1.IngressSpec, backend *net
 		pathType = networkingv1.PathType(pt)
 	}
 	if len(i.jaeger.Spec.Ingress.Hosts) > 0 || path != "" {
+		// Prefix and Exact path types require an absolute path, unlike ImplementationSpecific.
+		// Default to "/" so the generated Ingress isn't rejected by the API server when no
+		// query base-path has been configured.
+		if path == "" && (pathType == networkingv1.PathTypePrefix || pathType == networkingv1.PathTypeExact) {
+			path = "/"
+		}
 		spec.Rules = append(spec.Rules, getRules(path, &pathType, i.jaeger.Spec.Ingress.Hosts, backend)...)
 	} else {
 		// no hosts and no custom path -> fall back to a single service Ingress

--- a/pkg/ingress/query_test.go
+++ b/pkg/ingress/query_test.go
@@ -160,10 +160,30 @@ func TestQueryIngressWithPathType(t *testing.T) {
 	assert.Len(t, dep.Spec.Rules, 1)
 
 	assert.Len(t, dep.Spec.Rules[0].HTTP.Paths, 1)
-	assert.Empty(t, dep.Spec.Rules[0].HTTP.Paths[0].Path)
+	// Prefix requires an absolute path, so an unset query base-path must default to "/"
+	// rather than producing an Ingress that the API server rejects.
+	assert.Equal(t, "/", dep.Spec.Rules[0].HTTP.Paths[0].Path)
 	assert.Equal(t, networkingv1.PathType("Prefix"), *dep.Spec.Rules[0].HTTP.Paths[0].PathType)
 	assert.Equal(t, "test-host-1", dep.Spec.Rules[0].Host)
 	assert.NotNil(t, dep.Spec.Rules[0].HTTP.Paths[0].Backend)
+}
+
+func TestQueryIngressWithExactPathTypeDefaultsPath(t *testing.T) {
+	enabled := true
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestQueryIngressWithExactPathTypeDefaultsPath"})
+	jaeger.Spec.Ingress.Enabled = &enabled
+	jaeger.Spec.Ingress.PathType = networkingv1.PathType("Exact")
+	jaeger.Spec.Ingress.Hosts = []string{"test-host-1"}
+
+	ingress := NewQueryIngress(jaeger)
+
+	dep := ingress.Get()
+
+	assert.NotNil(t, dep)
+	assert.Len(t, dep.Spec.Rules, 1)
+	assert.Len(t, dep.Spec.Rules[0].HTTP.Paths, 1)
+	assert.Equal(t, "/", dep.Spec.Rules[0].HTTP.Paths[0].Path)
+	assert.Equal(t, networkingv1.PathType("Exact"), *dep.Spec.Rules[0].HTTP.Paths[0].PathType)
 }
 
 func TestQueryIngressWithMultipleHosts(t *testing.T) {
@@ -195,6 +215,21 @@ func TestQueryIngressWithoutHosts(t *testing.T) {
 	enabled := true
 	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestQueryIngressWithoutHosts"})
 	jaeger.Spec.Ingress.Enabled = &enabled
+
+	ingress := NewQueryIngress(jaeger)
+
+	dep := ingress.Get()
+
+	assert.NotNil(t, dep)
+	assert.NotNil(t, dep.Spec.DefaultBackend)
+	assert.Empty(t, dep.Spec.Rules)
+}
+
+func TestQueryIngressWithoutHostsAndPathTypeKeepsDefaultBackend(t *testing.T) {
+	enabled := true
+	jaeger := v1.NewJaeger(types.NamespacedName{Name: "TestQueryIngressWithoutHostsAndPathTypeKeepsDefaultBackend"})
+	jaeger.Spec.Ingress.Enabled = &enabled
+	jaeger.Spec.Ingress.PathType = networkingv1.PathType("Prefix")
 
 	ingress := NewQueryIngress(jaeger)
 


### PR DESCRIPTION
Motivation:
When spec.ingress.pathType is set to "Prefix" or "Exact" and no
query.base-path option is configured, QueryIngress generates an
IngressRule with an empty path. The Kubernetes API server rejects
this Ingress with "must be an absolute path", since only
PathType ImplementationSpecific permits an empty/arbitrary path;
Prefix and Exact require a path starting with "/". This reproduces
the reported error, e.g. via examples/ingress-with-host-pathType.yaml.

Approach:
In pkg/ingress/query.go's addRulesSpec, once we're in the branch that
builds Ingress Rules (hosts set, or a base-path already configured),
default an empty path to "/" when the resolved pathType is Prefix or
Exact. The defaulting is scoped inside that branch so it does not
change the existing no-hosts/no-base-path behavior, which still falls
back to a single DefaultBackend Ingress.

Validation:
- go build ./... succeeds.
- go test ./pkg/... passes (all packages).
- go test ./pkg/ingress/... -v passes, including two new/updated
  tests: TestQueryIngressWithPathType now asserts the generated path
  is "/" instead of empty (previously it asserted the buggy empty
  path), and a new TestQueryIngressWithExactPathTypeDefaultsPath
  covers PathType Exact. A new
  TestQueryIngressWithoutHostsAndPathTypeKeepsDefaultBackend guards
  against a regression where the defaulting could otherwise leak into
  the no-hosts/no-path DefaultBackend branch.
- Confirmed fail-before/pass-after: reverting only the query.go change
  while keeping the updated tests makes both path-defaulting tests
  fail with "expected: / actual: ", proving the test reproduces the
  reported defect and the fix resolves it.
- go vet ./pkg/ingress/... and gofmt/goimports report no issues on the
  changed files.
- Could not run this repo's pinned golangci-lint (v1.55.2, via
  hack/install/install-golangci-lint.sh) locally: it fails to build
  under the local Go 1.26.5 toolchain. This repo's own CI
  (.github/workflows/base-checks.yaml) runs on Go 1.22, where that
  lint version builds and runs normally, so this is a local toolchain
  limitation, not a defect in this change.
- No model/API/CRD files were touched, so generated-code checks
  (make generate / ensure-generate-is-noop) are unaffected.

Impact: fixes Ingress generation so it is accepted by the Kubernetes
API server when pathType is explicitly set to Prefix or Exact without
a query base-path; behavior for ImplementationSpecific (the default)
and for configurations that already set a base-path is unchanged.

Report: https://github.com/jaegertracing/jaeger-operator/issues/2734
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>
Assisted-by: claude-sonnet-5 (via Claude Code)

Fixes #2734